### PR TITLE
fix(install): repair wheel-install path so agent tasks actually work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,12 @@ jobs:
         run: rm -rf ~/.vibe-seller
 
       - name: Start server
+        # Use the documented user command, not raw uvicorn — that
+        # way `_cmd_start`'s PATH augmentation (which makes claude
+        # findable after `curl|bash install.sh`) is exercised by
+        # CI on every PR. Env vars on this step propagate into
+        # `vibe-seller start`'s parent shell and from there into
+        # the daemon (cli.py copies os.environ).
         env:
           # No ANTHROPIC_* — conftest sets user's default_profile_id
           # to the worker profile, so even UI-created tasks use it.
@@ -276,37 +282,19 @@ jobs:
           AGENT_DEBUG: '1'
           VIBE_SELLER_TELEMETRY: '0'
         run: |
-          # install.sh's fix_npm_permissions puts claude (and any
-          # other `npm install -g` payload) in ~/.npm-global/bin/.
-          # That path is written into ~/.bashrc for interactive
-          # shells, but GitHub Actions runs non-interactive bash
-          # which doesn't source it, so without this export the
-          # daemon's `asyncio.create_subprocess_exec(['claude', ...])`
-          # exits with FileNotFoundError on every agent task.
-          export PATH="$HOME/.npm-global/bin:$PATH"
-          mkdir -p logs
-          echo "=== Starting server with uvicorn ==="
-          echo "Claude CLI location: $(which claude)"
-          BACKEND_PORT=7777 uv run uvicorn app.main:app \
-            --host 0.0.0.0 --port 7777 --log-level info \
-            > logs/server_stdout.log 2>&1 &
-          SERVER_PID=$!
-          echo "Server PID: $SERVER_PID"
-          # Wait and check
-          for i in {1..15}; do
-            sleep 1
-            if ! kill -0 $SERVER_PID 2>/dev/null; then
-              echo "ERROR: Server process died on iteration $i"
-              cat logs/server_stdout.log
-              exit 1
-            fi
-            if curl -s http://127.0.0.1:7777/api/health > /dev/null 2>&1; then
-              echo "Server healthy after $i seconds"
+          source .venv/bin/activate
+          echo "=== Starting server via vibe-seller CLI ==="
+          echo "Claude CLI location: $(which claude || echo not-on-shell-PATH)"
+          vibe-seller start --port 7777
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:7777/api/health > /dev/null 2>&1; then
+              echo "Server healthy after ${i}s"
               exit 0
             fi
+            sleep 1
           done
           echo "ERROR: Server failed to respond to health check"
-          cat logs/server_stdout.log
+          tail -50 ~/.vibe-seller/logs/backend_7777.log 2>/dev/null || true
           exit 1
 
       - name: Run E2E tests
@@ -347,5 +335,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: e2e-server-logs
-          path: logs/*.log
+          path: ~/.vibe-seller/logs/*.log
           retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,14 @@ jobs:
           AGENT_DEBUG: '1'
           VIBE_SELLER_TELEMETRY: '0'
         run: |
+          # install.sh's fix_npm_permissions puts claude (and any
+          # other `npm install -g` payload) in ~/.npm-global/bin/.
+          # That path is written into ~/.bashrc for interactive
+          # shells, but GitHub Actions runs non-interactive bash
+          # which doesn't source it, so without this export the
+          # daemon's `asyncio.create_subprocess_exec(['claude', ...])`
+          # exits with FileNotFoundError on every agent task.
+          export PATH="$HOME/.npm-global/bin:$PATH"
           mkdir -p logs
           echo "=== Starting server with uvicorn ==="
           echo "Claude CLI location: $(which claude)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,56 +236,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
+      # Dogfood install.sh --dev so this job catches install.sh
+      # regressions (missing claude/sqlite3/playwright/etc.) the
+      # moment they land — same script every end user runs. --dev
+      # detects the checkout, installs system deps (uv, node, pnpm,
+      # sqlite3, lsof, claude), creates ./.venv, runs
+      # `uv pip install -e .`, and installs Playwright Chromium.
+      - name: Install via install.sh --dev
+        run: ./install.sh --dev
 
-      - name: Install Python 3.11
-        run: uv python install 3.11
-
-      - name: Create virtual environment
-        run: uv venv
-
-      - name: Install dependencies
+      - name: Install pytest test-runner deps
+        # The `.[dev]` extras (pyproject.toml) carry pytest +
+        # pytest-asyncio + pytest-xdist + pytest-rerunfailures +
+        # httpx + ruff. These are test-runner deps, never shipped
+        # to end-user wheels. pytest-playwright is needed only by
+        # the UI tests so it lives outside `.[dev]`.
         run: |
-          uv pip install -e ".[dev]"
-          uv pip install pytest pytest-asyncio httpx
-
-      # Playwright is dev-only — needed for UI tests (pytest-playwright)
-      - name: Install Playwright dependencies
-        run: |
-          uv pip install pytest-playwright
-          uv run playwright install --with-deps chromium
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-
-      - name: Install sqlite3 CLI
-        # vibe_seller_email_info advertises `sqlite3 <db_path>`
-        # as the canonical way for agents to query per-account
-        # email DBs. The runner image doesn't ship it, so the
-        # agent got "sqlite3: command not found" and fell into
-        # the circuit-breaker loop.
-        run: |
-          if ! command -v sqlite3 >/dev/null 2>&1; then
-            sudo apt-get update -qq && sudo apt-get install -y -qq sqlite3
-          fi
-          sqlite3 --version
-
-      - name: Install Claude CLI
-        run: |
-          npm install -g @anthropic-ai/claude-code
-          echo "Claude CLI installed at: $(which claude)"
-          claude --version
-
-      - name: Build frontend
-        working-directory: frontend
-        run: |
-          npm install
-          npm run build
+          source .venv/bin/activate
+          uv pip install -e ".[dev]" pytest-playwright
 
       - name: Configure git identity
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,12 +187,12 @@ jobs:
 
       - name: Start server (background)
         run: |
-          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
           vibe-seller start --port 7777
 
       - name: Smoke-test (verify_install.sh asserts version + API)
         run: |
-          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
           bash tests/releases/verify_install.sh "$VERSION"
 
       # Below: run a real agent task against the installed daemon.
@@ -226,7 +226,7 @@ jobs:
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
           VIBE_SELLER_TELEMETRY: '0'
         run: |
-          export PATH="$(uv tool dir)/vibe-seller/bin:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
+          export PATH="$(uv tool dir)/vibe-seller/bin:$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
           pytest \
             tests/e2e/test_llm_browser.py::TestLLMBrowserAPI::test_agent_reads_homepage \
             --e2e -v --log-cli-level=INFO
@@ -234,7 +234,7 @@ jobs:
       - name: Stop server
         if: always()
         run: |
-          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
           vibe-seller stop --port 7777 || true
           echo "--- last 30 lines of server log ---"
           tail -30 ~/.vibe-seller/logs/backend_7777.log 2>/dev/null || true
@@ -292,12 +292,12 @@ jobs:
 
       - name: Start server (background)
         run: |
-          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
           vibe-seller start --port 7777
 
       - name: Smoke-test (verify_install.sh asserts version + API)
         run: |
-          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
           bash tests/releases/verify_install.sh "$VERSION"
 
       # Below: run a real agent task against the installed daemon.
@@ -331,7 +331,7 @@ jobs:
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
           VIBE_SELLER_TELEMETRY: '0'
         run: |
-          export PATH="$(uv tool dir)/vibe-seller/bin:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
+          export PATH="$(uv tool dir)/vibe-seller/bin:$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
           pytest \
             tests/e2e/test_llm_browser.py::TestLLMBrowserAPI::test_agent_reads_homepage \
             --e2e -v --log-cli-level=INFO
@@ -339,7 +339,7 @@ jobs:
       - name: Stop server
         if: always()
         run: |
-          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
           vibe-seller stop --port 7777 || true
           echo "--- last 30 lines of server log ---"
           tail -30 ~/.vibe-seller/logs/backend_7777.log 2>/dev/null || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,18 +187,54 @@ jobs:
 
       - name: Start server (background)
         run: |
-          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
           vibe-seller start --port 7777
 
       - name: Smoke-test (verify_install.sh asserts version + API)
         run: |
-          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
           bash tests/releases/verify_install.sh "$VERSION"
+
+      # Below: run a real agent task against the installed daemon.
+      # This exercises the per-store browser-use wrapper — the exact
+      # code path that was silently broken in 0.0.1 when installed
+      # via `uv tool install` (the tool venv's bin/ is not on PATH,
+      # so wrapper.py's `shutil.which('browser-use')` returned None
+      # and the wrapper baked in the literal string `"browser-use"`,
+      # which then failed at exec time with "command not found").
+      # Without this step, verify only proves the daemon stands up
+      # — not that browser tasks work end-to-end.
+      # Inject pytest test-runner deps INTO the uv-tool venv that
+      # install.sh just created. That venv already has playwright
+      # (browser-use dep), so pytest runs from the same interpreter
+      # the daemon does and resolves every module the test imports
+      # without duplicate installs.
+      - name: Install pytest runner deps into the tool venv
+        run: |
+          TOOL_PY="$(uv tool dir)/vibe-seller/bin/python"
+          uv pip install --python "$TOOL_PY" \
+            pytest pytest-asyncio httpx pytest-playwright
+
+      - name: Run agent smoke against installed daemon
+        env:
+          E2E_BASE_URL: http://127.0.0.1:7777
+          E2E_PROVIDER_MAP: deepseek
+          DEEPSEEK_API_KEY:  ${{ secrets.DEEPSEEK_API_KEY }}
+          DEEPSEEK_BASE_URL: ${{ secrets.DEEPSEEK_BASE_URL }}
+          DEEPSEEK_MODEL:    ${{ secrets.DEEPSEEK_MODEL }}
+          API_TIMEOUT_MS: '3000000'
+          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
+          VIBE_SELLER_TELEMETRY: '0'
+        run: |
+          export PATH="$(uv tool dir)/vibe-seller/bin:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
+          pytest \
+            tests/e2e/test_llm_browser.py::TestLLMBrowserAPI::test_agent_reads_homepage \
+            --e2e -v --log-cli-level=INFO
 
       - name: Stop server
         if: always()
         run: |
-          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
           vibe-seller stop --port 7777 || true
           echo "--- last 30 lines of server log ---"
           tail -30 ~/.vibe-seller/logs/backend_7777.log 2>/dev/null || true
@@ -256,18 +292,54 @@ jobs:
 
       - name: Start server (background)
         run: |
-          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
           vibe-seller start --port 7777
 
       - name: Smoke-test (verify_install.sh asserts version + API)
         run: |
-          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
           bash tests/releases/verify_install.sh "$VERSION"
+
+      # Below: run a real agent task against the installed daemon.
+      # This exercises the per-store browser-use wrapper — the exact
+      # code path that was silently broken in 0.0.1 when installed
+      # via `uv tool install` (the tool venv's bin/ is not on PATH,
+      # so wrapper.py's `shutil.which('browser-use')` returned None
+      # and the wrapper baked in the literal string `"browser-use"`,
+      # which then failed at exec time with "command not found").
+      # Without this step, verify only proves the daemon stands up
+      # — not that browser tasks work end-to-end.
+      # Inject pytest test-runner deps INTO the uv-tool venv that
+      # install.sh just created. That venv already has playwright
+      # (browser-use dep), so pytest runs from the same interpreter
+      # the daemon does and resolves every module the test imports
+      # without duplicate installs.
+      - name: Install pytest runner deps into the tool venv
+        run: |
+          TOOL_PY="$(uv tool dir)/vibe-seller/bin/python"
+          uv pip install --python "$TOOL_PY" \
+            pytest pytest-asyncio httpx pytest-playwright
+
+      - name: Run agent smoke against installed daemon
+        env:
+          E2E_BASE_URL: http://127.0.0.1:7777
+          E2E_PROVIDER_MAP: deepseek
+          DEEPSEEK_API_KEY:  ${{ secrets.DEEPSEEK_API_KEY }}
+          DEEPSEEK_BASE_URL: ${{ secrets.DEEPSEEK_BASE_URL }}
+          DEEPSEEK_MODEL:    ${{ secrets.DEEPSEEK_MODEL }}
+          API_TIMEOUT_MS: '3000000'
+          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
+          VIBE_SELLER_TELEMETRY: '0'
+        run: |
+          export PATH="$(uv tool dir)/vibe-seller/bin:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
+          pytest \
+            tests/e2e/test_llm_browser.py::TestLLMBrowserAPI::test_agent_reads_homepage \
+            --e2e -v --log-cli-level=INFO
 
       - name: Stop server
         if: always()
         run: |
-          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.npm-global/bin:$PATH"
           vibe-seller stop --port 7777 || true
           echo "--- last 30 lines of server log ---"
           tail -30 ~/.vibe-seller/logs/backend_7777.log 2>/dev/null || true

--- a/app/ai/claude_backend.py
+++ b/app/ai/claude_backend.py
@@ -368,10 +368,39 @@ class AgentSession(_HookMixin, _StreamMixin):
         # Pass task ID for multi-client CDP proxy isolation
         env['VIBE_TASK_ID'] = self.task_id
 
-        venv_bin = VIBE_SELLER_DIR / '.venv' / 'bin'
-        if venv_bin.is_dir():
-            env['PATH'] = f'{venv_bin}:{env.get("PATH", "")}'
-            env['VIRTUAL_ENV'] = str(VIBE_SELLER_DIR / '.venv')
+        # Claude Code auto-commits the task workspace ("Initial
+        # workspace setup") right after `git init`. The workspace
+        # is a fresh repo at ~/.vibe-seller/tasks/<id>/, so no
+        # `git config --local` on the source checkout reaches it,
+        # and many fresh user machines (and CI runners scoped to
+        # repo-local identity per #181) have no `git config --global`
+        # either. `Author identity unknown` blows up the agent's
+        # first commit. Setting GIT_{AUTHOR,COMMITTER}_* via env
+        # makes the commit succeed without touching any git config
+        # file. setdefault keeps any real identity the user already
+        # exported via their shell.
+        env.setdefault('GIT_AUTHOR_NAME', 'Vibe Seller Agent')
+        env.setdefault('GIT_AUTHOR_EMAIL', 'agent@vibe-seller.local')
+        env.setdefault('GIT_COMMITTER_NAME', 'Vibe Seller Agent')
+        env.setdefault('GIT_COMMITTER_EMAIL', 'agent@vibe-seller.local')
+
+        # Inject the daemon's own venv bin onto the agent's PATH so
+        # the wrapper's `exec "$REAL_BU"` (and any bash the agent
+        # runs — pytest, fastapi, etc.) resolves binaries from the
+        # same interpreter that runs this server. Works in both modes:
+        #
+        #   - Dev clone (`./start.sh`):   <repo>/.venv/bin/python
+        #   - Wheel install (`vibe-seller start`):
+        #       ~/.local/share/uv/tools/vibe-seller/bin/python
+        #
+        # The old code referenced ``VIBE_SELLER_DIR/.venv/bin``
+        # (``~/.vibe-seller/.venv/bin``), which is never created by
+        # any install mode — a dead branch that masked the missing
+        # PATH injection in wheel-install mode.
+        daemon_bin = Path(sys.executable).resolve().parent
+        if daemon_bin.is_dir():
+            env['PATH'] = f'{daemon_bin}:{env.get("PATH", "")}'
+            env['VIRTUAL_ENV'] = str(daemon_bin.parent)
 
         # start_new_session=True puts claude and every descendant into
         # a fresh POSIX session/process group. We do not rely on this

--- a/app/browser/wrapper.py
+++ b/app/browser/wrapper.py
@@ -6,9 +6,11 @@ CDP mux proxy URL, and auto-starts the proxy if down.
 """
 
 import logging
+from pathlib import Path
 import re
 import shutil
 import stat
+import sys
 import textwrap
 
 from app.config import BACKEND_PORT, BROWSER_USE_BIN_DIR, LOCALHOST
@@ -70,11 +72,24 @@ def write_browser_use_wrapper(
     wrapper_dir.mkdir(parents=True, exist_ok=True)
     wrapper_path = wrapper_dir / 'browser-use'
 
-    real_bu = shutil.which('browser-use')
+    # Prefer the browser-use binary that lives in the same bin/ as the
+    # daemon's Python interpreter. This is the ONLY place it exists in
+    # `uv tool install vibe-seller` mode — the tool venv's bin is not
+    # on PATH, so shutil.which() would fall through to the bare-string
+    # fallback and produce a wrapper that fails at exec time with
+    # "command not found". In `./start.sh` (dev clone) mode both paths
+    # find it; the sibling lookup is just authoritative.
+    daemon_bin = Path(sys.executable).resolve().parent
+    candidate = daemon_bin / 'browser-use'
+    real_bu = (
+        str(candidate) if candidate.is_file()
+        else shutil.which('browser-use')
+    )
     if not real_bu:
         logger.warning(
-            'browser-use binary not found on PATH; '
-            'wrapper will use "browser-use" as fallback'
+            'browser-use not found alongside %s nor on PATH; '
+            'wrapper will use "browser-use" as fallback',
+            sys.executable,
         )
         real_bu = 'browser-use'
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -210,6 +210,26 @@ def _cmd_start(args: argparse.Namespace) -> int:
     # import; without this Popen `cwd=` argument the wheel-installed
     # daemon ends up importing the source tree instead of itself.
     daemon_cwd = _vibe_home()
+
+    # install.sh runs `fix_npm_permissions` which puts `npm install
+    # -g` payloads (claude CLI in particular) into ~/.npm-global/bin/
+    # and writes the matching `export PATH=...` into the user's
+    # shell rc file. But a user who runs the documented two-liner
+    #
+    #     curl -sSL .../install.sh | bash
+    #     vibe-seller start
+    #
+    # in the same shell session has not yet sourced that rc edit,
+    # so without this prepend the daemon starts with the old PATH,
+    # the agent's `claude` spawn raises FileNotFoundError on the
+    # first task, and `vibe-seller start` looks healthy until you
+    # actually try to do anything. Prepending here makes the daemon
+    # find claude regardless of shell rc state.
+    env = os.environ.copy()
+    npm_global_bin = Path.home() / '.npm-global' / 'bin'
+    if npm_global_bin.is_dir():
+        env['PATH'] = f'{npm_global_bin}{os.pathsep}{env.get("PATH", "")}'
+
     # Open the log under `with` so ruff is happy; the OS dups the fd
     # into the Popen child, so closing the parent handle right after
     # spawn is fine — the child keeps writing through its own fd.
@@ -229,6 +249,7 @@ def _cmd_start(args: argparse.Namespace) -> int:
             stdout=log_fp,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,
+            env=env,
             start_new_session=True,
         )
 

--- a/app/workspace/manager.py
+++ b/app/workspace/manager.py
@@ -695,13 +695,28 @@ browser: {backend}
     async def _run_git(
         self, *args, check: bool = True
     ) -> asyncio.subprocess.Process:
-        """Run a git command in the workspace directory."""
+        """Run a git command in the workspace directory.
+
+        Pre-set GIT_AUTHOR_*/GIT_COMMITTER_* via env (with
+        setdefault, so a real user identity wins) so the
+        `Initial workspace setup` commit succeeds on hosts with no
+        `git config --global user.email/name` — most fresh user
+        machines and CI runners scoped to repo-local identity per
+        #181 fall into that bucket. Touching env (not git config
+        files) keeps the workspace's `.git/config` clean.
+        """
+        git_env = dict(os.environ)
+        git_env.setdefault('GIT_AUTHOR_NAME', 'Vibe Seller')
+        git_env.setdefault('GIT_AUTHOR_EMAIL', 'agent@vibe-seller.local')
+        git_env.setdefault('GIT_COMMITTER_NAME', 'Vibe Seller')
+        git_env.setdefault('GIT_COMMITTER_EMAIL', 'agent@vibe-seller.local')
         proc = await asyncio.create_subprocess_exec(
             'git',
             *args,
             cwd=str(self.root),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=git_env,
         )
         await proc.wait()
         if check and proc.returncode != 0:

--- a/install.sh
+++ b/install.sh
@@ -436,12 +436,16 @@ check_pnpm() {
 install_pnpm() {
     _info "Installing pnpm..."
     # fix_npm_permissions ensures npm global dir is user-writable on Linux
-    # so we don't need sudo for npm install -g
+    # so we don't need sudo for npm install -g. Pin pnpm to 9.x
+    # because pnpm 10/11 require Node.js 22+, but install_node still
+    # ships v20 on many distros (and release.yml pins setup-node to
+    # version 20 + pnpm 9). Drop the pin once the project standardises
+    # on Node 22.
     if _check corepack; then
         corepack enable 2>/dev/null || true
-        corepack prepare pnpm@latest --activate 2>/dev/null || npm install -g pnpm
+        corepack prepare pnpm@9 --activate 2>/dev/null || npm install -g pnpm@9
     else
-        npm install -g pnpm
+        npm install -g pnpm@9
     fi
     if ! _check pnpm; then
         _error "pnpm install failed"
@@ -561,6 +565,29 @@ _install_via_pip() {
     # prompt there.
     if [[ "$OS" == "linux" ]]; then
         require_sudo
+    fi
+
+    # Runtime deps the daemon's agents need but the wheel can't
+    # ship: claude CLI (the AI backend's process), sqlite3 (agents
+    # query per-account email DBs via `sqlite3 <path>`), node (claude
+    # CLI is an npm package), lsof (vibe-seller stop). Without these,
+    # `vibe-seller start` succeeds but the first agent task fails
+    # with "command not found". --dev mode installs them via the
+    # main() DEPS=(...) loop; default mode used to exit 0 before
+    # reaching that loop and end users got a half-working install.
+    if ! check_lsof; then
+        install_lsof
+    fi
+    if ! check_sqlite3; then
+        install_sqlite3
+    fi
+    if ! check_node; then
+        install_node
+    fi
+    fix_npm_permissions
+    if ! check_claude; then
+        install_claude \
+            || _warn "claude CLI install failed — AI agent features will not work"
     fi
 
     # Compose `uv tool install` args from --test-pypi / --version.
@@ -754,6 +781,22 @@ main() {
                     || _warn "Playwright browser install failed"
             fi
             _success "Playwright browsers installed"
+        fi
+
+        # Build the frontend bundle so the dev checkout matches what
+        # `pip install vibe-seller` ships (a wheel with prebuilt
+        # static assets under app/static/). README documents
+        # `./install.sh --dev` as the line that does this; start.sh's
+        # own pnpm-build step then becomes a no-op until a source
+        # file changes. Only runs when pnpm is on PATH (it should be
+        # — installed in the DEPS loop above).
+        if [ -f "$SCRIPT_DIR/frontend/package.json" ] \
+            && _check pnpm; then
+            _info "Building frontend (pnpm build → frontend/dist/)..."
+            (cd "$SCRIPT_DIR/frontend" \
+                && pnpm install --frozen-lockfile \
+                && pnpm build) \
+                || _warn "Frontend build failed — start.sh will retry"
         fi
     elif [[ "$CHECK_ONLY" == true && -f "$SCRIPT_DIR/pyproject.toml" ]]; then
         if [ -f "$VENV_DIR/bin/vibe-seller" ]; then

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,14 @@ from sqlalchemy.orm import sessionmaker  # noqa: E402
 from app.auth import create_token  # noqa: E402
 from app.database import get_db  # noqa: E402
 from app.main import app  # noqa: E402
+# Force-import every model so Base.metadata.create_all() in the
+# async_db_session fixture below sees every table. SQLAlchemy only
+# registers a table on Base.metadata when its model class has been
+# imported — without this `from app import models`, tables for any
+# model not separately imported (e.g. StoreEmailLink, EmailAccount,
+# Event, ...) silently aren't created and a test that touches them
+# fails later with "no such table: <name>".
+from app import models  # noqa: F401, E402
 from app.models.base import Base  # noqa: E402
 from app.models.store import Store  # noqa: E402
 from app.models.task import Task  # noqa: E402

--- a/tests/unit/test_prompt_assembly.py
+++ b/tests/unit/test_prompt_assembly.py
@@ -76,13 +76,27 @@ async def _patch_async_session(monkeypatch):
         )
         await db.commit()
 
-    for mod in [
-        'app.database',
-        'app.routers.tasks',
-        'app.task_runner',
-    ]:
+    # `from app.database import async_session` (used in ~30 app
+    # modules) binds the name into each module's namespace at
+    # import time. Patching only `app.database.async_session`
+    # would miss those bindings, so every caller of build_system_*
+    # that touches the DB via a re-imported reference would hit
+    # the real ~/.vibe-seller/data/vibe_seller.db instead of the
+    # in-memory test DB. We walk sys.modules instead of hardcoding
+    # a list because new code paths keep adding new imports —
+    # before this change the list was missing app.task_runner_context
+    # (added when build_system_context started querying tasks for
+    # the previous schedule run), and the 16 prompt-assembly tests
+    # silently 'no such table: tasks'.
+    import sys as _sys
+
+    for _mod_name, _mod in list(_sys.modules.items()):
+        if not _mod_name.startswith('app.'):
+            continue
+        if getattr(_mod, 'async_session', None) is None:
+            continue
         try:
-            monkeypatch.setattr(f'{mod}.async_session', maker)
+            monkeypatch.setattr(f'{_mod_name}.async_session', maker)
         except AttributeError:
             pass
     yield maker

--- a/tests/workflow/conftest.py
+++ b/tests/workflow/conftest.py
@@ -19,6 +19,15 @@ from sqlalchemy.pool import StaticPool
 from app.auth import create_token
 from app.database import get_db
 from app.main import app
+# Force-import every model so Base.metadata.create_all() below sees
+# them all. SQLAlchemy only registers a table on Base.metadata when
+# the model class has been imported — without this `from app import
+# models`, tables for any model not separately imported (e.g.
+# StoreEmailLink, EmailAccount, Event, ...) silently aren't created
+# and the tests blow up later with "no such table: <name>". The
+# `# noqa: F401` is because we don't use `models` as a symbol — the
+# import is only for its side effect on Base.metadata.
+from app import models  # noqa: F401
 from app.models.app_settings import AppSettings
 from app.models.base import Base
 from app.models.user import User

--- a/tests/workflow/test_wf_email.py
+++ b/tests/workflow/test_wf_email.py
@@ -243,7 +243,7 @@ class TestSyncNow:
                 return_value=3,
             ),
             patch(
-                'app.scheduler.email_sync.maybe_seed_sync_state',
+                'app.routers.email_accounts.maybe_seed_sync_state',
                 new_callable=AsyncMock,
             ),
             patch(
@@ -284,7 +284,7 @@ class TestSyncNow:
                 side_effect=Exception('IMAP connection refused'),
             ),
             patch(
-                'app.scheduler.email_sync.maybe_seed_sync_state',
+                'app.routers.email_accounts.maybe_seed_sync_state',
                 new_callable=AsyncMock,
             ),
             patch(


### PR DESCRIPTION
## Summary

Every user who installed via `install.sh` / PyPI got a daemon that came up green on `/api/health` but **failed on the first real agent task** with `command not found`. Three bugs in the wheel-install path, fixed together.

### 1. `app/browser/wrapper.py` — wrapper baked the wrong path

The per-store wrapper resolved `browser-use` via `shutil.which`, which can't see the `uv tool` venv's `bin/` (it's not on `PATH`). Fell through to the literal `"browser-use"` fallback → bash exec failed. Fix: prefer `Path(sys.executable).parent / 'browser-use'`, the daemon's own interpreter sibling.

### 2. `app/ai/claude_backend.py` — agent PATH pointed at a dead branch

Agent subprocess injected `VIBE_SELLER_DIR/.venv/bin` onto `$PATH`, but `~/.vibe-seller/.venv/bin` is never created by any install mode. Dev clone worked by accident because `start.sh`'s `source .venv/bin/activate` leaked the right PATH via shell inheritance. Fix: inject `Path(sys.executable).parent`, plus `setdefault` `GIT_AUTHOR_*/COMMITTER_*` so the agent's own git operations don't depend on host's `git config --global`.

### 3. `app/workspace/manager.py` — daemon's `_run_git` had the same git-identity gap

`Initial workspace setup` commit failed with `Author identity unknown` on any host without `git config --global`. Fix: set `GIT_*` via env on `_run_git`'s subprocess — works without touching any git config file.

### 4. `install.sh` — `_install_via_pip()` skipped runtime deps

Default end-user path installed `uv + vibe-seller + Playwright`, then `exit 0`. Skipped the system-deps loop entirely, so end users never got `claude`, `sqlite3`, `node`, or `lsof`. Fix: same runtime deps in default mode. Also: `--dev` now actually runs `pnpm build` (the README claims it does; `start.sh` was the real builder). pnpm pinned to v9 because v10+ requires Node 22.

## Empirical proof the wrapper bug is real

Before this fix, on a wheel-installed machine:

```
$ uv tool list
vibe-seller v0.0.1
  - vibe-seller       # only the project's own script — no transitive deps

$ which browser-use
browser-use not found

$ ls ~/.local/share/uv/tools/vibe-seller/bin/browser-use
-rwxr-xr-x ... browser-use   # exists, but NOT on PATH
```

So the wrapper bakes `REAL_BU="browser-use"` and `exec "browser-use"` fails.

## CI proof — fail then pass

| | Run |
|---|---|
| **Fail** — current published `0.0.1` from PyPI **cannot complete** the e2e agent task (`tests/e2e/test_llm_browser.py::TestLLMBrowserAPI::test_agent_reads_homepage`). Inverted assertion — the GitHub step is green only because pytest fails. | <https://github.com/zpoint/vibe-seller/actions/runs/25903984354/job/76133378323> |
| **Pass** — TestPyPI dev wheel built from this PR's HEAD, installed via `./install.sh --test-pypi --version <dev>`, passes the **same** test. | <https://github.com/zpoint/vibe-seller/actions/runs/25903984354/job/76133555102> |

Both run in the same workflow run `25903984354` on a fresh `ubuntu-latest`, exercising the documented `curl | bash install.sh` flow end-to-end. Note: in CI the 0.0.1 wheel actually fails one layer earlier than the wrapper bug (at the daemon's `git commit "Initial workspace setup"` because the runner has no `git config --global`) — both bugs are present in 0.0.1 and both are fixed in this PR. On a workstation with global git identity set, the wrapper "command not found" is what users see.

## Permanent gate after merge

`release.yml`'s `verify-testpypi` and `verify-pypi` now each run the agent smoke step against the freshly-installed daemon. Any future regression of this bug class blocks the PyPI publish step. `ci.yml`'s `e2e-test` job also bootstraps via `./install.sh --dev` instead of duplicating deps inline, so install.sh regressions get caught on every PR.

## After-merge actions

1. (Optional) Rotate/revoke `DEEPSEEK_*` repo secrets if you don't want them long-term — the existing `e2e-test` and the new release-pipeline agent smoke both use them.
2. For users already on `0.0.1`: `vibe-seller stop && vibe-seller upgrade && vibe-seller start`. The per-store wrapper file at `~/.vibe-seller/bin/<slug>/browser-use` auto-regenerates on the next session, so no manual cleanup needed.