### PR TITLE
fix: don't resolve venv symlinks; let agents force-restart Ziniao

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # Mirror what contributors run locally: `pre-commit run --all-files`.
+      # Frontend hooks (frontend-lint, frontend-typecheck) are skipped here
+      # because the frontend-test job below already runs the same checks
+      # (`npm run lint`, `npx tsc -b`) with full node_modules — running them
+      # twice would just slow CI down. Python hooks (ruff lint, ruff format),
+      # the line-limit script, and the file-hygiene hooks all run.
+      - name: Run pre-commit
+        env:
+          SKIP: frontend-lint,frontend-typecheck
+        uses: pre-commit/action@v3.0.1
+
   frontend-test:
     runs-on: ubuntu-latest
     defaults:

--- a/app/ai/claude_backend.py
+++ b/app/ai/claude_backend.py
@@ -363,12 +363,6 @@ class AgentSession(_HookMixin, _StreamMixin):
             env.get('ANTHROPIC_BASE_URL', '<default>'),
             env.get('ANTHROPIC_MODEL', '<default>'),
         )
-        # Browser-use CLI wrapper (per-store isolation)
-        if self.store_slug:
-            store_bin = VIBE_SELLER_DIR / 'bin' / self.store_slug
-            if store_bin.is_dir():
-                env['PATH'] = f'{store_bin}:{env.get("PATH", "")}'
-
         # Pass task ID for multi-client CDP proxy isolation
         env['VIBE_TASK_ID'] = self.task_id
 
@@ -388,23 +382,25 @@ class AgentSession(_HookMixin, _StreamMixin):
         env.setdefault('GIT_COMMITTER_NAME', 'Vibe Seller Agent')
         env.setdefault('GIT_COMMITTER_EMAIL', 'agent@vibe-seller.local')
 
-        # Inject the daemon's own venv bin onto the agent's PATH so
-        # the wrapper's `exec "$REAL_BU"` (and any bash the agent
-        # runs — pytest, fastapi, etc.) resolves binaries from the
-        # same interpreter that runs this server. Works in both modes:
-        #
-        #   - Dev clone (`./start.sh`):   <repo>/.venv/bin/python
-        #   - Wheel install (`vibe-seller start`):
-        #       ~/.local/share/uv/tools/vibe-seller/bin/python
-        #
-        # The old code referenced ``VIBE_SELLER_DIR/.venv/bin``
-        # (``~/.vibe-seller/.venv/bin``), which is never created by
-        # any install mode — a dead branch that masked the missing
-        # PATH injection in wheel-install mode.
-        daemon_bin = Path(sys.executable).resolve().parent
+        # Inject the daemon's venv bin so child bash resolves
+        # binaries from the same interpreter that runs the server.
+        # Do NOT .resolve(): uv tool / `uv venv` symlink the
+        # interpreter to a base Python (pyenv/homebrew/conda); the
+        # resolved bin often ships its own `browser-use` that would
+        # shadow the per-store wrapper prepended below.
+        daemon_bin = Path(sys.executable).parent
         if daemon_bin.is_dir():
             env['PATH'] = f'{daemon_bin}:{env.get("PATH", "")}'
             env['VIRTUAL_ENV'] = str(daemon_bin.parent)
+
+        # Per-store browser-use wrapper. MUST be prepended last so
+        # it sits ahead of daemon_bin — daemon_bin's `browser-use`
+        # would otherwise bypass proxy stripping, --cdp-url
+        # injection, per-task session naming, and URL validation.
+        if self.store_slug:
+            store_bin = VIBE_SELLER_DIR / 'bin' / self.store_slug
+            if store_bin.is_dir():
+                env['PATH'] = f'{store_bin}:{env.get("PATH", "")}'
 
         # start_new_session=True puts claude and every descendant into
         # a fresh POSIX session/process group. We do not rely on this

--- a/app/browser/wrapper.py
+++ b/app/browser/wrapper.py
@@ -79,11 +79,17 @@ def write_browser_use_wrapper(
     # fallback and produce a wrapper that fails at exec time with
     # "command not found". In `./start.sh` (dev clone) mode both paths
     # find it; the sibling lookup is just authoritative.
-    daemon_bin = Path(sys.executable).resolve().parent
+    #
+    # Do NOT .resolve() here: uv tool venvs (and `uv venv`) symlink the
+    # interpreter to a base Python (pyenv / homebrew / conda). Following
+    # that symlink lands in a dir that often has its OWN `browser-use`
+    # from a different (typically older) install — picking it up would
+    # bypass our pinned `browser-use>=0.12.5` and produce a wrapper that
+    # passes flags the older binary doesn't understand (--cdp-url, etc).
+    daemon_bin = Path(sys.executable).parent
     candidate = daemon_bin / 'browser-use'
     real_bu = (
-        str(candidate) if candidate.is_file()
-        else shutil.which('browser-use')
+        str(candidate) if candidate.is_file() else shutil.which('browser-use')
     )
     if not real_bu:
         logger.warning(
@@ -156,7 +162,7 @@ def write_browser_use_wrapper(
                 -X POST \\{auth_header}
                 -H "Content-Type: application/json" \\
                 --max-time 90 \\
-                "http://{LOCALHOST}:{port}/api/stores/{store_id or 'UNKNOWN'}/browser/start" \\
+                "http://{LOCALHOST}:{port}/api/stores/{store_id or 'UNKNOWN'}/browser/start?force=1" \\
                 2>/dev/null) || true
               _start_http=${{_start_resp##*$'\\n'}}
               if ! [ "$_start_http" -ge 200 ] 2>/dev/null \\

--- a/app/routers/stores.py
+++ b/app/routers/stores.py
@@ -430,23 +430,38 @@ async def start_browser(
                 status_code=500,
                 detail=f'Failed to start browser: {e}',
             ) from e
-        account = await db.get(ZiniaoAccount, store.ziniao_account_id)
-        if not account:
+        # DB lookup / decrypt happen inside this handler, outside
+        # the outer try — wrap them so a transient DB error or a
+        # corrupt encrypted_password doesn't bubble out as an
+        # unstructured 500 from FastAPI's default handler.
+        try:
+            account = await db.get(ZiniaoAccount, store.ziniao_account_id)
+            if not account:
+                raise HTTPException(
+                    status_code=500,
+                    detail=f'Failed to start browser: {e}',
+                ) from e
+            user_info = {
+                'company': account.company,
+                'username': account.username,
+                'password': decrypt_password(account.encrypted_password),
+            }
+            client_path = account.client_path or 'ziniao'
+        except HTTPException:
+            raise
+        except Exception as prep_err:
             raise HTTPException(
                 status_code=500,
-                detail=f'Failed to start browser: {e}',
-            ) from e
+                detail=(
+                    'Failed to prepare Ziniao credentials for '
+                    f'force-restart: {prep_err}'
+                ),
+            ) from prep_err
         logger.info(
             'force=true: Ziniao in normal mode for store %s, '
             'relaunching in WebDriver mode',
             store.name,
         )
-        user_info = {
-            'company': account.company,
-            'username': account.username,
-            'password': decrypt_password(account.encrypted_password),
-        }
-        client_path = account.client_path or 'ziniao'
         try:
             await kill_and_relaunch_ziniao(
                 account.socket_port, client_path, user_info

--- a/app/routers/stores.py
+++ b/app/routers/stores.py
@@ -15,6 +15,10 @@ from app.browser.manager import (
     browser_manager,
     store_slug as _store_slug,
 )
+from app.browser.ziniao_utils import (
+    ZiniaoNormalModeError,
+    kill_and_relaunch_ziniao,
+)
 from app.database import get_db
 from app.models.browser_session import BrowserSession
 from app.models.event import Event
@@ -23,10 +27,12 @@ from app.models.store import Store
 from app.models.store_email_link import StoreEmailLink
 from app.models.task import Task
 from app.models.user import User
+from app.models.ziniao_account import ZiniaoAccount
 from app.scheduler.cron import remove_schedule_job
 from app.schemas.store import StoreCreate, StoreResponse, StoreUpdate
 from app.task_states import ACTIVE
 from app.telemetry_events import TelemetryEvent
+from app.utils.crypto import decrypt_password
 from app.workspace.manager import VIBE_SELLER_DIR, workspace_manager
 
 logger = logging.getLogger(__name__)
@@ -388,6 +394,17 @@ async def get_store_bookmarks(
 @router.post('/{store_id}/browser/start')
 async def start_browser(
     store_id: str,
+    force: bool = Query(
+        False,
+        description=(
+            'If True and Ziniao is detected in normal (non-WebDriver) '
+            'mode, kill-and-relaunch Ziniao in WebDriver mode then '
+            'retry the start. Default False preserves the existing '
+            'safety: the user must explicitly click Force Restart in '
+            'the UI. Agent task wrappers pass force=True so they can '
+            'self-recover instead of failing the task.'
+        ),
+    ),
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(get_current_user),
 ):
@@ -397,6 +414,59 @@ async def start_browser(
         raise HTTPException(status_code=404, detail='Store not found')
     try:
         await browser_manager.start_session(store, db)
+    except ZiniaoNormalModeError as e:
+        # Ziniao is sitting in normal (UI) mode. Only the
+        # `Force Restart` button (UI) can relaunch in WebDriver
+        # mode by default — agent tasks must opt in via
+        # ``force=True`` to keep the original safety boundary
+        # explicit. Without ``force``, behave exactly as before.
+        if not force:
+            raise HTTPException(
+                status_code=500,
+                detail=f'Failed to start browser: {e}',
+            ) from e
+        if store.browser_backend != 'ziniao' or not store.ziniao_account_id:
+            raise HTTPException(
+                status_code=500,
+                detail=f'Failed to start browser: {e}',
+            ) from e
+        account = await db.get(ZiniaoAccount, store.ziniao_account_id)
+        if not account:
+            raise HTTPException(
+                status_code=500,
+                detail=f'Failed to start browser: {e}',
+            ) from e
+        logger.info(
+            'force=true: Ziniao in normal mode for store %s, '
+            'relaunching in WebDriver mode',
+            store.name,
+        )
+        user_info = {
+            'company': account.company,
+            'username': account.username,
+            'password': decrypt_password(account.encrypted_password),
+        }
+        client_path = account.client_path or 'ziniao'
+        try:
+            await kill_and_relaunch_ziniao(
+                account.socket_port, client_path, user_info
+            )
+        except RuntimeError as relaunch_err:
+            raise HTTPException(
+                status_code=502,
+                detail=(f'Ziniao relaunch failed: {relaunch_err}'),
+            ) from relaunch_err
+        # Retry the start now that Ziniao is in WebDriver mode.
+        try:
+            await browser_manager.start_session(store, db)
+        except Exception as retry_err:
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    'Failed to start browser after Ziniao '
+                    f'relaunch: {retry_err}'
+                ),
+            ) from retry_err
     except Exception as e:
         raise HTTPException(
             status_code=500,

--- a/app/workspace/manager.py
+++ b/app/workspace/manager.py
@@ -1,10 +1,8 @@
-"""
-WorkspaceManager: manages the ~/.vibe-seller/ directory.
+"""WorkspaceManager: manages the ~/.vibe-seller/ directory.
 
-This directory is git-managed and contains:
-  - .claude/skills/      — Claude Code auto-discovers via --add-dir
-  - knowledge/           — shared platform knowledge
-  - stores/<slug>/       — per-store profiles and accumulated knowledge
+Git-managed, contains ``.claude/skills/`` (auto-discovered via
+``--add-dir``), ``knowledge/`` (shared platform knowledge), and
+``stores/<slug>/`` (per-store profiles and accumulated knowledge).
 """
 
 import asyncio
@@ -695,16 +693,11 @@ browser: {backend}
     async def _run_git(
         self, *args, check: bool = True
     ) -> asyncio.subprocess.Process:
-        """Run a git command in the workspace directory.
-
-        Pre-set GIT_AUTHOR_*/GIT_COMMITTER_* via env (with
-        setdefault, so a real user identity wins) so the
-        `Initial workspace setup` commit succeeds on hosts with no
-        `git config --global user.email/name` — most fresh user
-        machines and CI runners scoped to repo-local identity per
-        #181 fall into that bucket. Touching env (not git config
-        files) keeps the workspace's `.git/config` clean.
-        """
+        """Run a git command in the workspace directory."""
+        # GIT_*_NAME/EMAIL via env (setdefault, so a real identity
+        # wins) keeps the initial-commit working on hosts with no
+        # global `git config user.email/name` (#181) without touching
+        # `.git/config`.
         git_env = dict(os.environ)
         git_env.setdefault('GIT_AUTHOR_NAME', 'Vibe Seller')
         git_env.setdefault('GIT_AUTHOR_EMAIL', 'agent@vibe-seller.local')
@@ -738,13 +731,10 @@ browser: {backend}
     ) -> Path:
         """Create a per-task working directory with symlinks.
 
-        Returns the absolute path to ``tasks/{task_id}/``.
-
-        Shared resources (knowledge, stores, skills, CLAUDE.md)
-        are symlinked so the agent can discover and update them
-        while task-specific files stay isolated.
-
-        When *store_id* is ``None`` (orchestrator / non-store task),
+        Returns the absolute path to ``tasks/{task_id}/``. Shared
+        resources (knowledge, stores, skills, CLAUDE.md) are
+        symlinked; task-specific files stay isolated. When
+        *store_id* is ``None`` (orchestrator / non-store task),
         browser-only skills are excluded from the copy.
         """
         await self.ensure_init()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,9 +27,6 @@ from sqlalchemy.ext.asyncio import (  # noqa: E402
 )
 from sqlalchemy.orm import sessionmaker  # noqa: E402
 
-from app.auth import create_token  # noqa: E402
-from app.database import get_db  # noqa: E402
-from app.main import app  # noqa: E402
 # Force-import every model so Base.metadata.create_all() in the
 # async_db_session fixture below sees every table. SQLAlchemy only
 # registers a table on Base.metadata when its model class has been
@@ -38,6 +35,9 @@ from app.main import app  # noqa: E402
 # Event, ...) silently aren't created and a test that touches them
 # fails later with "no such table: <name>".
 from app import models  # noqa: F401, E402
+from app.auth import create_token  # noqa: E402
+from app.database import get_db  # noqa: E402
+from app.main import app  # noqa: E402
 from app.models.base import Base  # noqa: E402
 from app.models.store import Store  # noqa: E402
 from app.models.task import Task  # noqa: E402

--- a/tests/e2e/test_skill_prereq_hook.py
+++ b/tests/e2e/test_skill_prereq_hook.py
@@ -25,9 +25,9 @@ Requires: real ``claude`` CLI + LLM API key + running server.
 """
 
 import logging
+from pathlib import Path
 import re
 import time
-from pathlib import Path
 
 import httpx
 import pytest
@@ -150,7 +150,7 @@ class TestSkillPrereqHookEndToEnd:
                 '`skill="noon-ads"` again. It will now succeed.\n\n'
                 '4. Echo back the noon login URL '
                 '(https://login.noon.partners/en/) on its own line '
-                "in your final response. Copy it exactly from the "
+                'in your final response. Copy it exactly from the '
                 'noon-shared content you loaded.'
             ),
         )
@@ -184,8 +184,7 @@ class TestSkillPrereqHookEndToEnd:
             'of this test.\n\n'
             'Log excerpt around task_id:\n'
             + '\n'.join(
-                line for line in log_text.splitlines()
-                if task_id_prefix in line
+                line for line in log_text.splitlines() if task_id_prefix in line
             )[:2000]
         )
 
@@ -195,13 +194,15 @@ class TestSkillPrereqHookEndToEnd:
         # loaded after the retry — which can only happen if the
         # agent corrected its load order in response to the deny.
         messages = get_messages(api_client, task_id)
-        all_text = ' '.join(
-            m.get('content', '') for m in messages
-        ) + ' ' + (result.get('result') or '')
+        all_text = (
+            ' '.join(m.get('content', '') for m in messages)
+            + ' '
+            + (result.get('result') or '')
+        )
         assert NOON_SHARED_MARKER in all_text, (
             f'Expected the noon login URL {NOON_SHARED_MARKER!r} '
             "(from noon-shared) to appear in the agent's "
-            "transcript after the prerequisite load succeeded. "
+            'transcript after the prerequisite load succeeded. '
             'Either the agent never loaded noon-shared, or its '
             'content never reached the context.\n'
             f'Transcript first 800 chars: {all_text[:800]!r}'

--- a/tests/unit/test_browser/test_browser_use_wrapper.py
+++ b/tests/unit/test_browser/test_browser_use_wrapper.py
@@ -11,6 +11,7 @@ Generates wrapper scripts to a tmp dir and verifies:
 """
 
 from pathlib import Path
+import re
 import subprocess
 from unittest import mock
 
@@ -49,12 +50,13 @@ def _generate_wrapper(
     wrapper = bin_dir / slug / 'browser-use'
 
     # Replace REAL_BU with echo so the wrapper prints args
-    # instead of executing the real binary.
+    # instead of executing the real binary. Use regex because
+    # the generator picks the sibling `browser-use` next to
+    # `sys.executable` first (real path on dev clones) and
+    # only falls back to `shutil.which` if that's missing —
+    # so the mocked /usr/local/bin path isn't guaranteed.
     content = wrapper.read_text()
-    content = content.replace(
-        'REAL_BU="/usr/local/bin/browser-use"',
-        'REAL_BU="echo"',
-    )
+    content = re.sub(r'REAL_BU="[^"]*"', 'REAL_BU="echo"', content)
     # Replace curl with /usr/bin/true so auto-start checks
     # pass instantly without hitting real endpoints.
     content = content.replace('curl ', '/usr/bin/true ')

--- a/tests/unit/test_browser/test_manager.py
+++ b/tests/unit/test_browser/test_manager.py
@@ -65,6 +65,12 @@ class TestWriteBrowserUseWrapper:
     def test_creates_wrapper_ziniao(self, tmp_path: Path, monkeypatch):
         """Creates executable wrapper for ziniao store."""
         monkeypatch.setattr('app.browser.wrapper._BIN_DIR', tmp_path / 'bin')
+        # Point sys.executable at a tmp dir with no browser-use
+        # sibling so the wrapper falls back to shutil.which.
+        monkeypatch.setattr(
+            'app.browser.wrapper.sys.executable',
+            str(tmp_path / 'fake-venv' / 'bin' / 'python'),
+        )
         monkeypatch.setattr(
             'app.browser.wrapper.shutil.which',
             lambda x: '/usr/local/bin/browser-use',
@@ -163,6 +169,13 @@ class TestWriteBrowserUseWrapper:
     def test_fallback_when_binary_not_found(self, tmp_path: Path, monkeypatch):
         """Uses 'browser-use' as fallback if binary not found."""
         monkeypatch.setattr('app.browser.wrapper._BIN_DIR', tmp_path / 'bin')
+        # No sibling next to sys.executable AND shutil.which
+        # returns None — the wrapper should fall back to the
+        # bare-string "browser-use".
+        monkeypatch.setattr(
+            'app.browser.wrapper.sys.executable',
+            str(tmp_path / 'fake-venv' / 'bin' / 'python'),
+        )
         monkeypatch.setattr(
             'app.browser.wrapper.shutil.which',
             lambda x: None,

--- a/tests/unit/test_prompt_assembly.py
+++ b/tests/unit/test_prompt_assembly.py
@@ -88,7 +88,7 @@ async def _patch_async_session(monkeypatch):
     # (added when build_system_context started querying tasks for
     # the previous schedule run), and the 16 prompt-assembly tests
     # silently 'no such table: tasks'.
-    import sys as _sys
+    import sys as _sys  # noqa: PLC0415
 
     for _mod_name, _mod in list(_sys.modules.items()):
         if not _mod_name.startswith('app.'):

--- a/tests/unit/test_routers/test_stores.py
+++ b/tests/unit/test_routers/test_stores.py
@@ -2,13 +2,17 @@
 
 import json
 from unittest import mock
+import uuid
 
 from httpx import AsyncClient
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.browser.ziniao_utils import ZiniaoNormalModeError
 from app.models.store import Store
 from app.models.user import User
+from app.models.ziniao_account import ZiniaoAccount
+from app.utils.crypto import encrypt_password
 
 
 class TestStoresRouter:
@@ -129,3 +133,105 @@ class TestStoresRouter:
         response = await async_client.get('/api/stores')
 
         assert response.status_code == 401
+
+
+class TestBrowserStartForce:
+    """POST /api/stores/{id}/browser/start with optional ?force=1.
+
+    Covers the agent-side opt-in recovery when Ziniao is sitting in
+    normal (non-WebDriver) mode. Default behavior (no force) must
+    keep the original 500 so the UI's Force Restart button stays the
+    sole entry point for the kill-and-relaunch path.
+    """
+
+    async def _make_ziniao_store(self, async_db_session: AsyncSession) -> Store:
+        account = ZiniaoAccount(
+            id=str(uuid.uuid4()),
+            name='test-account',
+            company='c',
+            username='u',
+            encrypted_password=encrypt_password('p'),
+            socket_port=16851,
+        )
+        async_db_session.add(account)
+        store = Store(
+            id=str(uuid.uuid4()),
+            name='Z Store',
+            browser_backend='ziniao',
+            browser_config='{}',
+            ziniao_account_id=account.id,
+            platforms='["amazon"]',
+            countries='["SA"]',
+        )
+        async_db_session.add(store)
+        await async_db_session.commit()
+        return store
+
+    @pytest.mark.asyncio
+    async def test_force_false_propagates_normal_mode_error(
+        self,
+        authenticated_client: AsyncClient,
+        async_db_session: AsyncSession,
+    ):
+        """Without ?force, ZiniaoNormalModeError still becomes 500."""
+        store = await self._make_ziniao_store(async_db_session)
+        with mock.patch(
+            'app.routers.stores.browser_manager.start_session',
+            side_effect=ZiniaoNormalModeError('normal mode'),
+        ):
+            response = await authenticated_client.post(
+                f'/api/stores/{store.id}/browser/start'
+            )
+        assert response.status_code == 500
+        assert 'normal mode' in response.json()['detail']
+
+    @pytest.mark.asyncio
+    async def test_force_true_relaunches_and_retries(
+        self,
+        authenticated_client: AsyncClient,
+        async_db_session: AsyncSession,
+    ):
+        """force=1: kill_and_relaunch then start_session succeeds."""
+        store = await self._make_ziniao_store(async_db_session)
+        start_session = mock.AsyncMock(
+            side_effect=[ZiniaoNormalModeError('normal'), None]
+        )
+        relaunch = mock.AsyncMock(return_value=True)
+        with (
+            mock.patch(
+                'app.routers.stores.browser_manager.start_session',
+                start_session,
+            ),
+            mock.patch('app.routers.stores.kill_and_relaunch_ziniao', relaunch),
+        ):
+            response = await authenticated_client.post(
+                f'/api/stores/{store.id}/browser/start?force=1'
+            )
+        assert response.status_code == 200
+        assert response.json() == {'ok': True}
+        relaunch.assert_awaited_once()
+        assert start_session.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_force_true_relaunch_failure_returns_502(
+        self,
+        authenticated_client: AsyncClient,
+        async_db_session: AsyncSession,
+    ):
+        """force=1: 502 when kill_and_relaunch raises RuntimeError."""
+        store = await self._make_ziniao_store(async_db_session)
+        with (
+            mock.patch(
+                'app.routers.stores.browser_manager.start_session',
+                side_effect=ZiniaoNormalModeError('normal'),
+            ),
+            mock.patch(
+                'app.routers.stores.kill_and_relaunch_ziniao',
+                side_effect=RuntimeError('relaunch boom'),
+            ),
+        ):
+            response = await authenticated_client.post(
+                f'/api/stores/{store.id}/browser/start?force=1'
+            )
+        assert response.status_code == 502
+        assert 'relaunch boom' in response.json()['detail']

--- a/tests/workflow/conftest.py
+++ b/tests/workflow/conftest.py
@@ -16,9 +16,6 @@ from sqlalchemy.ext.asyncio import (
 )
 from sqlalchemy.pool import StaticPool
 
-from app.auth import create_token
-from app.database import get_db
-from app.main import app
 # Force-import every model so Base.metadata.create_all() below sees
 # them all. SQLAlchemy only registers a table on Base.metadata when
 # the model class has been imported — without this `from app import
@@ -28,6 +25,9 @@ from app.main import app
 # `# noqa: F401` is because we don't use `models` as a symbol — the
 # import is only for its side effect on Base.metadata.
 from app import models  # noqa: F401
+from app.auth import create_token
+from app.database import get_db
+from app.main import app
 from app.models.app_settings import AppSettings
 from app.models.base import Base
 from app.models.user import User


### PR DESCRIPTION
## Summary

Three latent bugs all share the same root cause: `Path(sys.executable).resolve().parent` follows the venv interpreter symlink into a base Python (pyenv / homebrew / conda) whose `bin/` happens to contain its own `browser-use`. Under `uv tool install vibe-seller` that's the default — uv tool venvs symlink the interpreter and most contributor machines have `browser-use` installed somewhere else too. Plus one design gap that surfaced alongside.

### Bugs fixed

- **`app/ai/claude_backend.py`** — PATH was built `daemon_bin:store_bin:...` with `daemon_bin` coming via `.resolve()`. The base Python's `browser-use` ended up shadowing the per-store wrapper, so the wrapper's `unset all_proxy`, `--cdp-url` injection, and per-task session naming were silently bypassed. Now drops `.resolve()` and prepends `store_bin` **last** so the wrapper always wins on PATH.
- **`app/browser/wrapper.py`** — same `.resolve()` picked a sibling `browser-use` from pyenv / homebrew that's older than the pin (`browser-use>=0.12.5`). The generated wrapper exec'd a binary that doesn't recognize `--cdp-url` and `browser-use open` always failed with ``error: argument command: invalid choice: 'ws://...'``. Drops `.resolve()`.
- **`app/routers/stores.py`** — when Ziniao was in normal (non-WebDriver) mode, the only recovery was the UI's *Force Restart* button. Agent tasks hit a hard 500 and gave up. Adds `?force=1` to `POST /stores/{id}/browser/start` so agent wrappers can opt into `kill_and_relaunch_ziniao`. Default behavior is unchanged — UI flow still requires the explicit button. Wrapper template now always passes `?force=1`.

### Observed symptom in the wild

End-user shell had `all_proxy=socks5://127.0.0.1:7890` set (ClashX). Agent's `browser-use open` failed with `Using SOCKS proxy, but the 'socksio' package is not installed` — but `socksio` *was* installed; the wrapper that strips proxy env was just being shadowed off PATH. Vibe-seller's target market (Chinese cross-border sellers) very commonly has SOCKS proxies in their shell env, so this hit the wheel-install path almost universally.

### CI

Adds a `pre-commit` job to `ci.yml` that runs `pre-commit run --all-files`, skipping the two frontend hooks (`frontend-lint`, `frontend-typecheck`) since the existing `frontend-test` job already runs the same checks with full `node_modules`.

## Test plan

- [x] Reproduced original SOCKS error on a wheel-install machine with `all_proxy` set
- [x] Verified `daemon_bin` now points at `~/.local/share/uv/tools/vibe-seller/bin/` (not pyenv) after the `.resolve()` removal in `claude_backend.py`
- [x] Verified generated wrapper's `REAL_BU=` now points at the uv tool venv's `browser-use` (not pyenv's older binary)
- [x] Verified `POST /browser/start?force=1` triggers `kill_and_relaunch_ziniao` when Ziniao is in normal mode
- [x] Verified `POST /browser/start` without `force` preserves original behavior (raises the existing `ZiniaoNormalModeError`)
- [x] End-to-end: created a task on Mac (wheel install, proxy in shell, Ziniao starting in normal mode) → task ran successfully, no manual intervention
- [x] `pre-commit run --all-files` passes locally (including the 800-line limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)