### PR TITLE
fix(reflection): don't let reflection text replace user-facing answer

### DIFF
--- a/app/ai/claude_backend_hooks.py
+++ b/app/ai/claude_backend_hooks.py
@@ -355,8 +355,14 @@ class _HookMixin:
                 pre = '\n\n'.join(p for p in self._exec_phase_text_parts if p)
                 if not pre:
                     pre = tool_input.get('last_assistant_message', '')
+                # Always set (even to '') so the result handler can
+                # detect that Stop-hook reflection fired. If pre is
+                # empty, the post-reflection text in the next
+                # ``result`` event is reflection content (e.g. 'No
+                # transferable learning…') and MUST NOT become the
+                # user-facing answer.
+                self._pre_reflection_result = pre
                 if pre:
-                    self._pre_reflection_result = pre
                     await self._save_result(pre)
                 reason = render_prompt(
                     REFLECTION_PROMPT,

--- a/app/ai/claude_backend_stream.py
+++ b/app/ai/claude_backend_stream.py
@@ -272,11 +272,22 @@ class _StreamMixin:
             # reflection text — in that case the post-reflection
             # text is reflection content and must NOT become the
             # user-facing result. Distinguish via ``is not None``.
+            reflection_suppressed = False
             if self._pre_reflection_result is not None:
                 if not is_error:
                     text = self._pre_reflection_result
+                reflection_suppressed = self._pre_reflection_result == ''
                 self._pre_reflection_result = None
-            if text:
+            # Emit when there's text, OR when reflection was
+            # suppressed (text intentionally empty). The result
+            # event existence is the "turn ended" signal that
+            # downstream consumers (UI, the e2e test poll) depend
+            # on; dropping it entirely just because reflection
+            # contaminated the text turns one bug (wrong text)
+            # into another (no end-of-turn signal). Legitimate
+            # empty results from the agent (no reflection, no
+            # text) stay ignored — see test_empty_result_ignored.
+            if text or reflection_suppressed:
                 self._last_result_event = text
                 if is_error:
                     self._is_error_result = True

--- a/app/ai/claude_backend_stream.py
+++ b/app/ai/claude_backend_stream.py
@@ -267,13 +267,14 @@ class _StreamMixin:
             is_error = event.get('is_error', False)
             if event.get('subtype') == 'success' and not is_error:
                 self._agent_success = True
-            # Prefer pre-reflection result (saved before Stop hook
-            # blocked) over the post-reflection text that Claude
-            # Code reports in the final result event.
-            if self._pre_reflection_result:
+            # ``None`` means Stop-hook reflection never fired this
+            # turn; '' means it fired but the agent had no pre-
+            # reflection text — in that case the post-reflection
+            # text is reflection content and must NOT become the
+            # user-facing result. Distinguish via ``is not None``.
+            if self._pre_reflection_result is not None:
                 if not is_error:
                     text = self._pre_reflection_result
-                # Always clear to prevent stale leakage
                 self._pre_reflection_result = None
             if text:
                 self._last_result_event = text

--- a/app/routers/tasks_conversation.py
+++ b/app/routers/tasks_conversation.py
@@ -101,6 +101,16 @@ async def _spawn_followup_agent(
             resume=True,
             auto_approve_plan=auto_approve_plan,
             store_slug=(_store_slug(store.name, store.id) if store else None),
+            # Follow-up turns are conversational — reflection is
+            # for initial task knowledge capture. Re-running it on
+            # every follow-up forces a text-emitting reflection
+            # phase that overwrites the agent's actual response
+            # when the model put its answer only in a thinking
+            # block (e.g. GLM-4.7 on terse follow-ups). The
+            # initial task's reflection already captured any
+            # learnings; conversational turns have nothing new
+            # to learn from.
+            skip_reflection=True,
         )
     except Exception:
         logger.exception(

--- a/tests/unit/test_handle_event_result.py
+++ b/tests/unit/test_handle_event_result.py
@@ -172,3 +172,86 @@ class TestHandleEventResultDedup:
         assert emitted[0] == ('result', 'Auto result')
         assert emitted[1] == ('assistant', 'Extra ack')
         assert session._result_text == 'Auto result'
+
+
+class TestHandleEventReflectionGuard:
+    """_handle_event must distinguish ``_pre_reflection_result``:
+
+    - ``None`` → Stop-hook reflection never fired this turn; use the
+      result event's own text as-is.
+    - non-empty string → reflection fired AFTER the agent produced
+      real exec-phase text; the pre-reflection snapshot is the
+      user-facing answer and overrides the result event (which
+      otherwise reports reflection content).
+    - empty string ``''`` → reflection fired but the agent had no
+      exec-phase text (e.g. answer in a ``thinking`` block only);
+      the result event's text is reflection content and must be
+      suppressed so reflection never becomes the user-facing answer.
+
+    The ``is not None`` check is the contract; this pin guards it.
+    """
+
+    async def test_none_pre_reflection_uses_result_text(self):
+        """Default ``_pre_reflection_result`` is None → result event
+        text passes through unchanged."""
+        session = _make_session('execute')
+        assert session._pre_reflection_result is None
+        emitted: list[tuple[str, str]] = []
+
+        async def _mock_emit(role, content):
+            emitted.append((role, content))
+
+        with patch.object(session, '_emit_message', _mock_emit):
+            await session._handle_event({
+                'type': 'result',
+                'result': 'Plain answer',
+            })
+
+        assert emitted == [('result', 'Plain answer')]
+        assert session._result_text == 'Plain answer'
+
+    async def test_nonempty_pre_reflection_overrides_result(self):
+        """Pre-reflection snapshot (real answer) overrides the
+        post-reflection text in the result event."""
+        session = _make_session('execute')
+        session._pre_reflection_result = 'The real answer'
+        emitted: list[tuple[str, str]] = []
+
+        async def _mock_emit(role, content):
+            emitted.append((role, content))
+
+        with patch.object(session, '_emit_message', _mock_emit):
+            await session._handle_event({
+                'type': 'result',
+                'result': 'No transferable learning…',
+            })
+
+        assert emitted == [('result', 'The real answer')]
+        assert session._result_text == 'The real answer'
+        # Always cleared so a later turn does not adopt stale state.
+        assert session._pre_reflection_result is None
+
+    async def test_empty_pre_reflection_suppresses_reflection_text(self):
+        """Empty-string ``_pre_reflection_result`` proves reflection
+        fired but the agent had no exec-phase text. The result
+        event's reflection content MUST NOT become the user-facing
+        answer — text is overridden to empty and nothing is emitted
+        (matches the empty-result branch)."""
+        session = _make_session('execute')
+        session._pre_reflection_result = ''
+        emitted: list[tuple[str, str]] = []
+
+        async def _mock_emit(role, content):
+            emitted.append((role, content))
+
+        with patch.object(session, '_emit_message', _mock_emit):
+            await session._handle_event({
+                'type': 'result',
+                'result': 'No transferable learning from this task.',
+            })
+
+        assert emitted == []
+        assert session._first_result_emitted is False
+        assert session._result_text == ''
+        # Always cleared so a later turn does not adopt stale state.
+        assert session._pre_reflection_result is None

--- a/tests/unit/test_handle_event_result.py
+++ b/tests/unit/test_handle_event_result.py
@@ -235,8 +235,12 @@ class TestHandleEventReflectionGuard:
         """Empty-string ``_pre_reflection_result`` proves reflection
         fired but the agent had no exec-phase text. The result
         event's reflection content MUST NOT become the user-facing
-        answer — text is overridden to empty and nothing is emitted
-        (matches the empty-result branch)."""
+        answer — text is overridden to empty. BUT we still emit a
+        result message with that empty text: the result event's
+        existence is the "turn ended" signal downstream consumers
+        (UI, e2e test polls) depend on, so dropping it entirely
+        would just trade one bug (wrong text) for another (no
+        end-of-turn signal)."""
         session = _make_session('execute')
         session._pre_reflection_result = ''
         emitted: list[tuple[str, str]] = []
@@ -250,8 +254,10 @@ class TestHandleEventReflectionGuard:
                 'result': 'No transferable learning from this task.',
             })
 
-        assert emitted == []
-        assert session._first_result_emitted is False
+        # Result emitted with empty text — turn-end signal goes out,
+        # reflection content does NOT become the answer.
+        assert emitted == [('result', '')]
+        assert session._first_result_emitted is True
         assert session._result_text == ''
         # Always cleared so a later turn does not adopt stale state.
         assert session._pre_reflection_result is None


### PR DESCRIPTION
## Summary

The post-task reflection step was contaminating the agent's response to the user. Two layered design fixes, either of which is sufficient to trigger the bug:

1. **Reflection fired on every conversational follow-up.** `app/routers/tasks_conversation.py` — follow-ups via `POST /api/tasks/{id}/messages` called `agent_manager.run()` without `skip_reflection=True`, so each conversational turn ran the same knowledge-capture cycle as initial task completion. The initial task already captured learnings; re-running it on every follow-up forces the agent to emit a text "reflection" block that overwrites whatever answer it produced for the user. Matches the existing skip-reflection sites (`/agent/start` ad-hoc spawn, the system catalog-sync task).

2. **Pre-reflection snapshot was only set when there was text to save.** `app/ai/claude_backend_hooks.py` — `_pre_reflection_result` was only assigned when `pre` was truthy. If the model emitted only a `thinking` block this turn (observed: GLM-4.7 on terse follow-ups), `pre` was empty, the field stayed `None`, and the result handler had no way to know that the post-reflection text in the next `result` event was reflection content. Now the field is always set (to `''` if no pre-text), and the result handler in `app/ai/claude_backend_stream.py` uses `is not None` so reflection content never replaces a missing answer.

## User-visible scenario

User says "remember code ALPHA-7742," then asks "what was the code?" — the agent's reply could end up being "*No transferable learning from this task*" instead of "ALPHA-7742." That reflection text is also persisted to the conversation history, so subsequent follow-ups see it and may mimic the pattern.

## Test plan

- [x] `pre-commit run --files <changed>` passes locally
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)