### PR TITLE
fix: cc-switch override guard hardening + pnpm-workspace.yaml packages field

### DIFF
--- a/app/ai/external_config.py
+++ b/app/ai/external_config.py
@@ -112,18 +112,24 @@ class ExternalConfigOverrideError(RuntimeError):
         }
 
     def _clear_command(self) -> str:
+        # Drop ALL ``ANTHROPIC_*`` keys from ``settings.json`` env by
+        # prefix rather than interpolating each specific key into a
+        # python3 -c one-liner. The interpolated form had two real
+        # footguns:
+        #   - The outer shell string is double-quoted, so quoting
+        #     the key list with double-quotes (json.dumps) breaks
+        #     the shell escape.
+        #   - A key containing a quote could let a hostile
+        #     settings.json synthesize unintended shell text.
+        # Prefix-iterate sidesteps both — and matches the README
+        # snippet so users see one consistent recipe.
         return (
             'python3 -c "import json,pathlib;'
             "p=pathlib.Path.home()/'.claude'/'settings.json';"
             'd=json.loads(p.read_text());'
             "env=d.get('env') or {};"
-            # NB: list literal (not tuple) — ``('SINGLE_KEY')`` is a
-            # string in Python and would iterate char-by-char, which
-            # silently breaks the one-key cc-switch shape (the most
-            # common case).
-            "[env.pop(k,None) for k in ['"
-            + "','".join(self.overriding_keys)
-            + "']];"
+            '[env.pop(k,None) for k in list(env) '
+            "if k.startswith('ANTHROPIC_')];"
             "d['env']=env;"
             'p.write_text(json.dumps(d,indent=2))"'
         )

--- a/app/routers/tasks_conversation.py
+++ b/app/routers/tasks_conversation.py
@@ -105,33 +105,48 @@ async def _spawn_followup_agent(
         try:
             assert_profile_compatible(profile_id)
         except ExternalConfigOverrideError as override_err:
-            # JSON-encode the structured detail so the frontend
-            # ``ExternalConfigOverrideErrorCard`` can render it in
-            # the user's locale — same shape as the auto-launch
-            # path in ``app/task_runner_auto.py``.
+            # Expected, user-actionable condition — don't ``raise``
+            # into the outer ``except Exception`` (it would log a
+            # full stack trace via ``logger.exception``). Instead
+            # update the revert vars in-place and skip past the
+            # agent_manager.run call so the existing revert path
+            # below runs with the structured detail.
+            #
+            # JSON-encode so the frontend's
+            # ``ExternalConfigOverrideErrorCard`` renders the
+            # localized template (same shape as auto_run_task).
             revert_error = json.dumps(override_err.to_api_detail())
             revert_error_category = 'external_config_override'
-            raise
-        started = await agent_manager.run(
-            task_id,
-            prompt,
-            system_extra=system_extra,
-            mode=mode,
-            profile_id=profile_id,
-            resume=True,
-            auto_approve_plan=auto_approve_plan,
-            store_slug=(_store_slug(store.name, store.id) if store else None),
-            # Follow-up turns are conversational — reflection is
-            # for initial task knowledge capture. Re-running it on
-            # every follow-up forces a text-emitting reflection
-            # phase that overwrites the agent's actual response
-            # when the model put its answer only in a thinking
-            # block (e.g. GLM-4.7 on terse follow-ups). The
-            # initial task's reflection already captured any
-            # learnings; conversational turns have nothing new
-            # to learn from.
-            skip_reflection=True,
-        )
+            logger.info(
+                'Follow-up for task %s blocked by external config '
+                'override (%s); will revert.',
+                task_id,
+                override_err.overriding_keys,
+            )
+            started = False
+        else:
+            started = await agent_manager.run(
+                task_id,
+                prompt,
+                system_extra=system_extra,
+                mode=mode,
+                profile_id=profile_id,
+                resume=True,
+                auto_approve_plan=auto_approve_plan,
+                store_slug=(
+                    _store_slug(store.name, store.id) if store else None
+                ),
+                # Follow-up turns are conversational — reflection is
+                # for initial task knowledge capture. Re-running it
+                # on every follow-up forces a text-emitting
+                # reflection phase that overwrites the agent's
+                # actual response when the model put its answer
+                # only in a thinking block (e.g. GLM-4.7 on terse
+                # follow-ups). The initial task's reflection already
+                # captured any learnings; conversational turns have
+                # nothing new to learn from.
+                skip_reflection=True,
+            )
     except Exception:
         logger.exception(
             'Background follow-up agent run failed for task %s', task_id

--- a/app/task_runner_exec.py
+++ b/app/task_runner_exec.py
@@ -7,7 +7,10 @@ from sqlalchemy import select
 from app import telemetry
 from app.ai.claude_backend_manager import agent_manager
 from app.ai.claude_backend_utils import parse_wait_condition
-from app.ai.external_config import assert_profile_compatible
+from app.ai.external_config import (
+    ExternalConfigOverrideError,
+    assert_profile_compatible,
+)
 from app.ai.profiles import DEFAULT_PROFILE_ID, profile_kind_for_id
 from app.browser.manager import browser_manager, store_slug as _store_slug
 from app.database import async_session
@@ -44,6 +47,30 @@ logger = logging.getLogger(__name__)
 
 _send_task_completed = send_task_completed
 _send_task_failed = send_task_failed
+
+
+async def _fail_task_external_config_override(
+    task_id: str, ext_err: ExternalConfigOverrideError
+) -> None:
+    # Persist as structured failure: JSON detail in task.error +
+    # error_category='external_config_override' so the frontend's
+    # ExternalConfigOverrideErrorCard renders the localized template.
+    async with async_session() as db_fail:
+        t = await db_fail.get(Task, task_id)
+        if t and can_transition(t.status, TaskStatus.FAILED):
+            t.status = TaskStatus.FAILED
+            t.error = json.dumps(ext_err.to_api_detail())
+            t.error_category = 'external_config_override'
+            t.completed_at = datetime.now(UTC).isoformat()
+            await db_fail.commit()
+            await event_bus.emit(
+                'task_update',
+                {
+                    'task_id': task_id,
+                    'status': TaskStatus.FAILED,
+                    'error': t.error,
+                },
+            )
 
 
 async def execute_planned_task(task_id: str, store: Store | None):
@@ -194,12 +221,16 @@ async def execute_planned_task(task_id: str, store: Store | None):
                 store,
                 header=TaskHeader.EXECUTE,
             )
-            # Re-check the override before each execute-phase spawn
-            # — cc-switch may have written settings.json since the
-            # initial plan. Raises ExternalConfigOverrideError which
-            # the outer ``_run_with_status`` failure handler maps to
-            # the task FAILED transition.
-            assert_profile_compatible(task.ai_profile_id or DEFAULT_PROFILE_ID)
+            # Re-check the override before each execute-phase spawn —
+            # cc-switch may have written settings.json since the
+            # initial plan.
+            try:
+                assert_profile_compatible(
+                    task.ai_profile_id or DEFAULT_PROFILE_ID
+                )
+            except ExternalConfigOverrideError as ext_err:
+                await _fail_task_external_config_override(task_id, ext_err)
+                return
             await agent_manager.run(
                 task_id,
                 bundle.prompt,
@@ -557,10 +588,12 @@ async def execute_woken_task(task_id: str, store: Store | None):
             store_emails=store_emails,
         )
         # Same cc-switch / external-override re-check as the execute
-        # phase above — see that site for the rationale. Raises
-        # ``ExternalConfigOverrideError`` which the woken-launch
-        # error handler maps to a task FAILED transition.
-        assert_profile_compatible(task.ai_profile_id or DEFAULT_PROFILE_ID)
+        # phase above.
+        try:
+            assert_profile_compatible(task.ai_profile_id or DEFAULT_PROFILE_ID)
+        except ExternalConfigOverrideError as ext_err:
+            await _fail_task_external_config_override(task_id, ext_err)
+            return
         await agent_manager.run(
             task_id,
             prompt,
@@ -765,5 +798,3 @@ async def execute_woken_task(task_id: str, store: Store | None):
                 'Failed to update woken task %s after error',
                 task_id,
             )
-    finally:
-        pass

--- a/docs/subsystems.md
+++ b/docs/subsystems.md
@@ -285,7 +285,7 @@ When the agent calls `vibe_seller_set_task_result`, the resolved result text run
 
 ### Why soft, not hard
 
-Gates can be wrong, the model can be stubborn, and trapping the agent forever in a deny loop wastes tokens. Each gate is allowed at most `SOFT_GATE_MAX_DENIALS` (currently 2) per task; on the next attempt the result is allowed through with the original text and a `logger.warning(...)`. Deny counts are tracked in-memory by task id (`record_attempt` in `app/ai/stop_gates/__init__.py`).
+Gates can be wrong, the model can be stubborn, and trapping the agent forever in a deny loop wastes tokens. Each gate is allowed at most `SOFT_GATE_MAX_DENIALS` denials per task (the agent sees the deny reason and can retry); past the cap the result is allowed through with the original text and a `logger.warning(...)`. Deny counts are tracked in-memory by task id (`record_attempt` in `app/ai/stop_gates/__init__.py`); the current cap value lives there alongside the rationale.
 
 ### Why at the MCP tool call, not the Stop hook
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,3 +1,12 @@
+# Single-package "workspace" — pnpm 11+ requires a `packages:` field
+# whenever this file exists, even though we only have one package
+# rooted here. The actual reason this file exists is `allowBuilds`:
+# pnpm 11+ refuses ignored post-install scripts in CI by default
+# (esbuild / core-js / protobufjs need their native binaries), so
+# they have to be explicitly approved here.
+packages:
+  - .
+
 allowBuilds:
   core-js: true
   esbuild: true

--- a/tests/unit/test_external_config.py
+++ b/tests/unit/test_external_config.py
@@ -8,6 +8,7 @@ and we want a single source of truth for the user-facing message.
 
 import json
 from pathlib import Path
+import subprocess
 
 import pytest
 
@@ -160,42 +161,45 @@ class TestUserMessage:
         assert 'cc-switch' in msg.lower() or 'quit' in msg.lower()
 
 
-import json as _json  # noqa: E402 — moved out of test method body
-import subprocess  # noqa: E402
-
-from app.ai.external_config import (  # noqa: E402,F811
-    ExternalConfigOverrideError as _ECOE,
-)
-
-
 class TestClearCommandActuallyWorks:
     """Run the generated cleanup command against a fixture
     ``settings.json`` to prove it actually removes the conflicting
-    keys. Pins the ``('SINGLE_KEY')``-is-a-string-not-a-tuple
-    regression — the single-key case is the most common cc-switch
-    shape, and a list literal makes it work for any count.
+    keys. The command iterates by ``ANTHROPIC_*`` prefix so it
+    works for any number of keys (one, many, or future ones we
+    don't know about yet) without needing the names interpolated
+    into the shell command — which was the source of two prior
+    bugs (single-key-becomes-string-not-tuple, and shell-escape
+    breakage from double-quoted JSON inside the outer python3 -c
+    double-quoted arg).
     """
 
-    def _run_clear(self, tmp_path, keys: list[str], env_seed: dict):
-        """Build the clear command for ``keys``, patch its target
-        path to ``tmp_path/settings.json`` (so we don't touch the
-        real home dir), then execute it. Returns the resulting env
-        dict."""
+    def _run_clear(self, tmp_path, env_seed: dict):
+        """Build the clear command, patch its target path to
+        ``tmp_path/settings.json`` so we don't touch the real home
+        dir, then execute it. Returns the resulting env dict."""
         path = tmp_path / 'settings.json'
-        path.write_text(_json.dumps({'env': env_seed}))
+        path.write_text(json.dumps({'env': env_seed}))
 
-        err = _ECOE('deepseek', keys)
+        # The overriding_keys argument is no longer used by
+        # ``_clear_command`` (it iterates by prefix), but the
+        # constructor still requires it to build the user-facing
+        # message — pass whatever's in the seed for realism.
+        anthropic_keys = [k for k in env_seed if k.startswith('ANTHROPIC_')]
+        err = ExternalConfigOverrideError('deepseek', anthropic_keys)
+        # ``repr(str(path))`` produces a properly-escaped Python
+        # string literal, so the swap survives tmp paths that
+        # contain single quotes, backslashes (Windows), or other
+        # characters that would break a naive f-string.
         cmd = err._clear_command().replace(
             "pathlib.Path.home()/'.claude'/'settings.json'",
-            f"pathlib.Path('{path}')",
+            f'pathlib.Path({repr(str(path))})',
         )
         subprocess.run(cmd, shell=True, check=True)
-        return _json.loads(path.read_text())['env']
+        return json.loads(path.read_text())['env']
 
     def test_single_key_removed(self, tmp_path):
         env = self._run_clear(
             tmp_path,
-            ['ANTHROPIC_BASE_URL'],
             {
                 'ANTHROPIC_BASE_URL': 'https://x.test',
                 'PATH': '/usr/bin',
@@ -207,7 +211,6 @@ class TestClearCommandActuallyWorks:
     def test_multiple_keys_all_removed(self, tmp_path):
         env = self._run_clear(
             tmp_path,
-            ['ANTHROPIC_BASE_URL', 'ANTHROPIC_AUTH_TOKEN'],
             {
                 'ANTHROPIC_BASE_URL': 'https://x.test',
                 'ANTHROPIC_AUTH_TOKEN': 'sk-fake',
@@ -216,4 +219,17 @@ class TestClearCommandActuallyWorks:
         )
         assert 'ANTHROPIC_BASE_URL' not in env
         assert 'ANTHROPIC_AUTH_TOKEN' not in env
+        assert env.get('PATH') == '/usr/bin'
+
+    def test_future_anthropic_key_also_removed(self, tmp_path):
+        """A key the code has never heard of should still be cleaned
+        — prefix iteration is the whole point."""
+        env = self._run_clear(
+            tmp_path,
+            {
+                'ANTHROPIC_FUTURE_FLAG_2027': '1',
+                'PATH': '/usr/bin',
+            },
+        )
+        assert 'ANTHROPIC_FUTURE_FLAG_2027' not in env
         assert env.get('PATH') == '/usr/bin'

--- a/tests/workflow/test_wf_external_config_override.py
+++ b/tests/workflow/test_wf_external_config_override.py
@@ -80,11 +80,12 @@ class TestProfileRouterBlocksNonDefaultUnderOverride:
         assert detail['profile_id'] == 'deepseek'
         assert 'ANTHROPIC_BASE_URL' in detail['overriding_keys']
         assert detail['settings_path'].endswith('settings.json')
-        # The copy-paste cleanup command is rendered by the backend
-        # because it parameterises over the actual overriding keys.
+        # The copy-paste cleanup command iterates by ``ANTHROPIC_*``
+        # prefix so it works for any current or future key without
+        # shell-escaping the names. Verify the prefix-iteration form,
+        # not specific names.
         assert 'python3 -c' in detail['clear_command']
-        for key in detail['overriding_keys']:
-            assert key in detail['clear_command']
+        assert "startswith('ANTHROPIC_')" in detail['clear_command']
         # The English ``message`` field is kept as a fallback for
         # non-i18n consumers (logs, task.error).
         assert isinstance(detail['message'], str) and detail['message']


### PR DESCRIPTION
## Summary

Two fixes:

1. **pnpm-workspace.yaml `packages:` field** — pnpm 11 refuses an empty packages list, breaking the release pipeline. Add `packages: [.]` so the single-package workspace is accepted while keeping `allowBuilds` (esbuild / core-js / protobufjs) where it is.

2. **cc-switch override guard hardening** — round of review fixes on the `ExternalConfigOverrideError` flow that lands the structured failure-card payload, removes a shell-quoting footgun, and de-duplicates the persist-and-emit path:
   - `_clear_command()` now drops *all* `ANTHROPIC_*` keys by prefix iteration instead of interpolating the names into the python3 -c snippet. The interpolated form had two real footguns — a single-key list collapsed to a string-not-tuple, and a double-quoted JSON literal embedded inside the outer python3 -c double-quoted shell arg broke escaping. Prefix iteration sidesteps both, and also cleans up any future `ANTHROPIC_*` key we don't yet know about.
   - Extract `_fail_task_external_config_override` so the execute and woken paths share one persist-and-emit helper. Both now persist the structured JSON detail in `task.error` and set `error_category='external_config_override'`, so the frontend's `ExternalConfigOverrideErrorCard` renders the localized template rather than the generic failure card.
   - Handle the override case inline in `tasks_conversation._spawn_followup_agent` so the generic `except Exception` doesn't log a noisy stack trace for an expected user-visible state.
   - `docs/subsystems.md`: drop stale `(currently 2)` next to `SOFT_GATE_MAX_DENIALS`; point readers at the module constant.
   - Tests: clean up the override-config suite (subprocess import at module scope, drop the `_ECOE` alias and noqa, use `repr(str(path))` for safe path encoding, and rewrite the run-the-cleanup-command tests around prefix iteration — single key, multiple keys, future unknown key).
   - Drop dead `finally: pass` on `execute_woken_task` — pre-existing but had to come out to bring the file back under the 800-line cap that the helper extraction pushed up against.

## Test plan

- [x] `pytest -m unit` (675 passed, 1 skipped)
- [x] `pytest tests/unit/test_external_config.py tests/workflow/test_wf_external_config_override.py` (25 passed)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)