### PR TITLE
refresh AI profile presets + restore install.sh runtime deps + UI default-to-first-store

### DIFF
--- a/app/ai/profiles.py
+++ b/app/ai/profiles.py
@@ -84,24 +84,38 @@ PROVIDER_PRESETS = {
             'ANTHROPIC_DEFAULT_HAIKU_MODEL': 'glm-4.5-air',
         },
     },
+    # Env keys per DeepSeek's official integration doc:
+    # https://api-docs.deepseek.com/zh-cn/quick_start/agent_integrations/claude_code
+    # The ``[1m]`` suffix on the pro model picks the 1M-context variant
+    # (docs render the suffix literally in both EN and CN examples).
     'deepseek': {
         'name': 'DeepSeek',
-        'description': 'DeepSeek V4 Pro via DeepSeek API',
+        'description': 'DeepSeek V4 Pro (1M context) via DeepSeek API',
         'load_global_mcp': False,
         'env': {
             'ANTHROPIC_BASE_URL': 'https://api.deepseek.com/anthropic',
             'API_TIMEOUT_MS': '3000000',
             'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC': '1',
-            'ANTHROPIC_MODEL': 'deepseek-v4-pro',
-            'ANTHROPIC_SMALL_FAST_MODEL': 'deepseek-v4-pro',
-            'ANTHROPIC_DEFAULT_SONNET_MODEL': 'deepseek-v4-pro',
-            'ANTHROPIC_DEFAULT_OPUS_MODEL': 'deepseek-v4-pro',
-            'ANTHROPIC_DEFAULT_HAIKU_MODEL': 'deepseek-v4-pro',
+            'ANTHROPIC_MODEL': 'deepseek-v4-pro[1m]',
+            'ANTHROPIC_SMALL_FAST_MODEL': 'deepseek-v4-flash',
+            'ANTHROPIC_DEFAULT_SONNET_MODEL': 'deepseek-v4-pro[1m]',
+            'ANTHROPIC_DEFAULT_OPUS_MODEL': 'deepseek-v4-pro[1m]',
+            'ANTHROPIC_DEFAULT_HAIKU_MODEL': 'deepseek-v4-flash',
+            'CLAUDE_CODE_SUBAGENT_MODEL': 'deepseek-v4-flash',
+            'CLAUDE_CODE_EFFORT_LEVEL': 'max',
         },
     },
+    # Alibaba Cloud / DashScope has two separate Anthropic endpoints —
+    # pay-as-you-go and Coding Plan — with DIFFERENT base URLs and
+    # different recommended models. Keep them as two presets so the
+    # UI can offer the right one based on the user's subscription.
+    # https://help.aliyun.com/zh/model-studio/claude-code
+    # https://help.aliyun.com/zh/model-studio/claude-code-coding-plan
     'qwen': {
-        'name': 'Qwen',
-        'description': 'Qwen3-Max via Alibaba Cloud Bailian',
+        'name': 'Qwen (Pay-as-you-go)',
+        'description': (
+            'Qwen3.7-Max via Alibaba Cloud DashScope, pay-as-you-go billing'
+        ),
         'load_global_mcp': False,
         'env': {
             'ANTHROPIC_BASE_URL': (
@@ -109,11 +123,32 @@ PROVIDER_PRESETS = {
             ),
             'API_TIMEOUT_MS': '3000000',
             'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC': '1',
-            'ANTHROPIC_MODEL': 'qwen3-max',
-            'ANTHROPIC_SMALL_FAST_MODEL': 'qwen3-max',
-            'ANTHROPIC_DEFAULT_SONNET_MODEL': 'qwen3-max',
-            'ANTHROPIC_DEFAULT_OPUS_MODEL': 'qwen3-max',
-            'ANTHROPIC_DEFAULT_HAIKU_MODEL': 'qwen3-max',
+            'ANTHROPIC_MODEL': 'qwen3.7-max',
+            'ANTHROPIC_SMALL_FAST_MODEL': 'qwen3.6-flash',
+            'ANTHROPIC_DEFAULT_SONNET_MODEL': 'qwen3.7-max',
+            'ANTHROPIC_DEFAULT_OPUS_MODEL': 'qwen3.7-max',
+            'ANTHROPIC_DEFAULT_HAIKU_MODEL': 'qwen3.6-flash',
+        },
+    },
+    'qwen_coding': {
+        'name': 'Qwen (Coding Plan)',
+        'description': (
+            'Qwen3.6-Plus via Alibaba Cloud DashScope Coding Plan '
+            '(monthly subscription)'
+        ),
+        'load_global_mcp': False,
+        'env': {
+            'ANTHROPIC_BASE_URL': (
+                'https://coding.dashscope.aliyuncs.com/apps/anthropic'
+            ),
+            'API_TIMEOUT_MS': '3000000',
+            'CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC': '1',
+            'ANTHROPIC_MODEL': 'qwen3.6-plus',
+            'ANTHROPIC_SMALL_FAST_MODEL': 'qwen3.6-plus',
+            'ANTHROPIC_DEFAULT_SONNET_MODEL': 'qwen3.6-plus',
+            'ANTHROPIC_DEFAULT_OPUS_MODEL': 'qwen3.6-plus',
+            'ANTHROPIC_DEFAULT_HAIKU_MODEL': 'qwen3.6-plus',
+            'CLAUDE_CODE_SUBAGENT_MODEL': 'qwen3.6-plus',
         },
     },
 }
@@ -223,7 +258,8 @@ def profile_kind(profile: dict | None) -> str:
     """Return a privacy-safe enum identifying which provider a profile uses.
 
     Matches the profile's ANTHROPIC_BASE_URL against PROVIDER_PRESETS
-    to get one of: kimi/minimax/glm/glm_intl/deepseek/qwen/default/custom.
+    to get one of: kimi/minimax/glm/glm_intl/deepseek/qwen/qwen_coding/
+    default/custom.
     Used by telemetry; never sends the env itself.
     """
     if not profile:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -182,19 +182,17 @@ export default function App() {
 
   const debugInitialized = useRef(false)
   useEffect(() => { if (!debugInitialized.current) { debugInitialized.current = true; return } if (currentUser) api.patch('/api/auth/me/debug-mode', { debug_mode: debugMode }).catch(() => {}) }, [debugMode])
+  // Login default: first store else all-stores. Refs guard against a click landing during in-flight loadStores.
+  const selRef = useRef(selectedStore), allRef = useRef(showAllTasks); selRef.current = selectedStore; allRef.current = showAllTasks
   useEffect(() => {
-    if (currentUser) {
-      loadStores(); loadZiniaoAccounts(); loadProfiles()
-      // Default: load all-stores view on login
-      if (!selectedStore && showAllTasks) {
-        api.get('/api/tasks?store_id=__none__').then(setTasks).catch(() => {})
-        loadSchedules()
-      }
-    }
+    if (!currentUser) return
+    loadZiniaoAccounts(); loadProfiles()
+    loadStores().then(f => { if (selRef.current || !allRef.current) return; if (f?.length) selectStore(f[0]); else selectAllTasks() })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentUser])
 
   // ─── Data loaders ──────────────────────────────────
-  const loadStores = async () => { setStores(await api.get('/api/stores')) }
+  const loadStores = async (): Promise<Store[]> => { const f: Store[] = await api.get('/api/stores'); setStores(f); return f }
   const loadZiniaoAccounts = async () => { try { setZiniaoAccounts(await api.get('/api/ziniao-accounts')) } catch { /* ignore */ } }
   const loadProfiles = async () => { try { const data = await api.get('/api/profiles'); setProfiles(data.profiles || []) } catch { setProfiles([]) } }
   const loadUsers = async () => { try { setAllUsers(await api.get('/api/users')) } catch { /* ignore */ } }
@@ -591,7 +589,9 @@ export default function App() {
 
   // ─── Auth helpers ──────────────────────────────────
   const handleLogin = async () => { setLoginError(''); try { const r = await fetch('/api/auth/login', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ identifier: loginIdentifier, password: loginPassword }), credentials: 'include' }); if (!r.ok) { setLoginError(t('auth.invalidCredentials')); return }; const u = await r.json(); setCurrentUser(u); if (u.default_profile_id) setSelectedProfileId(u.default_profile_id); setDebugMode(u.debug_mode ?? false); setLoginIdentifier(''); setLoginPassword('') } catch { setLoginError(t('auth.invalidCredentials')) } }
-  const handleLogout = async () => { await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' }); setCurrentUser(null); setAppView('tasks') }
+  // Reset session-scoped selection on logout so next login re-enters
+  // the default-selection branch (else a stale selectedStore skips it).
+  const handleLogout = async () => { await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' }); setCurrentUser(null); setSelectedStore(null); setShowAllTasks(true); setSelectedTask(null); setSelectedSchedule(null); setAppView('tasks') }
 
   // ─── Settings helpers ──────────────────────────────
   const createUser = async () => { if (!newUserForm.username.trim() || !newUserForm.password.trim()) return; try { await api.post('/api/users', { ...newUserForm, email: newUserForm.email.trim() || undefined }); setNewUserForm({ username: '', email: '', password: '', role: 'member' }); setShowAddUser(false); await loadUsers() } catch { /* ignore */ } }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -171,13 +171,6 @@ export function Sidebar(props: SidebarProps) {
             />
           )}
           <div className="flex-1 overflow-y-auto">
-            <button
-              onClick={() => { sendEvent(FrontendEvent.STORE_SWITCHED, { is_all_stores: true }); selectAllTasks() }}
-              className={`w-full text-left px-4 py-3 hover:bg-gray-50 border-b border-gray-100 ${showAllTasks ? 'bg-purple-50 border-l-4 border-l-purple-600' : ''}`}
-            >
-              <div className="font-medium text-sm">{t('tasks.allStores')}</div>
-              <div className="text-xs text-gray-500">{t('tasks.noStore')}</div>
-            </button>
             {stores.map(store => (
               <button
                 key={store.id}
@@ -191,6 +184,13 @@ export function Sidebar(props: SidebarProps) {
             {stores.length === 0 && (
               <div className="p-4 text-sm text-gray-400 text-center">{t('navigation.stores')}</div>
             )}
+            <button
+              onClick={() => { sendEvent(FrontendEvent.STORE_SWITCHED, { is_all_stores: true }); selectAllTasks() }}
+              className={`w-full text-left px-4 py-3 hover:bg-gray-50 border-b border-gray-100 ${showAllTasks ? 'bg-purple-50 border-l-4 border-l-purple-600' : ''}`}
+            >
+              <div className="font-medium text-sm">{t('tasks.allStores')}</div>
+              <div className="text-xs text-gray-500">{t('tasks.noStore')}</div>
+            </button>
           </div>
         </>
       ) : appView === 'workspace' ? (

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -63,6 +63,7 @@
     "noStore": "No Store",
     "filterByStore": "Filter by store",
     "allStores": "All Stores",
+    "allStoresHint": "This is the cross-store task list — these tasks can't open a specific store's browser. Best for jobs like reading email or sending WeCom messages. To use a store's backend, click the store on the left first, then create a task.",
     "noStoreTasks": "No Store Tasks",
     "browser": "Browser",
     "browserBackend": "Browser Backend",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -63,6 +63,7 @@
     "noStore": "无店铺",
     "filterByStore": "按店铺筛选",
     "allStores": "全部店铺",
+    "allStoresHint": "当前为通用任务列表，无法进入具体店铺的浏览器，适合执行读取邮件、发送企微消息等任务。如果需要进入店铺后台，请先点击左侧店铺再创建任务。",
     "noStoreTasks": "无店铺任务",
     "browser": "浏览器",
     "browserBackend": "浏览器后端",

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -291,6 +291,11 @@ export function TasksView({
                 </button>
               </div>
             </div>
+            {showAllTasks && taskSubTab === 'onetime' && (
+              <div className="px-3 py-2 bg-amber-50 border-b border-amber-200 text-[11px] leading-snug text-amber-900">
+                {t('tasks.allStoresHint')}
+              </div>
+            )}
             <div className="flex-1 overflow-y-auto">
               {taskSubTab === 'onetime' ? (
                 <>

--- a/install.sh
+++ b/install.sh
@@ -588,6 +588,32 @@ _install_via_pip() {
         require_sudo
     fi
 
+    # Runtime deps the daemon's agents need but the wheel can't ship:
+    # claude CLI (the AI backend's subprocess), sqlite3 (agents query
+    # per-account email DBs via `sqlite3 <path>`), node (claude CLI is
+    # an npm package), lsof (vibe-seller stop). Without these,
+    # `vibe-seller start` succeeds but the first agent task fails
+    # with FileNotFoundError. --dev mode installs them via main()'s
+    # DEPS loop; the default mode `exit 0`s before reaching that loop,
+    # so the deps have to be installed here explicitly. This block
+    # was dropped in an install.sh refactor that introduced a
+    # half-working default install, observed as a CI verify-testpypi
+    # failure on v0.0.6 (FileNotFoundError on `claude` spawn).
+    if ! check_lsof; then
+        install_lsof
+    fi
+    if ! check_sqlite3; then
+        install_sqlite3
+    fi
+    if ! check_node; then
+        install_node
+    fi
+    fix_npm_permissions
+    if ! check_claude; then
+        install_claude \
+            || _warn "claude CLI install failed — AI agent features will not work"
+    fi
+
     # Compose `uv tool install` args from --test-pypi / --version.
     # TestPyPI only hosts our project — pull dependencies (FastAPI,
     # uvicorn, etc.) from real PyPI via --extra-index-url so the

--- a/install.sh
+++ b/install.sh
@@ -554,12 +554,18 @@ install_claude() {
         _warn "npm not available — skipping claude CLI install"
         return 1
     fi
-    # npm global prefix is user-writable after fix_npm_permissions
-    npm install -g @anthropic-ai/claude-code || {
+    # Pin to 2.1.153 — the last release before Claude Code started
+    # emitting messages[N].role="system" entries that strict
+    # Anthropic-compatible endpoints (DeepSeek, etc.) reject with
+    # HTTP 400 "invalid message role: system". 2.1.154+ break the
+    # whole DeepSeek integration; bump this pin only after the
+    # upstream regression is resolved and re-verified end-to-end.
+    # npm global prefix is user-writable after fix_npm_permissions.
+    npm install -g @anthropic-ai/claude-code@2.1.153 || {
         _warn "Claude CLI install failed (non-fatal)"
         return 1
     }
-    _success "claude CLI installed"
+    _success "claude CLI installed (pinned 2.1.153)"
 }
 
 # ============================================================

--- a/tests/workflow/test_wf_profiles.py
+++ b/tests/workflow/test_wf_profiles.py
@@ -98,10 +98,60 @@ class TestProfileCrud:
             'glm_intl',
             'deepseek',
             'qwen',
+            'qwen_coding',
         ):
             assert name in presets
             assert 'name' in presets[name]
             assert 'env' in presets[name]
+
+    async def test_presets_match_vendor_docs(self, admin_client):
+        """Pin the load-bearing values for the vendor-doc-aligned
+        presets so a typo or accidental revert is caught by CI rather
+        than only surfacing on a real agent run. Asserts:
+
+        - DeepSeek: ``[1m]`` suffix on opus/sonnet (1M-context variant),
+          ``deepseek-v4-flash`` for haiku/small-fast/subagent, and the
+          new ``CLAUDE_CODE_EFFORT_LEVEL=max`` flag.
+        - Qwen split: pay-as-you-go vs Coding Plan have DIFFERENT
+          base URLs and DIFFERENT model name tiers.
+        """
+        r = await admin_client.get('/api/profiles/presets')
+        presets = r.json()['presets']
+
+        ds = presets['deepseek']['env']
+        assert ds['ANTHROPIC_BASE_URL'] == (
+            'https://api.deepseek.com/anthropic'
+        )
+        assert ds['ANTHROPIC_MODEL'] == 'deepseek-v4-pro[1m]'
+        assert ds['ANTHROPIC_DEFAULT_OPUS_MODEL'] == 'deepseek-v4-pro[1m]'
+        assert ds['ANTHROPIC_DEFAULT_SONNET_MODEL'] == 'deepseek-v4-pro[1m]'
+        assert ds['ANTHROPIC_DEFAULT_HAIKU_MODEL'] == 'deepseek-v4-flash'
+        assert ds['ANTHROPIC_SMALL_FAST_MODEL'] == 'deepseek-v4-flash'
+        assert ds['CLAUDE_CODE_SUBAGENT_MODEL'] == 'deepseek-v4-flash'
+        assert ds['CLAUDE_CODE_EFFORT_LEVEL'] == 'max'
+
+        qwen = presets['qwen']['env']
+        assert qwen['ANTHROPIC_BASE_URL'] == (
+            'https://dashscope.aliyuncs.com/apps/anthropic'
+        )
+        assert qwen['ANTHROPIC_MODEL'] == 'qwen3.7-max'
+        assert qwen['ANTHROPIC_DEFAULT_HAIKU_MODEL'] == 'qwen3.6-flash'
+        assert qwen['ANTHROPIC_SMALL_FAST_MODEL'] == 'qwen3.6-flash'
+
+        qwen_cp = presets['qwen_coding']['env']
+        assert qwen_cp['ANTHROPIC_BASE_URL'] == (
+            'https://coding.dashscope.aliyuncs.com/apps/anthropic'
+        )
+        # Coding Plan uses one model uniformly across tiers + subagent
+        assert qwen_cp['ANTHROPIC_MODEL'] == 'qwen3.6-plus'
+        assert qwen_cp['ANTHROPIC_DEFAULT_OPUS_MODEL'] == 'qwen3.6-plus'
+        assert qwen_cp['ANTHROPIC_DEFAULT_SONNET_MODEL'] == 'qwen3.6-plus'
+        assert qwen_cp['ANTHROPIC_DEFAULT_HAIKU_MODEL'] == 'qwen3.6-plus'
+        assert qwen_cp['CLAUDE_CODE_SUBAGENT_MODEL'] == 'qwen3.6-plus'
+
+        # The two qwen tiers MUST diverge on base URL — collapsing them
+        # back into one preset is what this PR's split was undoing.
+        assert qwen['ANTHROPIC_BASE_URL'] != qwen_cp['ANTHROPIC_BASE_URL']
 
     async def test_profile_env_injection_roundtrip(self, admin_client):
         env = {


### PR DESCRIPTION
## Summary

Three bundled improvements.

### AI profile presets (`app/ai/profiles.py`)

**DeepSeek** — aligned to [DeepSeek's official Claude Code integration doc](https://api-docs.deepseek.com/zh-cn/quick_start/agent_integrations/claude_code):

- `ANTHROPIC_MODEL` / Opus / Sonnet: `deepseek-v4-pro` → `deepseek-v4-pro[1m]` (1M-context variant — the bracketed suffix is the literal model id; both EN and CN docs render it that way in shell + PowerShell examples).
- `ANTHROPIC_SMALL_FAST_MODEL` / Haiku / `CLAUDE_CODE_SUBAGENT_MODEL`: `deepseek-v4-pro` → `deepseek-v4-flash`. The previous preset uniformly used `v4-pro` for the small-fast / haiku / subagent tiers — wasted capacity and not what the docs recommend.
- Added `CLAUDE_CODE_EFFORT_LEVEL=max` per the same doc.

**Qwen — split into two presets** because Alibaba Cloud / DashScope exposes two distinct Anthropic-compatible endpoints with different base URLs depending on billing model:

- `qwen` (Pay-as-you-go) — keeps the existing preset id so stored profiles using `{'kind': 'qwen'}` continue to resolve. Base URL `https://dashscope.aliyuncs.com/apps/anthropic`, models split across `qwen3.7-max` (opus/sonnet/main) and `qwen3.6-flash` (haiku/small-fast). Source: [Alibaba Cloud Model Studio — Claude Code](https://help.aliyun.com/zh/model-studio/claude-code).
- `qwen_coding` (Coding Plan) **— new** — Base URL `https://coding.dashscope.aliyuncs.com/apps/anthropic`, `qwen3.6-plus` uniformly across all tiers + `CLAUDE_CODE_SUBAGENT_MODEL`. Source: [Coding Plan — Alibaba Cloud Model Studio](https://help.aliyun.com/zh/model-studio/claude-code-coding-plan).

Test suite (`tests/workflow/test_wf_profiles.py`) gained value-pinning assertions so a typo or accidental revert is caught by CI, not just on real agent runs.

### `install.sh` — restore runtime deps in `_install_via_pip`

A prior install.sh refactor moved the runtime-deps install loop out of `_install_via_pip`, leaving the default end-user install path without `claude` / `sqlite3` / `node` / `lsof`. `vibe-seller start` still succeeds, but the first agent task crashes:

```
FileNotFoundError: [Errno 2] No such file or directory
  at asyncio.create_subprocess_exec(...)  # spawn `claude`
```

This was the v0.0.6 `verify-testpypi` CI failure — the verify stage runs `./install.sh --test-pypi --version <ver>` then drives one real agent task against the freshly-installed daemon, the exact scenario above. End-users running plain `./install.sh` on a fresh machine hit the same bug — CI just made it loud.

Restored the deps block in `_install_via_pip` with a comment naming the regression so future refactors don't re-drop it. `install.sh` is the source of truth for installation; CI's verify stage is just exercising the same path an end user would.

### UI — default-select first store on login + cross-store hint banner

The sidebar used to lead with `全部店铺 / All stores`, but day-to-day the user is always working inside a specific store. Three changes:

- **Sidebar.tsx** — per-store buttons render first; "All stores" sits at the bottom as the explicit global lens.
- **App.tsx** — on login, after `loadStores()` resolves, default-select `stores[0]` if any exist; fall back to the all-stores lens only when no stores are configured. Refs guard the `.then()` so a user click landing during the in-flight load is not silently overwritten (an e2e race the first version hit). `handleLogout` resets session-scoped selection so the next login re-enters the default-selection branch cleanly.
- **TasksView.tsx + i18n** — when the all-stores lens is active (and only on the one-time tab — scheduled tasks support all-stores fan-out), show an amber hint banner explaining the capability difference. EN + ZH both translated.

## Test plan

- [x] `pytest tests/workflow/test_wf_profiles.py` (12 passed)
- [x] `pnpm run build` (frontend builds cleanly)
- [x] `pnpm test --run` (321/321 passed)
- [x] `pnpm run lint` (no new warnings or errors)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)