### PR TITLE
refactor(plugins): remove lazy imports + the one real import cycle

### DIFF
--- a/app/ai/bash_safety.py
+++ b/app/ai/bash_safety.py
@@ -23,6 +23,11 @@ would be bad.
 from pathlib import Path
 import re
 
+from app.plugins import (
+    registered_pretool_gates,
+    registered_review_markers,
+)
+
 # Match `pkill`/`killall` only in *command position* — not as an
 # argument (``grep pkill file``) or inside a string (``echo "pkill -f
 # x"``). Command position = start of input, after a shell separator
@@ -428,7 +433,6 @@ def _is_server_reviewed(audit_text: str) -> bool:
     """
     if _SERVER_REVIEWED_RE.search(audit_text):
         return True
-    from app.plugins import registered_review_markers  # noqa: PLC0415
 
     for pattern in registered_review_markers():
         try:
@@ -768,7 +772,6 @@ def first_bash_deny(command, task_dir=None, catalog_read=False):
     ``check(command, task_dir, catalog_read)`` so the chain stays one
     testable unit regardless of which args a guard actually uses.
     """
-    from app.plugins import registered_pretool_gates  # noqa: PLC0415
 
     for label, check in registered_pretool_gates():
         reason = check(command, task_dir, catalog_read)

--- a/app/ai/claude_backend_hooks.py
+++ b/app/ai/claude_backend_hooks.py
@@ -25,11 +25,10 @@ from app.ai.claude_backend_utils import (
     check_exec_review_status_for_stop,
     check_review_status_for_stop,
     check_skill_prereqs,
-    find_skill_md,
     get_open_tasklist_items,
-    skill_name_from_read,
     validate_fanout_plan_text,
 )
+from app.ai.skill_gate_utils import find_skill_md, skill_name_from_read
 from app.ai.stop_gates import record_skill_load
 from app.database import async_session
 from app.events.bus import event_bus

--- a/app/ai/claude_backend_utils.py
+++ b/app/ai/claude_backend_utils.py
@@ -12,6 +12,7 @@ from app.ai.bash_safety import (
     check_exec_review_status,
     check_review_status,
 )
+from app.ai.skill_gate_utils import find_skill_md
 from app.database import async_session
 from app.env_options import Options
 from app.models.schedule import Schedule
@@ -152,78 +153,6 @@ def parse_skill_requires(skill_md_path: Path) -> list[str]:
         for item in m.group(1).split(',')
         if item.strip()
     ]
-
-
-_GATES_RE = re.compile(r'^gates:\s*\[([^\]]*)\]\s*$', re.MULTILINE)
-
-
-def parse_skill_gates(skill_md_path: Path) -> list[str]:
-    """Return the exit-gate names this SKILL.md declares.
-
-    Reads YAML frontmatter, looks for ``gates: [a, b]`` (same
-    inline-list format as ``requires:``). Returns ``[]`` if the file
-    is missing, has no frontmatter, or declares no gates. Resolved
-    against ``stop_gates.get_registered_gates`` at submit time — the
-    skill names WHICH reviewers apply to its outputs; the reviewers
-    themselves stay server-side code.
-    """
-    if not skill_md_path.is_file():
-        return []
-    try:
-        text = skill_md_path.read_text(encoding='utf-8')
-    except OSError:
-        return []
-    if not text.startswith('---\n'):
-        return []
-    end = text.find('\n---\n', 4)
-    if end == -1:
-        return []
-    m = _GATES_RE.search(text[: end + 5])
-    if not m:
-        return []
-    return [
-        item.strip().strip('"\'')
-        for item in m.group(1).split(',')
-        if item.strip()
-    ]
-
-
-_SKILL_MD_READ_RE = re.compile(r'(?:^|/)skills/([^/]+)/SKILL\.md$')
-
-
-def skill_name_from_read(tool_name: str, tool_input: dict) -> str | None:
-    """Return the skill name if this tool call Reads a SKILL.md.
-
-    Agents load skills two ways: the ``Skill`` tool (already tracked
-    into ``_loaded_skills`` by the prereq hook) and a plain ``Read``
-    of ``.claude/skills/<name>/SKILL.md`` (the catalog-driven path).
-    Skill-declared exit gates must see both, or a skill loaded via
-    Read would silently skip its own reviewers.
-    """
-    if tool_name != 'Read':
-        return None
-    path = tool_input.get('file_path', '')
-    if not isinstance(path, str) or not path:
-        return None
-    m = _SKILL_MD_READ_RE.search(path)
-    return m.group(1) if m else None
-
-
-def find_skill_md(workspace_dir: Path, skill_name: str) -> Path | None:
-    """Locate ``{workspace}/.claude/skills/{skill_name}/SKILL.md``.
-
-    Falls back to ``~/.vibe-seller/.claude/skills/`` if the per-task
-    workspace copy is missing (e.g. a CLI-builtin skill we don't ship).
-    Returns None if neither exists.
-    """
-    candidates = [
-        workspace_dir / '.claude' / 'skills' / skill_name / 'SKILL.md',
-        VIBE_SELLER_DIR / '.claude' / 'skills' / skill_name / 'SKILL.md',
-    ]
-    for p in candidates:
-        if p.is_file():
-            return p
-    return None
 
 
 def check_skill_prereqs(

--- a/app/ai/skill_gate_utils.py
+++ b/app/ai/skill_gate_utils.py
@@ -1,0 +1,86 @@
+"""Pure skill-gate helpers — a leaf module (stdlib + app.config only).
+
+Extracted from ``claude_backend_utils`` so the exit-gate machinery
+(``stop_gates``) can resolve a skill's declared gates and locate its
+SKILL.md WITHOUT importing ``claude_backend_utils`` (which pulls in
+bash_safety, the DB, models and the workspace manager). That import edge
+was the one real cycle in the plugin/gate wiring; keeping these three
+pure functions in a leaf breaks it by design rather than with a lazy
+import.
+"""
+
+from pathlib import Path
+import re
+
+from app.config import VIBE_SELLER_DIR
+
+_GATES_RE = re.compile(r'^gates:\s*\[([^\]]*)\]\s*$', re.MULTILINE)
+
+
+def parse_skill_gates(skill_md_path: Path) -> list[str]:
+    """Return the exit-gate names this SKILL.md declares.
+
+    Reads YAML frontmatter, looks for ``gates: [a, b]`` (same
+    inline-list format as ``requires:``). Returns ``[]`` if the file
+    is missing, has no frontmatter, or declares no gates. Resolved
+    against ``stop_gates.get_registered_gates`` at submit time — the
+    skill names WHICH reviewers apply to its outputs; the reviewers
+    themselves stay server-side code.
+    """
+    if not skill_md_path.is_file():
+        return []
+    try:
+        text = skill_md_path.read_text(encoding='utf-8')
+    except OSError:
+        return []
+    if not text.startswith('---\n'):
+        return []
+    end = text.find('\n---\n', 4)
+    if end == -1:
+        return []
+    m = _GATES_RE.search(text[: end + 5])
+    if not m:
+        return []
+    return [
+        item.strip().strip('"\'')
+        for item in m.group(1).split(',')
+        if item.strip()
+    ]
+
+
+_SKILL_MD_READ_RE = re.compile(r'(?:^|/)skills/([^/]+)/SKILL\.md$')
+
+
+def skill_name_from_read(tool_name: str, tool_input: dict) -> str | None:
+    """Return the skill name if this tool call Reads a SKILL.md.
+
+    Agents load skills two ways: the ``Skill`` tool (already tracked
+    into ``_loaded_skills`` by the prereq hook) and a plain ``Read``
+    of ``.claude/skills/<name>/SKILL.md`` (the catalog-driven path).
+    Skill-declared exit gates must see both, or a skill loaded via
+    Read would silently skip its own reviewers.
+    """
+    if tool_name != 'Read':
+        return None
+    path = tool_input.get('file_path', '')
+    if not isinstance(path, str) or not path:
+        return None
+    m = _SKILL_MD_READ_RE.search(path)
+    return m.group(1) if m else None
+
+
+def find_skill_md(workspace_dir: Path, skill_name: str) -> Path | None:
+    """Locate ``{workspace}/.claude/skills/{skill_name}/SKILL.md``.
+
+    Falls back to ``~/.vibe-seller/.claude/skills/`` if the per-task
+    workspace copy is missing (e.g. a CLI-builtin skill we don't ship).
+    Returns None if neither exists.
+    """
+    candidates = [
+        workspace_dir / '.claude' / 'skills' / skill_name / 'SKILL.md',
+        VIBE_SELLER_DIR / '.claude' / 'skills' / skill_name / 'SKILL.md',
+    ]
+    for p in candidates:
+        if p.is_file():
+            return p
+    return None

--- a/app/ai/stop_gates/__init__.py
+++ b/app/ai/stop_gates/__init__.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 import re
 
+from app.ai.skill_gate_utils import find_skill_md, parse_skill_gates
 from app.config import DATA_DIR
+from app.plugins import registered_gates
 
 # Module-level attempt counter, keyed by (task_id, gate_name). Lost
 # on server restart, which is fine — the agent session would also be
@@ -148,12 +150,8 @@ def get_registered_gates() -> dict[str, object]:
     :mod:`app.plugins` registry (OSS gates via the builtin plugin;
     any customer gates via their own externally-installed plugin wheels) — core no longer
     hardcodes the gate list, so excising a customer is "don't install
-    its wheel", not "edit this dict". Read lazily to avoid a circular
-    import (gate modules import :class:`GateDeny` from this package, and
-    the builtin plugin imports those modules).
+    its wheel", not "edit this dict".
     """
-    from app.plugins import registered_gates  # noqa: PLC0415 — cycle
-
     return registered_gates()
 
 
@@ -169,10 +167,6 @@ def resolve_skill_gates(
     (a skill must not be able to break submits by typo). Order is
     deterministic (sorted by gate name) and duplicates collapse.
     """
-    from app.ai.claude_backend_utils import (  # noqa: PLC0415 — cycle
-        find_skill_md,
-        parse_skill_gates,
-    )
 
     registry = get_registered_gates()
     resolved: dict[str, object] = {}

--- a/app/browser/manager.py
+++ b/app/browser/manager.py
@@ -29,6 +29,7 @@ from app.models.app_settings import AppSettings
 from app.models.browser_session import BrowserSession
 from app.models.store import Store
 from app.models.ziniao_account import ZiniaoAccount
+from app.plugins import registered_browser_backends
 from app.utils.crypto import decrypt_password
 from app.workspace.manager import VIBE_SELLER_DIR
 
@@ -260,10 +261,6 @@ class BrowserManager:
         multiplexing and shared cookie context.
         """
         if store_id not in self._backends:
-            from app.plugins import (  # noqa: PLC0415 — avoid import cycle
-                registered_browser_backends,
-            )
-
             backends = registered_browser_backends()
             cls = backends.get(backend_type)
             if cls is None:

--- a/app/builtin_plugin.py
+++ b/app/builtin_plugin.py
@@ -14,6 +14,22 @@ never from here.
 
 from __future__ import annotations
 
+from app.ai.bash_safety import (
+    check_bid_value_shape,
+    check_catalog_first,
+    check_dangerous_kill,
+    check_report_script_write,
+)
+from app.ai.stop_gates import (
+    ad_completeness_review,
+    ad_execution_fidelity,
+    ad_negation_allowlist,
+    review_completeness_review,
+    review_output_gate,
+)
+from app.browser.chrome import ChromeBackend
+from app.browser.winchrome import WinChromeBackend
+from app.browser.ziniao import ZiniaoBackend
 from app.plugins import ExtensionContext, Plugin
 
 
@@ -36,17 +52,6 @@ class BuiltinPlugin(Plugin):
 
     @staticmethod
     def _install_gates(ctx: ExtensionContext) -> None:
-        # Imported lazily so importing this module never drags in the
-        # whole gate graph (and to mirror the old lazy import that broke
-        # the GateDeny circular import).
-        from app.ai.stop_gates import (  # noqa: PLC0415
-            ad_completeness_review,
-            ad_execution_fidelity,
-            ad_negation_allowlist,
-            review_completeness_review,
-            review_output_gate,
-        )
-
         ctx.register_gate('ad_completeness_review', ad_completeness_review)
         ctx.register_gate('ad_negation_allowlist', ad_negation_allowlist)
         ctx.register_gate('ad_execution_fidelity', ad_execution_fidelity)
@@ -57,13 +62,6 @@ class BuiltinPlugin(Plugin):
 
     @staticmethod
     def _install_pretool_gates(ctx: ExtensionContext) -> None:
-        from app.ai.bash_safety import (  # noqa: PLC0415
-            check_bid_value_shape,
-            check_catalog_first,
-            check_dangerous_kill,
-            check_report_script_write,
-        )
-
         # Order matches the historical first_bash_deny chain:
         # kill → bid value → report-script → catalog-first.
         ctx.register_pretool_gate(
@@ -89,10 +87,6 @@ class BuiltinPlugin(Plugin):
 
     @staticmethod
     def _install_browser_backends(ctx: ExtensionContext) -> None:
-        from app.browser.chrome import ChromeBackend  # noqa: PLC0415
-        from app.browser.winchrome import WinChromeBackend  # noqa: PLC0415
-        from app.browser.ziniao import ZiniaoBackend  # noqa: PLC0415
-
         ctx.register_browser_backend('chrome', ChromeBackend)
         ctx.register_browser_backend('winchrome', WinChromeBackend)
         ctx.register_browser_backend('ziniao', ZiniaoBackend)

--- a/app/plugins.py
+++ b/app/plugins.py
@@ -259,8 +259,6 @@ _BUILTIN_PLUGIN = 'app.builtin_plugin:BuiltinPlugin'
 
 def _load_builtin(ctx: ExtensionContext) -> str | None:
     module_path, class_name = _BUILTIN_PLUGIN.split(':')
-    import importlib  # noqa: PLC0415 — local to keep top imports light
-
     module = importlib.import_module(module_path)
     plugin_cls = getattr(module, class_name)
     if not (isinstance(plugin_cls, type) and issubclass(plugin_cls, Plugin)):

--- a/app/task_runner.py
+++ b/app/task_runner.py
@@ -16,6 +16,7 @@ from app.models.schedule_constants import StalenessCheck
 from app.models.store import Store
 from app.models.store_email_link import StoreEmailLink
 from app.models.task import Task
+from app.plugins import registered_prompt_fragments
 from app.prompts import (
     CATALOG_RESTRICTION_PROMPT_L2,
     CATALOG_RESTRICTION_PROMPT_L3,
@@ -339,7 +340,6 @@ async def build_system_extra(
 
     # Plugin extension seam: fragments registered for the 'system_extra'
     # slot are appended to the end of the assembled system prompt.
-    from app.plugins import registered_prompt_fragments  # noqa: PLC0415
 
     parts.extend(registered_prompt_fragments('system_extra'))
 

--- a/app/workspace/skills_sync.py
+++ b/app/workspace/skills_sync.py
@@ -32,6 +32,7 @@ from app.config import AI_BOT_USER_ID, SKILLS_REPO_URL
 from app.database import async_session
 from app.models.app_settings import AppSettings
 from app.models.event import Event
+from app.plugins import registered_skill_sources
 from app.workspace.manager import VIBE_SELLER_DIR
 
 logger = logging.getLogger(__name__)
@@ -131,7 +132,6 @@ class SkillsSyncManager:
         appended here. De-duped on resolved path, order preserved, so a
         plugin can't double-sync an already-listed skill dir.
         """
-        from app.plugins import registered_skill_sources  # noqa: PLC0415
 
         sources: list[Path] = []
         local = self._get_local_source()

--- a/tests/unit/test_skill_gates.py
+++ b/tests/unit/test_skill_gates.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from app.ai.claude_backend_manager import agent_backend
-from app.ai.claude_backend_utils import (
+from app.ai.skill_gate_utils import (
     parse_skill_gates,
     skill_name_from_read,
 )


### PR DESCRIPTION
Lazy function-local imports (with `# noqa: PLC0415`) were papering over circular-import fears between the plugin framework and its consumers. Fixed from design rather than suppressed.

## Why most weren't real cycles
- `app/plugins.py` is already a **leaf** — it imports no `app.*` at module top.
- `builtin_plugin` is loaded **dynamically** (`importlib.import_module`), the registry pattern that breaks the only framework↔plugin edge.

So consumers can import `from app.plugins import registered_*` at the top with no cycle.

## The one real cycle — fixed structurally
`stop_gates` needed three pure helpers (`parse_skill_gates`, `skill_name_from_read`, `find_skill_md`) that lived in the **heavy** `claude_backend_utils` (which imports `bash_safety`, the DB, models, the workspace manager) → importing them dragged the whole chain → cycle. **Extracted them into a new leaf `app/ai/skill_gate_utils.py`** (stdlib + `app.config` only); both `stop_gates` and `claude_backend_utils` now import the leaf.

## Changes
- New `app/ai/skill_gate_utils.py` (leaf).
- Lifted every lazy `from app.plugins import registered_*` to top (`skills_sync`, `bash_safety`, `task_runner`, `browser/manager`, `stop_gates`); moved `builtin_plugin`'s gate/guard/backend imports to module top; dropped redundant lazy `import importlib`.
- Repointed `claude_backend_hooks` + `test_skill_gates` at the leaf.
- **13 of 14 `# noqa: PLC0415` removed.** The one kept (`cli.py` `uvicorn`) is a deliberate deferred-heavy-import (`vibe-seller stop`/`upgrade` must not drag uvicorn + FastAPI + the whole app graph onto the path) — not a cycle.

## Verification
- `import app.main` succeeds — no circular import.
- `ruff check` clean; **1079 unit tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)