### PR TITLE
ci(release): gate publish-testpypi on the Windows upgrade test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,30 @@
 name: Release to PyPI
 
-# Triggered by a `v*` tag. Six stages, fail-fast:
+# Triggered by a `v*` tag. Seven stages, fail-fast:
 #
-#   1. build              Produces TWO wheels in the same checkout:
+#   1. windows-upgrade-test  Calls windows-upgrade.yml (reusable). Proves
+#                         the native Windows in-place upgrade works
+#                         end-to-end. Gates publish-testpypi — nothing
+#                         is published anywhere, not even TestPyPI, if
+#                         the Windows upgrade path is broken.
+#   2. build              Produces TWO wheels in the same checkout:
 #                         - dist-pypi/      canonical (version from tag)
 #                         - dist-testpypi/  dev-versioned (`<tag>.devYYYYMMDDHHMMSS`)
 #                         so the TestPyPI verification stage can iterate
 #                         across runs without colliding with previous
 #                         uploads (PyPI/TestPyPI versions are immutable).
-#   2. publish-testpypi   Publish the dev-versioned wheel.
-#   3. verify-testpypi    Fresh runner: install via `install.sh --test-pypi
+#   3. publish-testpypi   Publish the dev-versioned wheel. Needs both
+#                         `build` and `windows-upgrade-test`.
+#   4. verify-testpypi    Fresh runner: install via `install.sh --test-pypi
 #                         --version <dev>`, start server, run
 #                         `tests/releases/verify_install.sh <dev>` — asserts
 #                         `vibe-seller --version` matches, /api/health is
 #                         200, and POST/GET round-trips on /api/stores +
 #                         /api/profiles. Gates the production publish.
-#   4. publish-pypi       Publish the canonical wheel.
-#   5. verify-pypi        Re-run the same smoke against PyPI (post-publish
+#   5. publish-pypi       Publish the canonical wheel.
+#   6. verify-pypi        Re-run the same smoke against PyPI (post-publish
 #                         audit; same script, different version + source).
-#   6. github-release     Draft a GitHub Release with auto-generated notes.
+#   7. github-release     Draft a GitHub Release with auto-generated notes.
 #
 # Prerequisites (one-time, per index):
 #
@@ -41,6 +47,10 @@ permissions:
   contents: read
 
 jobs:
+  windows-upgrade-test:
+    name: Windows Upgrade Test (gate)
+    uses: ./.github/workflows/windows-upgrade.yml
+
   build:
     name: Build wheels (canonical + testpypi-dev)
     runs-on: ubuntu-latest
@@ -135,7 +145,7 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI (dev-versioned)
-    needs: build
+    needs: [build, windows-upgrade-test]
     runs-on: ubuntu-latest
     environment:
       name: test-pypi

--- a/.github/workflows/windows-upgrade.yml
+++ b/.github/workflows/windows-upgrade.yml
@@ -1,15 +1,16 @@
 name: Windows Upgrade Test
 
 # Release-only: proves the native Windows in-place upgrade works
-# end-to-end. Heavy (two full installer builds), so it runs on a v* tag
-# push (release) + manual dispatch — NOT on pull requests. Kept in its
-# own workflow (no pull_request trigger) so it never shows up as a
-# skipped check on PRs. See installer/windows/README.md.
+# end-to-end. Heavy (two full installer builds), so it's called as a
+# gate from release.yml (must pass before publish-testpypi) rather
+# than triggered on pull requests — kept in its own file (no
+# pull_request trigger) so it never shows up as a skipped check on
+# PRs. `workflow_call` lets release.yml depend on it via `needs:`;
+# `workflow_dispatch` keeps ad-hoc manual runs available. See
+# installer/windows/README.md.
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- `windows-upgrade.yml` previously ran as a fully independent workflow triggered by the same `v*` tag push as `release.yml`, with no `needs:` link — a broken Windows in-place-upgrade path had zero effect on whether TestPyPI/PyPI publish or the GitHub release proceeded.
- Convert `windows-upgrade.yml` to a `workflow_call` reusable workflow (drops its own `push: tags` trigger, keeps `workflow_dispatch` for ad-hoc runs).
- Add it as a `windows-upgrade-test` job in `release.yml` and make `publish-testpypi` depend on it (`needs: [build, windows-upgrade-test]`) — nothing gets published anywhere, not even TestPyPI, until the Windows upgrade path is verified.
- Updated the stage-count comment header in `release.yml` (six → seven stages).

## Test plan
- [x] `yaml.safe_load` both changed workflow files — parse cleanly
- [ ] Push a test tag (or re-run on the next real release tag) and confirm in the Actions graph that `publish-testpypi` waits on `windows-upgrade-test` and that a forced failure there blocks TestPyPI publish