### PR TITLE
fix(amazon-ads): trigger bulk-sheet download by href, not by clicking the label

### DIFF
--- a/.claude/skills/debug-store/SKILL.md
+++ b/.claude/skills/debug-store/SKILL.md
@@ -400,18 +400,32 @@ flow; the resulting file lands in `~/.vibe-seller/downloads/<slug>/`.
 
 Files downloaded by Ziniao (CSV, XLSX, PDF) land in either:
 
-- `~/Library/Application Support/ziniaobrowserdatas/ziniao browser/<slug>/`
-  (Ziniao-managed, persistent), or
-- `~/.vibe-seller/downloads/<slug>/` (vibe-seller-monitored, more
-  reliable).
+- the Ziniao-managed native dir (persistent) —
+  `~/Library/Application Support/ziniaobrowserdatas/ziniao browser/<slug>/`
+  on macOS; under `%LOCALAPPDATA%\ziniaobrowser` / Chrome's default
+  `~/Downloads` on native-Windows — or
+- `~/.vibe-seller/downloads/<slug>/` (per-store, the reliable one).
 
-Recent bulk-export XLSX files always land in the second path because
-the project monitors a Chrome download dir and copies in. List most
-recent first:
+Recent bulk-export XLSX files land in the second path because the CDP
+mux proxy pins Chrome's download path there via `Browser.setDownloadBehavior`
+(`cdp_mux_proxy.py` / `cdp_mux_upstream.py`) — **verified working on
+native-Windows too**, not just macOS. List most recent first:
 
 ```bash
 ls -lt ~/.vibe-seller/downloads/<slug>/ | head -10
 ```
+
+**Download-trigger gotcha (verified 2026-07-02, Ziniao/native-Windows).**
+The pinned path works, but a page's *visible* download link is often a
+`<p>`/label, not the clickable `<a>` — a coordinate/element click on the
+label silently fires **no** download and the dir stays empty, which reads
+as "the download dir is broken" when it isn't. Trigger the real anchor by
+`href` (JS `.click()` on `a[href*="…/download/…"]`, or `browser-use open
+<href>` — the latter returns a benign `net::ERR_ABORTED` but the file
+still lands). See `amazon-ads` mechanics § 2d for the worked example.
+Downloaded files carry Amazon's real name (`bulk-<entity>-<dates>-<ts>.xlsx`),
+never a fixed `BulkSheetExport.xlsx` — glob the newest `*.xlsx`, don't
+assume a name.
 
 ## Capturing data → temp dir, never knowledge
 

--- a/.claude/skills/debug-store/SKILL.md
+++ b/.claude/skills/debug-store/SKILL.md
@@ -403,7 +403,7 @@ Files downloaded by Ziniao (CSV, XLSX, PDF) land in either:
 - the Ziniao-managed native dir (persistent) —
   `~/Library/Application Support/ziniaobrowserdatas/ziniao browser/<slug>/`
   on macOS; under `%LOCALAPPDATA%\ziniaobrowser` / Chrome's default
-  `~/Downloads` on native-Windows — or
+  `%USERPROFILE%\Downloads` on native-Windows — or
 - `~/.vibe-seller/downloads/<slug>/` (per-store, the reliable one).
 
 Recent bulk-export XLSX files land in the second path because the CDP

--- a/app/skills/amazon-ads/references/mechanics.md
+++ b/app/skills/amazon-ads/references/mechanics.md
@@ -190,10 +190,51 @@ has these checkboxes (default all checked for "Enabled & Paused"):
 - Sponsored brands search term data
 - Budget Rules Data
 
-Click `Download` (`下载`) in the modal. The job takes **5–15 min** for
-~150 campaigns. The status table polls infrequently — refresh the
-page to update. When status flips to `Success` (`成功`), click the row's
-`Download` link; the file lands in `~/.vibe-seller/downloads/<store>/BulkSheetExport.xlsx`.
+Click `Download` (`下载` / `下載` / localized) in the modal to submit.
+The job takes **5–15 min** for ~150 campaigns and the status table polls
+infrequently — re-`open` the bulk-operations URL to refresh. When the
+row's Status flips to `Success`, trigger the download by its **anchor,
+matched by href** — this is the one method that works on **both macOS
+and native-Windows**. Do NOT click the visible link text: the
+"下载 / 下載 / Download" cell content is a `<p>` label, not the clickable
+`<a>`. A coordinate/element click on that label happened to work on
+macOS but **silently no-ops on Ziniao / native-Windows** (nothing
+downloads, the dir stays empty — the failure this section fixes). The
+real link is an `<a download href="…/bulk-operations/download/…xlsx">`
+in that cell; match it **by href, not by button text** (the label is
+localized — 下载 / 下載 / Download — and the ag-Grid column *header* also
+reads "Download"):
+
+```bash
+# Preferred: click the real <a download> via JS (the grid is an ag-Grid
+# inside a web-component shadow root, so walk shadow roots to find it).
+browser-use eval "
+(function(){
+  function walk(root,acc){root.querySelectorAll('*').forEach(function(e){
+    if(e.shadowRoot)walk(e.shadowRoot,acc);
+    if(e.tagName==='A'&&/bulk-operations\/download\//.test(e.href||''))acc.push(e);
+  });return acc;}
+  var a=walk(document,[]);
+  if(!a.length)return 'NO_LINK';   // newest job is a[0]
+  a[0].click();                    // real <a download> click → fires the download
+  return 'CLICKED '+a[0].href.slice(-48);
+})()"
+# Alternative: capture a[0].href and `browser-use open <href>`. Chrome
+# aborts the 'navigation' to start a download, so open returns a benign
+# `Error: Navigation failed: net::ERR_ABORTED` — the file still lands.
+```
+
+The file lands in `~/.vibe-seller/downloads/<slug>/` (the CDP mux proxy
+pins Chrome's download path there via `setDownloadBehavior` — verified on
+native-Windows too, not just macOS). Its name is Amazon's real export
+name `bulk-<entity>-<YYYYMMDD>-<YYYYMMDD>-<epochms>.xlsx`
+(e.g. `bulk-a1b2c3d4e5-20250101-20250131-1700000000000.xlsx`), **NOT** a
+fixed `BulkSheetExport.xlsx`. Don't hard-code the name — grab the newest
+xlsx and wait for any in-progress `*.crdownload` to disappear first:
+
+```bash
+ls -t ~/.vibe-seller/downloads/<slug>/*.xlsx 2>/dev/null | head -1
+```
 
 The XLSX has 9 sheets; the meaningful ones for SP are
 `Sponsored Products Campaigns` (one row per entity: Campaign /


### PR DESCRIPTION
## Problem

Agents running the Amazon Ads bulk export/import flow reported the
downloaded bulk sheet was **missing** — the per-store downloads dir stayed
empty after the "download" step. The skill (`amazon-ads` mechanics § 2d)
instructed the agent to *"click the row's `Download` link"* and to expect a
file named `BulkSheetExport.xlsx`.

## Root cause (trigger, not path)

Reproduced live on Ziniao / native-Windows:

- The visible "Download" content in the Bulk Operations grid cell is a
  `<p>` **label**, not the clickable element. A coordinate/element click on
  it **silently fires no download** (it happened to work on macOS, hence the
  original skill text, but no-ops on Ziniao/Windows). The real link is an
  `<a download href="…/bulk-operations/download/…xlsx">` in the same cell.
- The CDP mux proxy's `Browser.setDownloadBehavior` pinning to
  `~/.vibe-seller/downloads/<slug>/` **works correctly on native-Windows**
  (verified: a real 52-column, 181-row bulk sheet landed there once the
  download actually fired). So there is **no code bug** in the download path.
- The real export filename is `bulk-<entity>-<dates>-<epochms>.xlsx`, never a
  fixed `BulkSheetExport.xlsx`.

## Fix (skill/docs only — no code change)

- Trigger the download by the **anchor matched on href**
  (`a[href*="/bulk-operations/download/"]`) via a JS `.click()`, or by
  `open`-ing the href directly (returns a benign `net::ERR_ABORTED` but the
  file still lands). **Works on both macOS and native-Windows** and is
  locale-independent (label renders as 下载 / 下載 / Download; the ag-Grid
  column *header* also reads "Download", so text-matching is doubly unsafe).
- Glob the newest `*.xlsx` in the downloads dir (and wait for any
  `*.crdownload` to clear) instead of assuming a fixed filename.
- `debug-store`: document the same trigger gotcha and that the pinned path is
  verified on native-Windows, plus the Windows-equivalent native download dir.

## Verification

Ran the exact documented snippet on a live store (KSA marketplace): the
export anchor `.click()` downloaded `bulk-…-….xlsx` (67 KB, 9 sheets, SP
Campaigns sheet = 181 rows × 52 cols) into `~/.vibe-seller/downloads/<slug>/`
as expected. Coordinate-clicking the label produced nothing, confirming the
diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)