### PR TITLE
feat(telemetry): attach app_version + os to every event, not just app_started

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -192,15 +192,15 @@ async def lifespan(app: FastAPI):
             user_count = (
                 await db_counts.execute(select(func.count(User.id)))
             ).scalar() or 0
-        props = telemetry.base_properties()
-        props.update({
+        props = {
             'store_count': store_count,
             'total_task_count': task_count,
             'active_schedule_count': schedule_count,
             'user_count': user_count,
-        })
+        }
     except Exception:
-        props = telemetry.base_properties()
+        props = {}
+    # base_properties() (app_version, os, …) is merged in by send().
     telemetry.send(TelemetryEvent.APP_STARTED, props)
     # Trigger initial email sync in background
     sync_task = asyncio.create_task(sync_all_email_accounts())

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -113,10 +113,17 @@ def send(event: str, properties: dict | None = None) -> None:
     if not is_enabled() or _install_id is None or _client is None:
         return
     try:
+        # Merge base properties (app_version, os, python_version, …) into
+        # EVERY event, not just app_started, so any event can be
+        # segmented by release version or platform. Caller-supplied keys
+        # win over the base defaults.
+        props = base_properties()
+        if properties:
+            props.update(properties)
         _client.capture(
             distinct_id=_install_id,
             event=event,
-            properties=properties or {},
+            properties=props,
         )
     except Exception:
         logger.debug('Telemetry send failed for %s', event, exc_info=True)

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,0 +1,64 @@
+"""Unit tests for app.telemetry.send() property merging.
+
+Guards the bug where only ``app_started`` carried ``app_version``: every
+other event was sent with just its caller-supplied dict, so dashboards
+couldn't segment task/store/browser events by release version or
+platform. ``send()`` must merge ``base_properties()`` into EVERY event.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app import telemetry
+
+pytestmark = pytest.mark.unit
+
+
+def _capture_props(monkeypatch, event: str, properties: dict | None) -> dict:
+    """Drive telemetry.send() with a mocked client and return the
+    properties dict handed to client.capture()."""
+    captured: dict = {}
+    client = MagicMock()
+
+    def fake_capture(distinct_id, event, properties):  # noqa: ARG001
+        captured['properties'] = properties
+
+    client.capture.side_effect = fake_capture
+    # Bypass the env/db gates that conftest sets (VIBE_SELLER_TELEMETRY=0).
+    monkeypatch.setattr(telemetry, '_client', client)
+    monkeypatch.setattr(telemetry, '_install_id', 'test-install-id')
+    monkeypatch.setattr(telemetry, '_db_disabled', False)
+    monkeypatch.setattr(telemetry, '_disabled_via_env', lambda: False)
+    telemetry.send(event, properties)
+    return captured['properties']
+
+
+def test_send_merges_base_properties_into_every_event(monkeypatch):
+    # A non-app_started event with its own caller props.
+    props = _capture_props(
+        monkeypatch, 'task_created', {'has_schedule': 'false'}
+    )
+    # base_properties keys must be present…
+    assert props['app_version'] == telemetry.APP_VERSION
+    assert 'os' in props
+    assert 'python_version' in props
+    assert 'is_docker' in props
+    # …and the caller's own property is preserved.
+    assert props['has_schedule'] == 'false'
+
+
+def test_send_includes_version_with_no_caller_properties(monkeypatch):
+    props = _capture_props(monkeypatch, 'store_deleted', None)
+    assert props['app_version'] == telemetry.APP_VERSION
+    assert 'os' in props
+
+
+def test_caller_property_overrides_base(monkeypatch):
+    # If a caller ever passes app_version explicitly, it wins over the base.
+    props = _capture_props(
+        monkeypatch, 'app_started', {'app_version': 'override'}
+    )
+    assert props['app_version'] == 'override'


### PR DESCRIPTION
## Problem

Only the `app_started` event carried `app_version`. It was the **single** `telemetry.send()` caller that passed `base_properties()` in; every other event (`task_created`, `browser_session_*`, `store_*`, `view_changed`, …) was captured with just its own small dict, so `app_version` was absent on all of them.

Verified in PostHog over 90 days:

| event | events | with `app_version` |
|---|---|---|
| `app_started` | 725 | 650 |
| `task_created` | 404 | **0** |
| `browser_session_attempted` | 2171 | **0** |
| *(all other events)* | … | **0** |

`$os` rides on every event (auto/person property), but `app_version` did not — so it was impossible to segment any event other than `app_started` by release version (e.g. filter the task/DAU dashboard to stable releases, or break task activity down by version).

## Fix

Merge `base_properties()` inside `send()` so `app_version`, `os`, `os_release`, `python_version`, `is_docker`, and `app_locale` are attached to **every** event. Caller-supplied keys still take precedence. The `app_started` caller in `main.py` no longer needs to merge base props by hand, so it's simplified.

No caller signatures change; this is purely additive to the event payloads.

## Tests

New `tests/unit/test_telemetry.py` pins the invariant: `send()` includes `app_version`/`os` on a non-`app_started` event, includes them when the caller passes no properties, and lets a caller-supplied key override the base. All pass.

## Note

This fixes it going forward — historical events already ingested without `app_version` are unaffected. Version-distribution / dev-DAU / platform insights built today are based on `app_started` (the only event that historically had version); once this ships, those can optionally be widened to the richer active-user events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)