### PR TITLE
fix(workspace): link task dirs with junctions on Windows, not privileged symlinks

### DIFF
--- a/app/task_delete.py
+++ b/app/task_delete.py
@@ -143,7 +143,16 @@ async def delete_task(
             # remove_task_workspace clears the shared-resource links
             # (POSIX symlinks / Windows junctions) before rmtree, so a
             # junction can never be followed into shared knowledge/stores.
-            await asyncio.to_thread(remove_task_workspace, task_dir)
+            # Best-effort: the task rows are already committed above, so a
+            # workspace-removal error must not bubble up as a 500.
+            try:
+                await asyncio.to_thread(remove_task_workspace, task_dir)
+            except OSError:
+                logger.warning(
+                    'Failed to remove task workspace %s',
+                    task_dir,
+                    exc_info=True,
+                )
     return True
 
 

--- a/app/task_delete.py
+++ b/app/task_delete.py
@@ -12,7 +12,6 @@ disk, and finally drops the row.
 import asyncio
 import logging
 from pathlib import Path
-import shutil
 
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -26,6 +25,7 @@ from app.models.task_message import TaskMessage
 from app.models.task_step import TaskStep
 from app.task_states import ACTIVE
 from app.workspace.manager import VIBE_SELLER_DIR
+from app.workspace.task_links import remove_task_workspace
 
 logger = logging.getLogger(__name__)
 
@@ -140,7 +140,10 @@ async def delete_task(
         except ValueError:
             continue
         if task_dir.exists():
-            await asyncio.to_thread(shutil.rmtree, task_dir, ignore_errors=True)
+            # remove_task_workspace clears the shared-resource links
+            # (POSIX symlinks / Windows junctions) before rmtree, so a
+            # junction can never be followed into shared knowledge/stores.
+            await asyncio.to_thread(remove_task_workspace, task_dir)
     return True
 
 

--- a/app/workspace/manager.py
+++ b/app/workspace/manager.py
@@ -20,7 +20,7 @@ import git as gitlib
 
 from app.config import VIBE_SELLER_DIR
 from app.platform import agent_venv_python
-from app.workspace import venv_bootstrap
+from app.workspace import task_links, venv_bootstrap
 from app.workspace.store_data_migrate import migrate_store_data
 from app.workspace.store_seed import write_catalog_stub
 from app.workspace.structured_stores import collect_store_entries
@@ -680,7 +680,7 @@ browser: {backend}
         await self.ensure_init()
         task_dir = self.root / 'tasks' / task_id
         if clean and task_dir.exists():
-            shutil.rmtree(task_dir)
+            task_links.remove_task_workspace(task_dir)
         task_dir.mkdir(parents=True, exist_ok=True)
 
         links: dict[str, Path] = {
@@ -691,15 +691,9 @@ browser: {backend}
         }
         for name, target in links.items():
             link_path = task_dir / name
-            if link_path.is_symlink():
-                link_path.unlink()
-            elif link_path.exists():
-                if link_path.is_dir():
-                    shutil.rmtree(link_path)
-                else:
-                    link_path.unlink()
+            task_links._clear_workspace_link(link_path)
             if target.exists():
-                link_path.symlink_to(target)
+                task_links._link_shared_into_task(link_path, target)
 
         # .claude is copied (not symlinked) because Claude Code's
         # Glob doesn't follow symlinks when traversing ** patterns.
@@ -712,10 +706,7 @@ browser: {backend}
 
         claude_src = self.root / '.claude'
         claude_dst = task_dir / '.claude'
-        if claude_dst.is_symlink():
-            claude_dst.unlink()
-        elif claude_dst.exists():
-            shutil.rmtree(claude_dst)
+        task_links._clear_workspace_link(claude_dst)
         if claude_src.is_dir():
             shutil.copytree(
                 claude_src,

--- a/app/workspace/manager.py
+++ b/app/workspace/manager.py
@@ -666,11 +666,14 @@ browser: {backend}
         *,
         clean: bool = False,
     ) -> Path:
-        """Create a per-task working directory with symlinks.
+        """Create a per-task working directory linked to shared dirs.
 
         Returns the absolute path to ``tasks/{task_id}/``. Shared
-        resources (knowledge, stores, skills, CLAUDE.md) are
-        symlinked; task-specific files stay isolated.
+        resources (knowledge, stores, store-data, CLAUDE.md) are linked
+        to the shared root — POSIX symlinks, or Windows directory
+        junctions plus a CLAUDE.md copy, since ``os.symlink`` needs a
+        privilege stock Windows lacks (see ``app/workspace/task_links``).
+        Task-specific files stay isolated.
 
         The ``browser-use`` skill is copied for every task, including
         no-store (orchestrator) tasks — they now have the store-less

--- a/app/workspace/task_links.py
+++ b/app/workspace/task_links.py
@@ -83,9 +83,14 @@ def remove_task_workspace(task_dir: Path) -> None:
     Clears the shared-resource links first so the final ``rmtree`` can
     never descend a junction into shared knowledge/stores, then removes
     the task-local files. Safe to call on POSIX (symlinks) too.
+
+    Raises on failure (e.g. a locked file) rather than swallowing it, so
+    ``clean=True`` callers surface the error as they did before this
+    helper existed; best-effort callers (task deletion) wrap it in
+    try/except.
     """
     if not task_dir.exists() and not task_dir.is_symlink():
         return
     for name in _SHARED_LINK_NAMES:
         _clear_workspace_link(task_dir / name)
-    shutil.rmtree(task_dir, ignore_errors=True)
+    shutil.rmtree(task_dir)

--- a/app/workspace/task_links.py
+++ b/app/workspace/task_links.py
@@ -1,0 +1,91 @@
+"""Per-task workspace linking, cross-platform.
+
+Each task workspace exposes the shared ``knowledge``/``stores``/
+``store-data``/``CLAUDE.md`` at a stable path resolving to the single
+shared copy (writable-through for the dirs). POSIX does this with
+symlinks; Windows uses directory *junctions* + a file copy, because
+``os.symlink`` on Windows needs ``SeCreateSymbolicLinkPrivilege`` — a
+privilege a normally-launched (non-elevated, Developer-Mode-off) process
+does NOT hold, which raised ``WinError 1314`` on task creation.
+Junctions and copies need no privilege, so the app runs as a plain user.
+"""
+
+import os
+from pathlib import Path
+import shutil
+import stat
+
+_IS_WINDOWS = os.name == 'nt'
+if _IS_WINDOWS:
+    import _winapi  # noqa: PLC2701 — stdlib junction API, no public equiv
+
+    _create_junction = _winapi.CreateJunction  # CreateJunction(src, dst)
+else:
+    _create_junction = None
+
+# Shared-root resources linked into every per-task workspace. Kept as a
+# module constant so teardown can clear the exact same set without having
+# to reason about junctions vs symlinks at each call site.
+_SHARED_LINK_NAMES = ('knowledge', 'stores', 'store-data', 'CLAUDE.md')
+
+
+def _is_junction(path: Path) -> bool:
+    """True if *path* is a Windows directory junction (reparse point)."""
+    if not _IS_WINDOWS:
+        return False
+    try:
+        attrs = os.lstat(path).st_file_attributes
+    except (OSError, AttributeError):
+        return False
+    return bool(attrs & stat.FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+def _clear_workspace_link(link_path: Path) -> None:
+    """Remove a per-task workspace link/copy *in place*.
+
+    Never follows the link into its shared target: a POSIX symlink is
+    unlinked; a Windows junction is dropped with ``os.rmdir`` (calling
+    ``shutil.rmtree`` on a junction raises on 3.11 and could delete the
+    shared target on other runtimes); a stray real dir/file left over
+    from an older layout is removed normally.
+    """
+    if link_path.is_symlink():  # POSIX symlink (or a broken one)
+        link_path.unlink()
+    elif _is_junction(link_path):  # Windows junction → drop reparse point
+        os.rmdir(link_path)
+    elif link_path.exists():
+        if link_path.is_dir():
+            shutil.rmtree(link_path)
+        else:
+            link_path.unlink()
+
+
+def _link_shared_into_task(link_path: Path, target: Path) -> None:
+    """Point ``link_path`` at the shared ``target``.
+
+    POSIX uses a symlink. Windows uses a directory *junction* for a
+    directory and a *copy* for a file, because ``os.symlink`` on Windows
+    needs a privilege stock machines lack (see module docstring).
+    Junctions resolve to the same shared dir, so agent write-through is
+    preserved; CLAUDE.md is static guidance, so a per-task copy is fine.
+    """
+    if not _IS_WINDOWS:
+        link_path.symlink_to(target)
+    elif target.is_dir():
+        _create_junction(os.path.abspath(target), str(link_path))
+    else:
+        shutil.copy2(target, link_path)
+
+
+def remove_task_workspace(task_dir: Path) -> None:
+    """Delete a task workspace dir without touching shared resources.
+
+    Clears the shared-resource links first so the final ``rmtree`` can
+    never descend a junction into shared knowledge/stores, then removes
+    the task-local files. Safe to call on POSIX (symlinks) too.
+    """
+    if not task_dir.exists() and not task_dir.is_symlink():
+        return
+    for name in _SHARED_LINK_NAMES:
+        _clear_workspace_link(task_dir / name)
+    shutil.rmtree(task_dir, ignore_errors=True)

--- a/tests/unit/test_workspace_symlinks.py
+++ b/tests/unit/test_workspace_symlinks.py
@@ -1,10 +1,22 @@
-"""Unit tests for per-task workspace isolation via symlinks."""
+"""Unit tests for per-task workspace isolation.
+
+Shared resources (knowledge, stores, store-data, CLAUDE.md) are linked
+into each task dir. POSIX uses symlinks; Windows uses directory
+*junctions* for dirs + a copy for CLAUDE.md, because ``os.symlink`` on
+Windows needs ``SeCreateSymbolicLinkPrivilege`` — a privilege a normally
+launched (non-elevated, Developer-Mode-off) process lacks, which raised
+``WinError 1314`` on task creation.
+"""
 
 import asyncio
+import os
 
 import pytest
 
+from app.workspace import task_links
 from app.workspace.manager import WorkspaceManager
+
+IS_WINDOWS = os.name == 'nt'
 
 
 @pytest.fixture
@@ -14,31 +26,45 @@ def ws(tmp_path):
     return mgr
 
 
+def _assert_shared_dir_link(link_path, target):
+    """A task→shared-dir link resolves to the shared dir via the
+    platform's privilege-free mechanism (POSIX symlink / Windows
+    junction) — never a raw os.symlink on Windows."""
+    assert link_path.is_dir()  # resolves through the link
+    assert link_path.resolve() == target.resolve()
+    if IS_WINDOWS:
+        assert not link_path.is_symlink(), 'must be a junction, not a symlink'
+        assert task_links._is_junction(link_path)
+    else:
+        assert link_path.is_symlink()
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_prepare_creates_symlinks(ws):
+async def test_prepare_creates_shared_links(ws):
     await ws.ensure_init()
     task_dir = await ws.prepare_task_workspace('tid-1')
 
     assert task_dir.is_dir()
-    # .claude is a full copy (not a symlink) so Claude Code's
-    # Glob can traverse it for skill discovery.
+    # .claude is a full copy (not a link) so Claude Code's Glob can
+    # traverse it for skill discovery.
     assert (task_dir / '.claude').is_dir()
     assert not (task_dir / '.claude').is_symlink()
     assert (task_dir / '.claude' / 'skills').is_dir()
     assert not (task_dir / '.claude' / 'skills').is_symlink()
-    assert (task_dir / 'knowledge').is_symlink()
-    assert (task_dir / 'stores').is_symlink()
-    # Per-store run data (reports/captures) lives outside stores/ so
-    # it never surfaces as knowledge; tasks reach it via this symlink.
-    assert (task_dir / 'store-data').is_symlink()
-    assert (task_dir / 'CLAUDE.md').is_symlink()
-    assert (task_dir / 'knowledge').resolve() == (
-        ws.root / 'knowledge'
-    ).resolve()
-    assert (task_dir / 'store-data').resolve() == (
-        ws.root / 'store-data'
-    ).resolve()
+    # Shared dirs are linked to the workspace root.
+    _assert_shared_dir_link(task_dir / 'knowledge', ws.root / 'knowledge')
+    _assert_shared_dir_link(task_dir / 'stores', ws.root / 'stores')
+    # Per-store run data (reports/captures) lives outside stores/ so it
+    # never surfaces as knowledge; tasks reach it via this link.
+    _assert_shared_dir_link(task_dir / 'store-data', ws.root / 'store-data')
+    # CLAUDE.md: symlink on POSIX, plain copy on Windows.
+    claude_md = task_dir / 'CLAUDE.md'
+    assert claude_md.exists()
+    if IS_WINDOWS:
+        assert claude_md.is_file() and not claude_md.is_symlink()
+    else:
+        assert claude_md.is_symlink()
 
 
 @pytest.mark.unit
@@ -55,16 +81,16 @@ async def test_prepare_clean_recreates(ws):
     # Recreated after clean
     assert (task_dir2 / '.claude').is_dir()
     assert not (task_dir2 / '.claude').is_symlink()
-    assert (task_dir2 / 'knowledge').is_symlink()
+    _assert_shared_dir_link(task_dir2 / 'knowledge', ws.root / 'knowledge')
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_write_through_symlink(ws):
+async def test_write_through_link(ws):
     await ws.ensure_init()
     task_dir = await ws.prepare_task_workspace('tid-3')
     (task_dir / 'knowledge' / 'test.md').write_text('hello')
-    # Written through symlink → lands in real dir
+    # Written through the link → lands in the real shared dir
     assert (ws.root / 'knowledge' / 'test.md').read_text() == 'hello'
 
 
@@ -95,19 +121,76 @@ async def test_idempotent_refresh(ws):
     task_dir = await ws.prepare_task_workspace('tid-5')
     assert (task_dir / '.claude').is_dir()
     assert not (task_dir / '.claude').is_symlink()
-    assert (task_dir / 'knowledge').is_symlink()
+    _assert_shared_dir_link(task_dir / 'knowledge', ws.root / 'knowledge')
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_list_tree_excludes_tasks(ws):
-    await ws.ensure_init()
-    task_dir = await ws.prepare_task_workspace('tid-6')
-    (task_dir / 'secret.txt').write_text('hidden')
+async def test_clean_and_remove_preserve_shared_data(ws):
+    """Tearing down a task workspace must never delete shared data.
 
-    tree = await ws.list_tree()
-    paths = [item['path'] for item in tree]
-    assert not any('tasks' in p for p in paths)
+    On Windows the shared links are junctions, and a naive rmtree of a
+    junction (or, on some runtimes, of a dir containing one) follows it
+    into the target. Both ``clean=True`` and ``remove_task_workspace``
+    must clear the links first so shared knowledge/stores survive.
+    """
+    await ws.ensure_init()
+    (ws.root / 'knowledge' / 'keep.md').write_text('precious')
+    task_dir = await ws.prepare_task_workspace('tid-del')
+
+    # clean=True rebuilds the workspace but must leave shared data intact
+    await ws.prepare_task_workspace('tid-del', clean=True)
+    assert (ws.root / 'knowledge' / 'keep.md').read_text() == 'precious'
+
+    # explicit teardown must also leave shared data intact
+    task_links.remove_task_workspace(task_dir)
+    assert not task_dir.exists()
+    assert (ws.root / 'knowledge' / 'keep.md').read_text() == 'precious'
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_windows_strategy_avoids_privileged_symlink(ws, monkeypatch):
+    """Regression guard for WinError 1314.
+
+    A stock Windows box cannot ``os.symlink`` (needs a privilege it
+    lacks). CI can't withhold that privilege — Linux and GitHub's
+    Windows runners both symlink fine — so we simulate it: force the
+    Windows link strategy and make ``os.symlink`` raise 1314. The
+    workspace must still build, via junctions (dirs) + copy (CLAUDE.md),
+    i.e. it must NOT call ``os.symlink`` for the shared resources.
+    """
+    real_symlink = os.symlink
+    junctions: list[str] = []
+
+    def fake_create_junction(target, link):
+        junctions.append(str(link))
+        real_symlink(target, link)  # stand-in so it resolves on POSIX
+
+    def deny_symlink(*args, **kwargs):
+        raise OSError(1314, 'A required privilege is not held by the client')
+
+    monkeypatch.setattr(task_links, '_IS_WINDOWS', True)
+    monkeypatch.setattr(task_links, '_create_junction', fake_create_junction)
+    monkeypatch.setattr(os, 'symlink', deny_symlink)
+
+    await ws.ensure_init()
+    # Must NOT raise WinError 1314:
+    task_dir = await ws.prepare_task_workspace('tid-nopriv')
+
+    # Every shared *dir* was linked via the junction primitive:
+    linked = {
+        name
+        for name in ('knowledge', 'stores', 'store-data')
+        if any(name in j for j in junctions)
+    }
+    assert linked == {'knowledge', 'stores', 'store-data'}
+    # CLAUDE.md was copied, not symlinked:
+    claude_md = task_dir / 'CLAUDE.md'
+    assert claude_md.is_file() and not claude_md.is_symlink()
+    # write-through still reaches the shared dir:
+    (task_dir / 'knowledge' / 'wt.md').write_text('ok')
+    assert (ws.root / 'knowledge' / 'wt.md').read_text() == 'ok'
 
 
 @pytest.mark.unit

--- a/tests/unit/test_workspace_symlinks.py
+++ b/tests/unit/test_workspace_symlinks.py
@@ -150,6 +150,11 @@ async def test_clean_and_remove_preserve_shared_data(ws):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    os.name == 'nt',
+    reason='POSIX-only: uses os.symlink as a junction stand-in, which '
+    'itself needs the privilege this scenario simulates missing',
+)
 async def test_windows_strategy_avoids_privileged_symlink(ws, monkeypatch):
     """Regression guard for WinError 1314.
 


### PR DESCRIPTION
## Problem

Creating a task on a native-Windows install crashes in workspace prep:

```
[WinError 1314] 客户端没有所需的特权。:
'C:\Users\Administrator\.vibe-seller\knowledge' ->
'...\.vibe-seller\tasks\<id>\knowledge'
```

`prepare_task_workspace()` links the shared `knowledge`/`stores`/`store-data`/`CLAUDE.md` into each task dir with `os.symlink`. **On Windows, creating a symlink requires `SeCreateSymbolicLinkPrivilege`**, which a normally-launched server does not hold: a tray/autostart process runs under a UAC-*filtered* token — even for an "Administrator" account — and Developer Mode is off on a stock machine. Hence `WinError 1314`.

### Why it worked on some machines but not others

Two independent things grant symlink creation; a stock box has neither:

1. **Developer Mode** (Win10 1703+) allows unprivileged symlink creation. Dev machines usually have it on; it's off on a fresh install.
2. An **elevated token** holds the privilege. The tray-launched server does not (UAC filters it), but an interactive admin **SSH** login *does* — which is why probing over SSH looked fine while the server failed.

### Why CI never caught it

- The Windows `agent-e2e` job is gated on a repo secret (`HAS_DEEPSEEK`) → skipped on forks.
- More fundamentally, **GitHub's `windows-latest` runner holds the symlink privilege**, so the buggy `os.symlink` *succeeds* there. A task-creating e2e can't observe a failure that never happens on the runner.

## Fix — from design, not a workaround

We deliberately do **not** require running elevated or enabling Developer Mode. Instead, pick the privilege-free primitive per platform (new `app/workspace/task_links.py`):

- **Windows**: directory **junctions** for the shared dirs (no privilege needed) + a **copy** for the static `CLAUDE.md`.
- **POSIX**: symlinks, unchanged.

Junctions resolve to the same shared dir, so agent write-through (`stores`/`knowledge`) is preserved, and a plain non-admin user can run the app.

Teardown is made **junction-safe**: links are cleared first (`os.rmdir` for a junction — `rmtree` on a junction raises on 3.11 and can delete the *target* on other runtimes) before `rmtree`, so a junction can never be followed into shared data. Task deletion routes through the shared `remove_task_workspace()`.

## Tests (run in the ubuntu unit job on every PR)

- **OS-aware assertions**: symlink on POSIX, junction on Windows.
- **Data-loss guard**: `clean=True` and `remove_task_workspace()` must not delete shared knowledge/stores.
- **Forced-Windows repro**: force the Windows path and make `os.symlink` raise 1314 → the build must still succeed via junctions + copy. This *fails on the old code*, giving a regression guard that runs every PR without needing a real non-elevated Windows box (which no CI provides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
