### PR TITLE
Amazon listing CRUD skill (flat-file) + reap task agents on server shutdown

### DIFF
--- a/app/ai/claude_backend.py
+++ b/app/ai/claude_backend.py
@@ -50,7 +50,7 @@ from app.browser.manager import (
     atomic_write_json,
     read_mcp_config,
 )
-from app.browser.process_utils import kill_with_escalation
+from app.browser.process_utils import kill_with_escalation, taskkill_tree
 from app.config import BACKEND_PORT, BASE_DIR
 from app.database import async_session
 from app.env_options import Options
@@ -627,11 +627,16 @@ class AgentSession(_HookMixin, _StreamMixin):
                 return
             except TimeoutError:
                 continue
-        # Final escalation: SIGKILL the group, then the leader as a
-        # cross-platform fallback if killpg isn't available.
+        # Final escalation: SIGKILL the group; on Windows (no process
+        # group) taskkill_tree kills the whole tree so the MCP server +
+        # skill_cli.daemon + browser-use children die too — killing only
+        # the leader would orphan the browser daemon, which then keeps
+        # driving browser/start on the shared Ziniao.
         try:
             if use_killpg:
                 os.killpg(pid, signal.SIGKILL)
+            elif IS_WINDOWS:
+                await taskkill_tree(pid, timeout=SIGNAL_TIMEOUT)
             else:
                 self._proc.kill()
         except ProcessLookupError:

--- a/app/ai/claude_backend_manager.py
+++ b/app/ai/claude_backend_manager.py
@@ -253,6 +253,35 @@ class ClaudeCodeBackend(AIAgentBackend):
         await session.stop()
         return True
 
+    async def stop_all(self) -> int:
+        """Stop every running task agent (used on server shutdown).
+
+        Each session's ``stop()`` killpg's the whole ``claude -p`` subtree
+        (MCP server, skill_cli.daemon, browser-use), so this prevents
+        agents being orphaned across a restart — orphans keep calling
+        ``browser/start`` on the next server and thrash the shared Ziniao
+        client. Best-effort: a failure on one session never blocks the
+        others or shutdown.
+        """
+        running = [
+            (tid, s)
+            for tid, s in list(self._sessions.items())
+            if s and s.running
+        ]
+        if not running:
+            return 0
+        logger.info(
+            'Stopping %d running task agent(s) on shutdown', len(running)
+        )
+        results = await asyncio.gather(
+            *(s.stop() for _tid, s in running),
+            return_exceptions=True,
+        )
+        for (tid, _s), res in zip(running, results, strict=True):
+            if isinstance(res, Exception):
+                logger.warning('stop_all: session %s stop failed: %s', tid, res)
+        return len(running)
+
     async def submit_answer(
         self, task_id: str, request_id: str, answers: dict
     ) -> bool:

--- a/app/browser/process_utils.py
+++ b/app/browser/process_utils.py
@@ -1,8 +1,38 @@
 """Shared process-management utilities for browser daemons."""
 
+import asyncio
+
 from app.platform import is_process_alive, kill_process
 
-__all__ = ['is_process_alive', 'kill_process', 'kill_with_escalation']
+__all__ = [
+    'is_process_alive',
+    'kill_process',
+    'kill_with_escalation',
+    'taskkill_tree',
+]
+
+
+async def taskkill_tree(pid: int, timeout: float = 3.0) -> None:
+    """Force-kill a process AND its whole child tree on Windows.
+
+    ``os.killpg`` is POSIX-only; on Windows there is no process group to
+    signal, and killing only the leader would orphan its children (MCP
+    server, skill_cli.daemon, browser-use). ``taskkill /F /T`` walks the
+    tree. Best-effort — never raises.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            'taskkill',
+            '/F',
+            '/T',
+            '/PID',
+            str(pid),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await asyncio.wait_for(proc.wait(), timeout=timeout)
+    except Exception:
+        pass
 
 
 async def kill_with_escalation(

--- a/app/cli.py
+++ b/app/cli.py
@@ -24,7 +24,12 @@ import subprocess
 import sys
 import time
 
-from app.platform import is_process_alive, kill_process
+from app.platform import (
+    collect_agent_descendants,
+    is_process_alive,
+    kill_process,
+    reap_task_agents,
+)
 
 
 def _resolve_version() -> str:
@@ -290,12 +295,29 @@ def _cmd_stop(args: argparse.Namespace) -> int:
         print(f'No vibe-seller process tracked on port {port}.')
         return 0
 
+    # Collect THIS server's task-agent descendants BEFORE killing it, so
+    # the reap is scoped to its own agents — a second vibe-seller server
+    # on another port keeps its agents. (Agents are spawned with
+    # start_new_session but remain descendants of the server until it
+    # exits; once it's killed they reparent to init/launchd, so we must
+    # snapshot them first.)
+    agent_pids = collect_agent_descendants(pid)
+
     # kill_process (psutil): terminate → poll → kill, cross-platform.
     # The old os.kill(SIGTERM)→SIGKILL path was Unix-only — signal.SIGKILL
     # doesn't even exist on Windows.
+    #
+    # Then reap those agents. On Unix a SIGTERM'd server runs its graceful
+    # shutdown (agent_manager.stop_all) and reaps its own agents; on
+    # Windows terminate()=TerminateProcess kills the server WITHOUT that
+    # handler, so we reap at the process level here as a backstop —
+    # otherwise orphaned `claude -p` agents keep driving browser/start on
+    # the next server and thrash the shared Ziniao client.
     asyncio.run(kill_process(pid))
+    reaped = asyncio.run(reap_task_agents(pids=agent_pids)) if agent_pids else 0
     _pid_file_for(port).unlink(missing_ok=True)
-    print(f'Stopped vibe-seller on port {port} (PID {pid}).')
+    suffix = f' (+{reaped} task agent(s) reaped)' if reaped else ''
+    print(f'Stopped vibe-seller on port {port} (PID {pid}).{suffix}')
     return 0
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -239,6 +239,15 @@ async def lifespan(app: FastAPI):
                 pass
     await task_queue_scheduler.stop()
     stop_scheduler()
+    # Reap running task agents so a graceful (SIGTERM) shutdown never
+    # orphans a `claude -p` subtree — an orphan keeps calling
+    # `browser/start` on the next server and thrashes the shared Ziniao
+    # client. (stop.sh SIGTERMs first to reach this path; it also kills
+    # any leftover agents as a -9 fallback.)
+    try:
+        await agent_manager.stop_all()
+    except Exception as e:
+        logger.warning('stop_all during shutdown failed: %s', e)
     telemetry.shutdown()
 
 

--- a/app/platform.py
+++ b/app/platform.py
@@ -162,6 +162,151 @@ async def find_processes_by_pattern(
     return await asyncio.to_thread(_scan)
 
 
+# Signature of a vibe-seller headless task agent (`claude -p` with the
+# bidirectional stream-json protocol) — a combo interactive Claude Code
+# never uses, so matching it can't hit an unrelated Claude session. Plus
+# the browser daemon it spawns.
+_AGENT_CMDLINE_PATTERN = 'output-format stream-json --input-format stream-json'
+_BROWSER_DAEMON_PATTERN = 'skill_cli.daemon'
+# The per-store wrapper. An agent that died ungracefully (a bare -9
+# instead of a process-group kill) can orphan a `bash .../browser-use
+# eval …` poll-loop — reparented to init/launchd — that keeps hammering
+# browser/start. Match the wrapper path AND a browser-use subcommand, so
+# a *running* wrapper is reaped but a mere reference to the path (e.g. an
+# editor viewing `~/.vibe-seller/bin/<slug>/browser-use`) is not.
+_WRAPPER_PATH = '.vibe-seller/bin/'
+_WRAPPER_VERBS = (
+    'eval',
+    'open',
+    'state',
+    'click',
+    'close',
+    'screenshot',
+    'type',
+    'input',
+    'keys',
+    'sessions',
+    'get',
+    'extract',
+    'scroll',
+    'wait',
+    'hover',
+    'dblclick',
+    'rightclick',
+    'select',
+    'upload',
+    'back',
+)
+
+
+def _is_task_process(cmdline: str) -> bool:
+    """True if the command line is a vibe-seller task agent, its browser
+    daemon, or a running per-store browser-use wrapper (not an editor
+    merely referencing the wrapper path)."""
+    if _AGENT_CMDLINE_PATTERN in cmdline or _BROWSER_DAEMON_PATTERN in cmdline:
+        return True
+    if _WRAPPER_PATH in cmdline and '/browser-use' in cmdline:
+        return any(f'browser-use {v}' in cmdline for v in _WRAPPER_VERBS)
+    return False
+
+
+def collect_agent_descendants(pid: int) -> set[int]:
+    """PIDs of task-agent processes descended from ``pid`` (a server).
+
+    Used by ``vibe-seller stop`` to scope reaping to the stopped server's
+    own agents. Must be called BEFORE the server is killed — once it
+    exits, its agents reparent to init/launchd and are no longer its
+    descendants. Best-effort; returns an empty set on any error.
+    """
+    try:
+        kids = psutil.Process(pid).children(recursive=True)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return set()
+    out: set[int] = set()
+    for child in kids:
+        try:
+            if _is_task_process(' '.join(child.cmdline() or [])):
+                out.add(child.pid)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    return out
+
+
+async def reap_task_agents(pids: set[int] | None = None) -> int:
+    """Kill orphaned task-agent process trees. Cross-platform.
+
+    A stopped/restarted server can leave `claude -p` agents (and their
+    MCP server / skill_cli.daemon / browser-use children) alive. An
+    orphan keeps calling ``browser/start`` on the next server and
+    thrashes the shared Ziniao client. The graceful in-process path
+    (``agent_manager.stop_all``) only runs on a clean SIGTERM shutdown —
+    Windows ``TerminateProcess`` (what ``vibe-seller stop`` / the tray
+    quit-restart use) bypasses it — so the stop command calls this as a
+    process-level backstop that works on every OS.
+
+    ``pids``: when given, only these root PIDs are considered (used by
+    ``vibe-seller stop`` to scope the reap to the *stopped server's own*
+    agent subtree — collected before the server is killed — so a second
+    server instance's agents are never touched). When ``None``, scans all
+    processes for the task signatures.
+
+    Kills each matched process together with its whole child tree via
+    psutil (``children(recursive=True)``), which needs no ``killpg`` /
+    ``taskkill`` and behaves identically on Windows and Unix. Best-effort:
+    never raises; returns the number of root processes reaped.
+    """
+    own = os.getpid()
+
+    def _reap() -> int:
+        roots: dict[int, psutil.Process] = {}
+        if pids is not None:
+            for pid in pids:
+                if pid == own:
+                    continue
+                try:
+                    roots[pid] = psutil.Process(pid)
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    continue
+        else:
+            for proc in psutil.process_iter(['pid', 'cmdline']):
+                try:
+                    if proc.info['pid'] == own:
+                        continue
+                    full = ' '.join(proc.info.get('cmdline') or [])
+                    if _is_task_process(full):
+                        roots[proc.info['pid']] = proc
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    continue
+        if not roots:
+            return 0
+        # Gather each root + its descendants, then terminate → kill.
+        victims: dict[int, psutil.Process] = {}
+        for root in roots.values():
+            victims[root.pid] = root
+            try:
+                for child in root.children(recursive=True):
+                    victims[child.pid] = child
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        for p in victims.values():
+            try:
+                p.terminate()
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        _gone, alive = psutil.wait_procs(list(victims.values()), timeout=3)
+        for p in alive:
+            try:
+                p.kill()
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        return len(roots)
+
+    reaped = await asyncio.to_thread(_reap)
+    if reaped:
+        logger.info('Reaped %d orphaned task agent(s)/daemon(s)', reaped)
+    return reaped
+
+
 # -- File permissions -------------------------------------------------
 
 

--- a/app/skills/MANIFEST.txt
+++ b/app/skills/MANIFEST.txt
@@ -10,6 +10,12 @@ amazon-ads/references/tuning-campaign-types.md
 amazon-ads/references/bulk-operations.md
 amazon-ads/scripts/ads_bulk.py
 amazon-ads/requirements.txt
+amazon-listing/SKILL.md
+amazon-listing/references/template-round-trip.md
+amazon-listing/references/1688-sourcing.md
+amazon-listing/scripts/listing_bulk.py
+amazon-listing/scripts/ocr_1688.py
+amazon-listing/requirements.txt
 amazon-invoice/SKILL.md
 amazon-invoice/generate_invoice.py
 amazon-invoice/requirements.txt

--- a/app/skills/amazon-listing/SKILL.md
+++ b/app/skills/amazon-listing/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: amazon-listing
+description: "Amazon listing CRUD via the category flat-file (Add Products via Upload). Create a variation family (parent + colour/size children), update attributes, change parent-child relationships, and delete SKUs — all in one template round trip. Also covers the end-to-end sourcing flow: a supplier link (e.g. 1688) → extract product data → local GPU-free OCR of detail images → generate title / bullet points / description → bilingual review with the user → propose the parent-child structure → fill the template → upload → read the processing report. Load this BEFORE any browser-use action on sellercentral.amazon.<tld>/listing/upload or when the task is to create / edit / delete a listing from a product link."
+allowed-tools: Bash(browser-use:*)
+requires: [amazon-shared]
+---
+
+# Amazon — Listing CRUD (flat-file upload)
+
+> **PREREQUISITE:** read `../amazon-shared/SKILL.md` for login, Ziniao
+> auto-fill / OTP, marketplace TLDs, hamburger navigation, and the
+> capture rule (live data → `/tmp/<task>/`, never `knowledge/`).
+
+Amazon's **Add Products via Upload** takes a category **flat-file
+template** — a macro-enabled `.xlsm` whose `Template` sheet is a wide
+table (one column per attribute). One upload creates or edits a whole
+**variation family** (a Parent plus N colour/size Children) at once.
+This is the batch equivalent of the per-SKU web wizard, and the default
+for anything touching more than one variant.
+
+Two references, load what the task needs:
+
+- **`references/template-round-trip.md`** — the download → inspect →
+  fill → upload → read-feedback loop, the operation column
+  (create/update/partialupdate/delete), and the parent-child cluster.
+  Load for **any** listing CRUD.
+- **`references/1688-sourcing.md`** — turning a supplier link into a
+  filled template: page extraction, local no-GPU OCR of detail images,
+  AI-generated copy, the **bilingual review** step, and image handling.
+  Load when the task starts from a **product link**.
+
+## The two scripts
+
+```bash
+S=<skills>/amazon-listing/scripts
+PY=<project-venv>/bin/python3     # needs openpyxl + rapidocr-onnxruntime
+```
+
+- **`listing_bulk.py`** — deterministic template writer. It keys every
+  field by its **field API name** (the row that contains `item_sku`),
+  which is identical in every console language, so it is locale-robust
+  the same way `amazon-ads/ads_bulk.py` is.
+  - `inspect TEMPLATE.xlsm [--field NAME]` — dump the field set, which
+    fields are Required, the accepted enum tokens, and the variation
+    cluster. **Run this first on every fresh template** — the column
+    set and valid values differ per product type.
+  - `fill TEMPLATE.xlsm --spec SPEC.json --out OUT.xlsm` — write
+    parent/child rows, set the operation column per row, validate enums
+    and required fields against the template's own metadata sheets, and
+    preserve the workbook (macros, signature row) verbatim.
+  - `parse-feedback REPORT` — summarise Amazon's processing report into
+    per-SKU errors / warnings.
+- **`ocr_1688.py`** — local, GPU-free OCR (rapidocr-onnxruntime) of the
+  supplier's detail images, where the spec table / size chart live.
+
+## Operation rules (the in-sheet `update_delete` column)
+
+The operation is **chosen per row in the sheet**, not inferred:
+
+| `operation` in spec | `update_delete` cell | Use when |
+|---|---|---|
+| `create` (default) | *blank* | new SKU. **No ASIN** → this is the default. |
+| `update` | `Update` | full re-submit of an existing SKU's attributes. |
+| `partialupdate` | `partialupdate` | change only the fields present; leave others as-is. |
+| `delete` | `delete` | remove the SKU. Needs only `sku` + `operation`. |
+
+Rule of thumb the user gave: **no ASIN filled → create; ASIN filled →
+update** — but the sheet's operation column is authoritative, so always
+set `operation` explicitly. For update/partialupdate by ASIN, put the
+ASIN in `external_product_id` with `external_product_id_type: asin`.
+
+## End-to-end flow (product link → live listing)
+
+1. **Extract** the product from the supplier link (see
+   `1688-sourcing.md`): page data + OCR of detail images.
+2. **Generate** an Amazon title, 5 bullet points, and a long
+   description from the extracted data.
+3. **Bilingual review** — present the generated copy to the user in
+   **both the user's language and the target marketplace language**,
+   plus the **proposed parent-child structure** (which variation theme,
+   which children). Wait for the user's confirmation / edits. This is
+   the one genuinely interactive step; do not skip it.
+4. **Download** the category template for the product type (into
+   `~/.vibe-seller/downloads/<slug>/`), `inspect` it.
+5. **Fill** a spec (parent + children) and produce the `.xlsm`.
+6. **Upload** it and **read the processing report**; fix row-level
+   errors from the report and re-upload. Common first-timers: an
+   invalid `recommended_browse_nodes` (pick from the template's valid
+   values) and a missing `external_product_id` (own-brand items need a
+   real barcode or a **GTIN exemption**).
+
+## Sourcing login
+
+The supplier site (1688) needs a login for some bulk specs, but the
+core product data is reachable without it. When a login **is** needed,
+the login is a QR scan — **ask the user to scan it** (do not attempt to
+authenticate on their behalf). Say which QR and wait.

--- a/app/skills/amazon-listing/references/1688-sourcing.md
+++ b/app/skills/amazon-listing/references/1688-sourcing.md
@@ -1,0 +1,101 @@
+# Sourcing a listing from a supplier link (1688) → filled template
+
+> **Load this when the task starts from a product link.** The goal:
+> turn a 1688 offer URL into a reviewed, filled Amazon template. The
+> agent (an LLM) does the extraction, copywriting, and review; the two
+> scripts do the deterministic OCR and template writing.
+
+## 1. Open the offer and extract core data
+
+Use the store's browser wrapper (an `-aux` session is fine — this is a
+public third-party page, not seller-central):
+
+```bash
+~/.vibe-seller/bin/<slug>/browser-use --session <slug>-aux open \
+  "https://detail.1688.com/offer/<OFFER_ID>.html?offerId=<OFFER_ID>&forcePC=1"
+```
+
+The core product data lives in the page's `window.context` JSON and the
+DOM — **no login needed** for it:
+
+```bash
+# title, price, sku props (colour/size), weight, category, detail-image url
+browser-use eval "JSON.stringify(window.context && window.context.result ? window.context.result : {}).slice(0,4000)"
+# gallery + detail image srcs
+browser-use eval "Array.from(document.images).map(i=>i.src).filter(s=>/alicdn|tmall/.test(s))"
+```
+
+Read off: the title, the **SKU property that varies** (usually Colour —
+this becomes your `variation_theme`), the size, the unit weight, the
+leaf category, and the image URLs. Login (a **QR scan**) is only needed
+for extra bulk specs — if you need it, **ask the user to scan the QR**
+and wait; do not authenticate for them. The page auto-switches to a
+Global/English view.
+
+## 2. Download the images (referer-protected)
+
+The gallery/detail CDN (`cbu01.alicdn.com`, `itemcdn.tmall.com`) rejects
+a bare `curl`. Read the `src`s from the DOM (above) and fetch each with
+a 1688 referer:
+
+```bash
+curl -sL -e "https://detail.1688.com/" -o /tmp/<task>/img_$N.webp "<img-src>"
+```
+
+Save captures to `/tmp/<task>/`, never `knowledge/` (capture rule).
+
+## 3. OCR the detail images (local, no GPU)
+
+1688 puts the spec table, feature callouts, and size/colour charts
+inside the long **description images**, not the HTML. OCR them locally:
+
+```bash
+$PY $S/ocr_1688.py /tmp/<task>/ --json --min-conf 0.6 > /tmp/<task>/ocr.json
+```
+
+`ocr_1688.py` uses `rapidocr-onnxruntime` (ONNX runtime on CPU — no GPU,
+no torch/paddle, no cloud) and reads mixed Chinese + English. WEBP is
+converted to PNG in memory. Fold the recognised lines into the
+product-info blob you pass to the copy-generation step.
+
+## 4. Generate the Amazon copy
+
+From the extracted page data + OCR text, generate:
+
+- **Title** — lead with the registered brand (from the template's
+  `brand_name` valid values), then the key nouns/specs a buyer searches;
+  respect the category's title length. Do not copy the supplier's
+  keyword-stuffed title verbatim.
+- **5 bullet points** — one benefit each, specification + why it matters.
+- **A long product description** — cover materials, use, care, sizing.
+- **Search terms** (`generic_keywords`) — short 1–2 word phrases, the
+  category essentials + differentiators; not long model numbers.
+
+Translate the source (often Chinese) into the **target marketplace
+language**. Keep the copy truthful to what the OCR/page actually say —
+do not invent specs.
+
+## 5. Bilingual review (required, interactive)
+
+Present to the user, side by side:
+
+- the generated **title / bullets / description** in **both the user's
+  language and the target marketplace language**, and
+- the **proposed parent-child structure**: the variation theme (e.g.
+  Colour), the parent SKU, and each child (colour → SKU).
+
+Wait for the user to confirm or edit. This is the one step that is
+genuinely the user's call — the copy and the variation split are
+judgement, not mechanics. Only after confirmation proceed to fill.
+
+## 6. Fill + upload
+
+Build the spec (parent + one child per confirmed colour/size) and hand
+off to the template round trip (`template-round-trip.md` §3–4): `fill`,
+upload, `parse-feedback`, iterate on row errors.
+
+The reference implementation that predates this skill
+(`AmazonListingCreator/listing_util`) fills a **single** variant and
+matches by localised label; this skill supersedes it with multi-row
+parent/child filling keyed by field API name and an explicit operation
+column.

--- a/app/skills/amazon-listing/references/template-round-trip.md
+++ b/app/skills/amazon-listing/references/template-round-trip.md
@@ -1,0 +1,170 @@
+# Listing template round trip — download → inspect → fill → upload → feedback
+
+> **Load this for any listing CRUD.** The flat-file template is
+> category-specific: the column set and valid values differ per product
+> type, so `inspect` a fresh template before filling it.
+
+## 0. The template geometry (verified on a real fptcustom template)
+
+The `Template` sheet is a wide table with a **three-row header**:
+
+```
+Excel row 1   TemplateType=fptcustom | Version | Signature | group names
+Excel row 2   Local Label Names   (LOCALISED — e.g. "Seller SKU")
+Excel row 3   field API names     (item_sku, update_delete, ...)  <-- key on THIS
+Excel row 4+  data rows
+```
+
+`listing_bulk.py` locates the field-name row structurally (the row that
+contains `item_sku`) and addresses every field by API name — **never**
+by the localised label above it. Data rows are appended from row 4.
+
+The metadata sheets are the source of truth:
+
+- **`Data Definitions`** — one row per field with `Required?`.
+- **`Valid Values`** / **`Dropdown Lists`** — the accepted enum tokens
+  (e.g. `variation_theme` ∈ {Color, color-size, Size, …}).
+- **`Browse data`** — the valid `recommended_browse_nodes` for the
+  category (a gated set; a guessed node id is rejected).
+
+## 1. Download the template
+
+Seller Central → **Catalogue → Add Products via Upload**
+(`sellercentral.amazon.<tld>/listing/upload` → `/product-search/bulk`).
+Open **Spreadsheet → Download Blank Template → Download Product
+Spreadsheet**, search the product type (e.g. "socks" → **Select**
+"Sock"), choose the language + target marketplaces, then **Generate
+Spreadsheet**. The file lands in `~/.vibe-seller/downloads/<slug>/`
+(a macro-enabled `.xlsm`).
+
+> **Product-Type search gotcha (Beta modal):** the search box is a
+> locked `kat-input` — typing the keyword alone (`browser-use input` /
+> `type`) does **not** open the candidate list. You must click the
+> **search icon** at the right of the input row to trigger the
+> suggestions, then click **Select** on the matched product type.
+
+> **The create template generates asynchronously** — "Generate
+> Spreadsheet" does not always land a direct download. If it doesn't
+> appear, use **Download Blank Template** (classic, direct), or collect
+> the generated file from **Check Upload Status** (element id
+> `spreadsheet-upload-status-kat-link`) / the account email.
+
+## 2. Inspect
+
+```bash
+$PY $S/listing_bulk.py inspect ~/.vibe-seller/downloads/<slug>/TEMPLATE.xlsm
+# one field's detail (columns / required / accepted values):
+$PY $S/listing_bulk.py inspect TEMPLATE.xlsm --field variation_theme
+```
+
+Read off: the total/required field counts, the operation column, the
+variation cluster (`parent_child`, `relationship_type`,
+`variation_theme`, `parent_sku`, `external_product_id[_type]`), and the
+required fields with their enums. `brand_name`'s valid values reveal
+the account's **registered brand** — a create must use it (brand-gated).
+
+## 3. The spec (parent + children)
+
+`fill` takes a JSON spec. Top-level `product_type` and `brand` are
+defaults applied to every row. Each row has `sku`, `operation`, and a
+`fields` map keyed by **field API name**; the friendly keys `parentage`,
+`parent_sku`, `variation_theme`, and `asin` fold into their flat-file
+fields.
+
+```json
+{
+  "product_type": "socks",
+  "brand": "ACME",
+  "rows": [
+    { "sku": "WIDGET-001", "operation": "create", "parentage": "Parent",
+      "variation_theme": "Color",
+      "fields": { "relationship_type": "Variation",
+                  "item_name": "ACME ...", "product_description": "...",
+                  "recommended_browse_nodes": "<from Valid Values>",
+                  "target_gender": "Male", "department_name": "mens",
+                  "batteries_required": "No", "are_batteries_included": "No" } },
+    { "sku": "WIDGET-001-WHT", "operation": "create", "parentage": "Child",
+      "parent_sku": "WIDGET-001", "variation_theme": "Color",
+      "fields": { "relationship_type": "Variation", "color_name": "White",
+                  "main_image_url": "https://.../white.jpg",
+                  "fulfillment_availability#1.fulfillment_channel_code": "DEFAULT",
+                  "fulfillment_availability#1.quantity": "100",
+                  "purchasable_offer[marketplace_id=<SA>]#1.our_price#1.schedule#1.value_with_tax": "29.00",
+                  "purchasable_offer[marketplace_id=<AE>]#1.our_price#1.schedule#1.value_with_tax": "29.00" } }
+  ]
+}
+```
+
+### Parent vs Child — what goes where
+
+- **Parent** row: shared catalogue data only (product type, brand,
+  title, description, `parent_child: Parent`, `relationship_type:
+  Variation`, `variation_theme`). It carries **no** offer, stock,
+  images, colour/size, or product-id — those are child-level.
+- **Child** rows: `parent_child: Child`, `parent_sku` = the parent's
+  SKU, the differentiating attribute (`color_name` / `size_name`), plus
+  the **offer** (`fulfillment_availability#1.*`) and **price**
+  (`purchasable_offer[marketplace_id=…]#1.our_price#1.schedule#1.value_with_tax`,
+  one block per target marketplace).
+
+`fill` knows this: it suppresses child-level required-field warnings on
+a Parent row, and suppresses battery/hazmat required-field warnings when
+the row declares no batteries.
+
+> **Child rows inherit the parent's catalogue attributes.** A child
+> legitimately omits `item_name`, `product_description`,
+> `recommended_browse_nodes`, gender/department/size/material/weight,
+> etc. — Amazon fills them from the parent. So `fill` WILL print
+> "missing required field(s)" warnings for those on child rows; that is
+> **expected noise, not an error** (verified live: a create with minimal
+> children — only `parent_sku`, the differentiator, offer + image —
+> returned 0 errors / 0 warnings from Amazon). Likewise
+> `external_product_id` is not needed when the brand is **GTIN-exempt**.
+> Treat child-row required warnings as informational; trust Amazon's
+> processing report for the real verdict.
+
+### The operation column
+
+`operation` maps to the `update_delete` cell: `create`→blank,
+`update`→`Update`, `partialupdate`→`partialupdate`, `delete`→`delete`.
+A **delete** row needs only `sku` + `operation: delete`. **Changing a
+parent-child relationship** is an update: re-submit the child with the
+new `parent_sku` / `variation_theme` (or clear `parent_sku` and set
+`parent_child` appropriately to detach).
+
+```bash
+$PY $S/listing_bulk.py fill TEMPLATE.xlsm --spec SPEC.json --out /tmp/<slug>/out.xlsm
+```
+
+`fill` prints a warning (never fails) for an enum value not in the
+template's valid list, a missing required field, or a field absent from
+this template — so an unseen-but-valid token from a new category still
+uploads. Read the warnings; they are the same errors Amazon would
+reject on.
+
+## 4. Upload + read the processing report
+
+Upload the `.xlsm` on the same page. Amazon processes asynchronously;
+**Check Upload Status** shows the result and a downloadable **processing
+report**. Save it to `/tmp/<slug>/` and parse it:
+
+```bash
+$PY $S/listing_bulk.py parse-feedback /tmp/<slug>/processing-report.xlsm
+```
+
+It prints per-SKU `[Error|Warning] sku=… code=…: message` and a summary
+count (exit code 1 if any error). Fix the flagged rows in the spec and
+re-fill / re-upload. Iterate until zero errors, then verify the family
+in the catalogue (parent with its children, prices, images).
+
+### First-upload gotchas (verified on a socks template)
+
+- **`recommended_browse_nodes`** is a **gated set** per category — a
+  guessed id is rejected. Pick one from the template's Valid Values /
+  `Browse data` sheet.
+- **`external_product_id` (GTIN/UPC/EAN)** is required per child. An
+  own-brand product with no barcode needs a **GTIN exemption** (applied
+  once per brand+category in Seller Central) before the create will pass.
+- Many **battery / lithium / hazmat** fields are marked Required but are
+  only *conditionally* required — leave them blank for a non-battery
+  product (set `batteries_required: No`, `are_batteries_included: No`).

--- a/app/skills/amazon-listing/requirements.txt
+++ b/app/skills/amazon-listing/requirements.txt
@@ -1,0 +1,3 @@
+openpyxl>=3.1
+rapidocr-onnxruntime>=1.3
+pillow>=10.0

--- a/app/skills/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills/amazon-listing/scripts/listing_bulk.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Amazon listing flat-file (category template) inspect + fill + feedback.
+
+Drives the "Add Products via Upload" round trip: download a category
+template (a macro-enabled `.xlsm` flat file, TemplateType=fptcustom),
+fill parent/child rows from a JSON spec, upload it, then parse the
+processing report Amazon returns.
+
+Why a script (vs. clicking the listing wizard)
+----------------------------------------------
+One template upload creates a whole variation family (a Parent plus N
+colour/size Children) in a single round trip. The per-field web wizard
+is one SKU at a time through shadow-DOM widgets. The flat file is the
+supported batch interface -- the same philosophy as `amazon-ads`'
+`ads_bulk.py`, but listing templates are **category-specific** (the
+column set differs per product type), so this tool cannot use a fixed
+positional schema. Instead it keys every field by its **field API name**
+(the row that contains `item_sku`), which is identical in every console
+language -- only the human label row above it is localised.
+
+Template geometry (verified on a real fptcustom template)
+---------------------------------------------------------
+  Excel row 1  TemplateType/Version/Signature + group names
+  Excel row 2  Local Label Names  (LOCALISED -- never keyed on)
+  Excel row 3  field API names    (item_sku, update_delete, ...) <-- keyed
+  Excel row 4+ data rows
+
+The operation column is `update_delete`:
+  blank  -> Create   (the default when no ASIN is supplied)
+  Update / partialupdate / delete
+The parent-child cluster is `parent_child` (Parent/Child),
+`relationship_type` (Variation), `variation_theme` (e.g. Color),
+`parent_sku`. Update-by-ASIN sets `external_product_id` = the ASIN and
+`external_product_id_type` = asin.
+
+The template's own sheets are the source of truth for validation:
+  'Data Definitions'  -> which fields are Required
+  'Valid Values' / 'Dropdown Lists' -> the accepted enum tokens
+
+Fill preserves the workbook verbatim (macros, data validation, the
+signature row) and only writes data rows -- Amazon's validator keys on
+that untouched header block, so we never rebuild it.
+
+Usage
+-----
+  listing_bulk.py inspect  TEMPLATE.xlsm [--field NAME]
+  listing_bulk.py fill     TEMPLATE.xlsm --spec SPEC.json --out OUT.xlsm
+  listing_bulk.py parse-feedback  REPORT[.xlsm|.txt|.csv]
+
+Requires: openpyxl.
+"""
+
+import argparse
+import json
+import shutil
+import sys
+
+try:
+    import openpyxl
+except ImportError:
+    sys.exit('error: openpyxl is required (pip install openpyxl)')
+
+
+# The Template sheet holds the flat file. Metadata lives in siblings.
+TEMPLATE_SHEET = 'Template'
+DEFN_SHEET = 'Data Definitions'
+VALID_SHEET = 'Valid Values'
+DROPDOWN_SHEET = 'Dropdown Lists'
+
+# The operation column and the tokens Amazon accepts in it. A blank
+# cell means Create -- that is the default and cannot be a literal
+# token, so callers pass operation='create' and we clear the cell.
+OP_COLUMN = 'update_delete'
+OP_TOKENS = {
+    'create': '',
+    'update': 'Update',
+    'partialupdate': 'partialupdate',
+    'delete': 'delete',
+}
+
+# Fields the caller addresses through friendly per-row keys, mapped to
+# their flat-file field API name. Everything else goes in `fields`.
+IDENTITY_FIELD = 'item_sku'
+PRODUCT_TYPE_FIELD = 'feed_product_type'
+BRAND_FIELD = 'brand_name'
+
+# A Parent (relationship) row carries only the shared catalogue data;
+# the offer, stock, images and product-id live on the Child rows. So a
+# Parent legitimately omits these even when the template marks them
+# Required -- don't warn about them for a Parent.
+CHILD_LEVEL_PREFIXES = (
+    'purchasable_offer',
+    'fulfillment_availability',
+    'main_image_url',
+    'other_image_url',
+    'swatch_image_url',
+    'external_product_id',
+    'color_name',
+    'size_name',
+    'apparel_size',
+)
+
+# Battery / hazmat / dangerous-goods fields are marked Required in the
+# Data Definitions but are only *conditionally* required -- Amazon
+# accepts them blank when the item has no batteries. Suppress the noise
+# when the row declares no batteries.
+BATTERY_TOKENS = (
+    'battery',
+    'batteries',
+    'lithium',
+    'hazmat',
+    'ghs_classification',
+    'safety_data_sheet',
+    'flash_point',
+    'supplier_declared_dg',
+    'number_of_lithium',
+)
+
+
+def _is_falsey(v):
+    return v is None or str(v).strip().lower() in ('', 'no', 'false', '0')
+
+
+def _keep_vba(path):
+    """Real Amazon templates are macro-enabled .xlsm (keep the macros and
+    the signature row); tolerate a plain .xlsx too (tests, blank forms)."""
+    return path.lower().endswith('.xlsm')
+
+
+def _find_header_row(ws, max_scan=8):
+    """Return the 1-based row index whose cells carry field API names.
+
+    Identified structurally by the presence of `item_sku`, so it works
+    regardless of console language (the label row above it is localised;
+    this row is not).
+    """
+    for r in range(1, max_scan + 1):
+        values = [c.value for c in ws[r]]
+        if IDENTITY_FIELD in values:
+            return r
+    raise ValueError(
+        f"could not find the field-name row (no '{IDENTITY_FIELD}' in the "
+        f'first {max_scan} rows) -- is this a listing flat-file template?'
+    )
+
+
+def _field_columns(ws, header_row):
+    """Map field API name -> list of 1-based column indices.
+
+    Repeated fields (bullet_point1..N are distinct, but some templates
+    reuse a bare name across marketplace-scoped offer blocks) map to
+    multiple columns; the first is used for scalar writes.
+    """
+    cols = {}
+    for cell in ws[header_row]:
+        name = cell.value
+        if name:
+            cols.setdefault(str(name), []).append(cell.column)
+    return cols
+
+
+def _load_required_fields(wb):
+    """Field API names marked Required in the Data Definitions sheet.
+
+    Data Definitions layout: header at Excel row 2, then per-field rows
+    with columns Group Name | Field Name | Local Label | Definition |
+    Accepted Values | Example | Required?.
+    """
+    if DEFN_SHEET not in wb.sheetnames:
+        return set()
+    ws = wb[DEFN_SHEET]
+    rows = list(ws.iter_rows(values_only=True))
+    required = set()
+    for row in rows[2:]:
+        if not row or len(row) < 7:
+            continue
+        field_name, req = row[1], row[6]
+        if field_name and req and str(req).strip().lower() == 'required':
+            required.add(str(field_name).strip())
+    return required
+
+
+def _load_valid_values(wb):
+    """Map field API name -> set of accepted enum tokens (lowercased).
+
+    Read from 'Dropdown Lists', whose row 3 holds field API names as
+    column headers and the rows below hold the tokens for each. Returns
+    {} silently if the sheet is absent or shaped unexpectedly -- enum
+    checks then degrade to warnings only.
+    """
+    if DROPDOWN_SHEET not in wb.sheetnames:
+        return {}
+    ws = wb[DROPDOWN_SHEET]
+    rows = list(ws.iter_rows(values_only=True))
+    if len(rows) < 4:
+        return {}
+    # The field-name header inside Dropdown Lists is the row that
+    # contains a known enum field; probe the first few rows for it.
+    hdr_idx = None
+    for i in range(min(5, len(rows))):
+        if rows[i] and OP_COLUMN in [str(c) for c in rows[i] if c]:
+            hdr_idx = i
+            break
+    if hdr_idx is None:
+        return {}
+    hdr = rows[hdr_idx]
+    out = {}
+    for ci, name in enumerate(hdr):
+        if not name:
+            continue
+        vals = set()
+        for ri in range(hdr_idx + 1, len(rows)):
+            v = rows[ri][ci] if ci < len(rows[ri]) else None
+            if v not in (None, ''):
+                vals.add(str(v).strip().lower())
+        if vals:
+            out[str(name).strip()] = vals
+    return out
+
+
+def cmd_inspect(args):
+    wb = openpyxl.load_workbook(
+        args.file, read_only=False, keep_vba=_keep_vba(args.file)
+    )
+    ws = wb[TEMPLATE_SHEET]
+    header_row = _find_header_row(ws)
+    cols = _field_columns(ws, header_row)
+    required = _load_required_fields(wb)
+    valid = _load_valid_values(wb)
+
+    def dig(name):
+        v = valid.get(name)
+        return sorted(v) if v else None
+
+    if args.field:
+        name = args.field
+        print(f'field: {name}')
+        print(f'  columns : {cols.get(name)}')
+        print(f'  required: {name in required}')
+        print(f'  values  : {dig(name)}')
+        return
+
+    tt = ws.cell(row=1, column=1).value
+    print(f'template : {tt}')
+    print(f'sheets   : {wb.sheetnames}')
+    print(f'header at Excel row {header_row}; data starts row {header_row + 1}')
+    print(f'total fields: {len(cols)}   required fields: {len(required)}')
+    print(
+        '\noperation column ({}): create=blank / {}'.format(
+            OP_COLUMN, ' / '.join(t for t in OP_TOKENS.values() if t)
+        )
+    )
+    print('\nvariation cluster:')
+    for f in (
+        'parent_child',
+        'relationship_type',
+        'variation_theme',
+        'parent_sku',
+        'external_product_id',
+        'external_product_id_type',
+    ):
+        if f in cols:
+            print(f'  {f:26} col={cols[f][0]:<4} values={dig(f)}')
+    print('\nrequired fields:')
+    for f in sorted(required):
+        print(f'  {f:30} values={dig(f)}')
+
+
+def _resolve_operation(op):
+    key = (op or 'create').strip().lower()
+    if key not in OP_TOKENS:
+        raise SystemExit(
+            f"error: operation '{op}' is not one of {', '.join(OP_TOKENS)}"
+        )
+    return OP_TOKENS[key], key
+
+
+def _row_fields(spec_row, top):
+    """Flatten one spec row into {field_api_name: value}.
+
+    Friendly per-row keys (sku, asin, parent_sku, parentage,
+    variation_theme) fold into their flat-file field names; `fields`
+    carries everything else verbatim by API name. Top-level `product_type`
+    and `brand` supply defaults when a row omits them.
+    """
+    out = dict(spec_row.get('fields') or {})
+    out.setdefault(PRODUCT_TYPE_FIELD, top.get('product_type'))
+    if top.get('brand'):
+        out.setdefault(BRAND_FIELD, top['brand'])
+    if spec_row.get('sku'):
+        out[IDENTITY_FIELD] = spec_row['sku']
+    if spec_row.get('parent_sku'):
+        out['parent_sku'] = spec_row['parent_sku']
+    if spec_row.get('parentage'):
+        out['parent_child'] = spec_row['parentage']
+    if spec_row.get('variation_theme'):
+        out['variation_theme'] = spec_row['variation_theme']
+    if spec_row.get('asin'):
+        out['external_product_id'] = spec_row['asin']
+        out.setdefault('external_product_id_type', 'asin')
+    # Drop keys with no value so we never blank an intended default.
+    return {k: v for k, v in out.items() if v not in (None, '')}
+
+
+def cmd_fill(args):
+    with open(args.spec, encoding='utf-8') as fh:
+        spec = json.load(fh)
+    rows = spec.get('rows') or []
+    if not rows:
+        raise SystemExit('error: spec has no rows')
+
+    shutil.copyfile(args.file, args.out)
+    wb = openpyxl.load_workbook(
+        args.out, read_only=False, keep_vba=_keep_vba(args.out)
+    )
+    ws = wb[TEMPLATE_SHEET]
+    header_row = _find_header_row(ws)
+    cols = _field_columns(ws, header_row)
+    required = _load_required_fields(wb)
+    valid = _load_valid_values(wb)
+
+    unknown_fields = set()
+    warnings = []
+    write_at = header_row + 1
+    # Clear any pre-existing data rows before writing the spec, so stale
+    # rows from an Example row or a previously-filled template can't be
+    # uploaded as unintended SKUs. A freshly-generated blank template has
+    # none, but a reused workbook might.
+    if ws.max_row >= write_at:
+        ws.delete_rows(write_at, ws.max_row - write_at + 1)
+    for i, spec_row in enumerate(rows):
+        op_token, op_key = _resolve_operation(spec_row.get('operation'))
+        fields = _row_fields(spec_row, spec)
+        sku = fields.get(IDENTITY_FIELD)
+        if not sku:
+            raise SystemExit(f'error: row {i} has no sku')
+
+        # Enum validation: reject an invalid operation-family token hard;
+        # warn (never fail) on other enums so an unseen-but-valid token
+        # from a new category still uploads.
+        for fname, fval in fields.items():
+            allowed = valid.get(fname)
+            if allowed and str(fval).strip().lower() not in allowed:
+                warnings.append(
+                    f'row {i} sku={sku}: {fname}={fval!r} not in template '
+                    f'valid values {sorted(allowed)}'
+                )
+
+        # Required-field guard applies to Create rows only. Update/
+        # partialupdate touch a subset; delete needs just sku+operation.
+        if op_key == 'create':
+            is_parent = str(fields.get('parent_child', '')).lower() == 'parent'
+            no_battery = _is_falsey(
+                fields.get('are_batteries_included')
+            ) and _is_falsey(fields.get('batteries_required'))
+            missing = []
+            for f in required:
+                if f not in cols or f in fields or f == OP_COLUMN:
+                    continue
+                if is_parent and f.startswith(CHILD_LEVEL_PREFIXES):
+                    continue
+                if no_battery and any(t in f for t in BATTERY_TOKENS):
+                    continue
+                missing.append(f)
+            if missing:
+                warnings.append(
+                    f'row {i} sku={sku}: missing required field(s) '
+                    f'{sorted(missing)}'
+                )
+
+        target = ws[write_at + i]
+        # Operation column: write the token (blank cell = Create).
+        if OP_COLUMN in cols:
+            target[cols[OP_COLUMN][0] - 1].value = op_token or None
+        for fname, fval in fields.items():
+            if fname not in cols:
+                unknown_fields.add(fname)
+                continue
+            target[cols[fname][0] - 1].value = fval
+
+    wb.save(args.out)
+
+    for w in warnings:
+        print(f'warning: {w}', file=sys.stderr)
+    if unknown_fields:
+        print(
+            f'warning: fields not in this template (skipped): '
+            f'{sorted(unknown_fields)}',
+            file=sys.stderr,
+        )
+    print(f'wrote {len(rows)} data row(s) -> {args.out}')
+
+
+def _iter_report_rows(path):
+    """Yield rows from a processing report (.xlsm/.xlsx or .txt/.csv)."""
+    lower = path.lower()
+    if lower.endswith(('.xlsm', '.xlsx')):
+        wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+        for name in wb.sheetnames:
+            for row in wb[name].iter_rows(values_only=True):
+                yield [('' if c is None else str(c)) for c in row]
+        return
+    delim = '\t'
+    with open(path, encoding='utf-8', errors='replace') as fh:
+        sample = fh.readline()
+        if ',' in sample and '\t' not in sample:
+            delim = ','
+        fh.seek(0)
+        for line in fh:
+            yield line.rstrip('\n').split(delim)
+
+
+def cmd_parse_feedback(args):
+    """Summarise Amazon's processing report: per-SKU errors/warnings.
+
+    Report layouts vary (a summary header block then a table). We locate
+    the table header by finding a row that names an error/SKU column,
+    then emit each data row's SKU + type + message. Falls back to
+    printing every row that mentions 'error' if no header is found.
+    """
+    rows = list(_iter_report_rows(args.file))
+    if not rows:
+        raise SystemExit('error: empty report')
+
+    def idx_of(header, *needles):
+        for j, cell in enumerate(header):
+            c = cell.strip().lower()
+            if any(n in c for n in needles):
+                return j
+        return None
+
+    hdr_i = None
+    for i, row in enumerate(rows):
+        joined = ' '.join(row).lower()
+        if ('error' in joined or 'sku' in joined) and (
+            'sku' in joined or 'record' in joined
+        ):
+            hdr_i = i
+            break
+
+    n_err = n_warn = 0
+    if hdr_i is not None:
+        header = rows[hdr_i]
+        c_sku = idx_of(header, 'sku')
+        c_type = idx_of(header, 'error type', 'type', 'severity')
+        c_msg = idx_of(header, 'message', 'error message', 'description')
+        c_code = idx_of(header, 'code')
+        print(f'report table header at row {hdr_i}: {header}')
+        for row in rows[hdr_i + 1 :]:
+            if not any(cell.strip() for cell in row):
+                continue
+            sku = row[c_sku] if c_sku is not None and c_sku < len(row) else ''
+            typ = (
+                row[c_type] if c_type is not None and c_type < len(row) else ''
+            )
+            msg = row[c_msg] if c_msg is not None and c_msg < len(row) else ''
+            code = (
+                row[c_code] if c_code is not None and c_code < len(row) else ''
+            )
+            tl = typ.strip().lower()
+            if tl == 'error' or 'error' in tl:
+                n_err += 1
+            elif 'warn' in tl:
+                n_warn += 1
+            print(f'  [{typ or "?"}] sku={sku} code={code}: {msg}')
+    else:
+        print('(no structured table found; rows mentioning "error")')
+        for row in rows:
+            if 'error' in ' '.join(row).lower():
+                print('  ' + ' | '.join(row))
+                n_err += 1
+
+    print(f'\nsummary: {n_err} error(s), {n_warn} warning(s)')
+    if n_err:
+        sys.exit(1)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    sub = ap.add_subparsers(dest='cmd', required=True)
+
+    p = sub.add_parser('inspect', help='dump fields / required / enums')
+    p.add_argument('file')
+    p.add_argument('--field', help='detail for one field API name')
+    p.set_defaults(func=cmd_inspect)
+
+    p = sub.add_parser('fill', help='write parent/child rows from a spec')
+    p.add_argument('file', help='the category template (.xlsm)')
+    p.add_argument('--spec', required=True, help='JSON spec of rows')
+    p.add_argument('--out', required=True, help='output .xlsm path')
+    p.set_defaults(func=cmd_fill)
+
+    p = sub.add_parser('parse-feedback', help='summarise a processing report')
+    p.add_argument('file')
+    p.set_defaults(func=cmd_parse_feedback)
+
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/app/skills/amazon-listing/scripts/ocr_1688.py
+++ b/app/skills/amazon-listing/scripts/ocr_1688.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Local, GPU-free OCR for 1688 product detail images.
+
+1688 puts a product's spec table, feature callouts, and size/colour
+charts inside the *description images* (long JPEG/WEBP strips), not in
+the page HTML. To generate an accurate Amazon title / bullets /
+description we OCR those images. This runs fully local with no GPU and
+no cloud vision API: `rapidocr-onnxruntime` (ONNX runtime,
+CPUExecutionProvider) reads mixed Chinese + English.
+
+Why not a cloud vision model: the detail strips are private supplier
+data and there can be a dozen per offer; a local pass keeps them off
+third-party services and costs nothing per image.
+
+Usage
+-----
+  ocr_1688.py IMAGE_OR_DIR [IMAGE_OR_DIR ...] [--json] [--min-conf 0.5]
+
+Prints the recognised text per image (WEBP is converted to PNG in
+memory first). With --json, emits {path: [lines]} for a downstream
+fill step to fold into the product-info blob.
+
+Requires: rapidocr-onnxruntime, pillow.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+# Heavy, optional deps — shipped via the skill's requirements.txt and
+# installed per-user, not in the test/CI env. Import once at module load
+# so a missing dep yields a clean message rather than a mid-run crash.
+try:
+    import numpy as np
+    from PIL import Image
+    from rapidocr_onnxruntime import RapidOCR
+except ImportError:  # pragma: no cover - exercised only when deps absent
+    np = Image = RapidOCR = None
+
+VALID_EXT = ('.png', '.jpg', '.jpeg', '.webp', '.bmp')
+
+
+def _iter_images(paths):
+    for p in paths:
+        if os.path.isdir(p):
+            for root, _dirs, files in os.walk(p):
+                for name in sorted(files):
+                    if name.lower().endswith(VALID_EXT):
+                        yield os.path.join(root, name)
+        elif p.lower().endswith(VALID_EXT):
+            yield p
+        else:
+            print(f'skip (not an image): {p}', file=sys.stderr)
+
+
+def _load_rgb(path):
+    """Return a numpy RGB array; converts WEBP/other via Pillow."""
+    with Image.open(path) as im:
+        return np.array(im.convert('RGB'))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    ap.add_argument('paths', nargs='+', help='image files or directories')
+    ap.add_argument(
+        '--json', action='store_true', help='emit {path: [lines]} JSON'
+    )
+    ap.add_argument(
+        '--min-conf',
+        type=float,
+        default=0.5,
+        help='drop lines below this confidence (default 0.5)',
+    )
+    args = ap.parse_args()
+
+    if RapidOCR is None:
+        sys.exit(
+            'error: rapidocr-onnxruntime + pillow are required '
+            '(pip install rapidocr-onnxruntime pillow)'
+        )
+
+    ocr = RapidOCR()
+    out = {}
+    for path in _iter_images(args.paths):
+        try:
+            img = _load_rgb(path)
+        except Exception as e:  # noqa: BLE001 - report and continue
+            print(f'error reading {path}: {e}', file=sys.stderr)
+            continue
+        result, _elapsed = ocr(img)
+        lines = []
+        for entry in result or []:
+            # rapidocr returns [box, text, confidence] per line.
+            text, conf = entry[1], float(entry[2])
+            if conf >= args.min_conf and text.strip():
+                lines.append(text.strip())
+        out[path] = lines
+        if not args.json:
+            print(f'\n=== {path} ({len(lines)} lines) ===')
+            for ln in lines:
+                print(ln)
+
+    if args.json:
+        print(json.dumps(out, ensure_ascii=False, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -31,7 +31,30 @@ Python FastAPI backend serving the REST API, managing browser sessions, and exec
 | `plugins.py` | Plugin framework (IoC registry) — core reads gates/guards/backends/skills/services from here instead of hardcoding them. See [Plugin Framework](#plugin-framework). |
 | `builtin_plugin.py` | The OSS "builtin plugin" — registers every core contribution through the plugin API. |
 | `utils/` | Shared utilities (crypto, etc.) |
-| `platform.py` | Cross-platform abstractions (Windows/macOS/Linux) — psutil-based process management (`kill_process`, `find_processes_by_pattern`), venv path helpers (`Scripts/` vs `bin/`, `venv_python`, `venv_executable`), `prepend_to_path` (uses `os.pathsep`), `safe_chmod` (no-op on Windows). Centralises every platform difference so the rest of the code stays platform-agnostic. See [Cross-platform support](subsystems.md#cross-platform-support-native-windows). |
+| `platform.py` | Cross-platform abstractions (Windows/macOS/Linux) — psutil-based process management (`kill_process`, `find_processes_by_pattern`, `reap_task_agents`, `collect_agent_descendants`), venv path helpers (`Scripts/` vs `bin/`, `venv_python`, `venv_executable`), `prepend_to_path` (uses `os.pathsep`), `safe_chmod` (no-op on Windows). Centralises every platform difference so the rest of the code stays platform-agnostic. See [Cross-platform support](subsystems.md#cross-platform-support-native-windows). |
+
+### Shutdown cleanup — reaping task agents
+
+A running task is a `claude -p` subprocess tree (claude → MCP server →
+`skill_cli.daemon` → browser-use). Stopping the server must take that
+whole tree down; a survivor keeps calling `POST /stores/<id>/browser/start`
+on the next server and, because the anti-detect browser client is a
+single shared process, competing survivors thrash it. Two layers ensure
+no orphans:
+
+- **`ClaudeCodeBackend.stop_all()`** (`ai/claude_backend_manager.py`) —
+  stops every running `AgentSession` (each `stop()` killpg's its subtree;
+  Windows uses `taskkill /F /T` via `process_utils.taskkill_tree`).
+  Wired into `main.py`'s `lifespan` shutdown so a graceful SIGTERM never
+  orphans an agent.
+- **`platform.reap_task_agents(pids=None)`** — a process-level backstop
+  for the paths that bypass graceful shutdown (a SIGKILL of the server;
+  Windows `TerminateProcess` from `vibe-seller stop` / the tray
+  quit-restart). Matches the headless-agent, `skill_cli.daemon`, and
+  running-wrapper signatures and kills each with its child tree.
+  `vibe-seller stop` scopes it with `collect_agent_descendants(server_pid)`
+  (snapshotted before the kill) so a second server instance's agents are
+  left alone.
 
 ## Request Flow
 

--- a/stop.sh
+++ b/stop.sh
@@ -1,11 +1,65 @@
 #!/bin/bash
 
-# Stop vibe-seller server
+# Stop vibe-seller server (and its task agents)
 # Usage: ./stop.sh           # stops port 7777 (default)
 #        ./stop.sh 7780     # stops port 7780
 #        ./stop.sh --all    # stops all uvicorn app.main:app processes from this project
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Reap any task agents / browser daemons that outlived the server.
+#
+# A running task is a `claude -p` subprocess tree (claude -> MCP server
+# -> skill_cli.daemon -> browser-use). The server's graceful (SIGTERM)
+# shutdown killpg's these via agent_manager.stop_all(); but a SIGKILL of
+# the server bypasses that, and an orphaned agent then keeps calling
+# `browser/start` on the next server, thrashing the shared Ziniao client
+# (each relaunch tears down other stores' browsers). So we always reap
+# as a backstop. Patterns are specific to vibe-seller's headless agent
+# (the `--output-format stream-json --input-format stream-json` combo,
+# which interactive Claude Code never uses) and its browser daemons, so
+# an unrelated Claude session is never touched.
+reap_agents() {
+    local agent_pat='output-format stream-json --input-format stream-json'
+    # A running wrapper poll-loop: the wrapper path followed by a
+    # browser-use subcommand. Requiring the subcommand keeps this from
+    # matching an editor merely viewing the wrapper script.
+    local wrapper_pat='\.vibe-seller/bin/[^ ]*/browser-use (eval|open|state|click|close|screenshot|type|input|keys|sessions|get|extract|scroll|wait|hover|dblclick|rightclick|select|upload|back)'
+    local scan="skill_cli.daemon|$agent_pat|$wrapper_pat"
+    local n_before
+    n_before=$(pgrep -f "$scan" 2>/dev/null | wc -l | tr -d ' ')
+    if [ "${n_before:-0}" -gt 0 ]; then
+        echo "Reaping $n_before orphaned task agent(s)/daemon(s)/wrapper(s)..."
+        # Kill the agent's whole process group so its subtree goes too.
+        for pid in $(pgrep -f "$agent_pat" 2>/dev/null); do
+            kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null
+        done
+        pkill -TERM -f 'skill_cli.daemon' 2>/dev/null
+        pkill -TERM -f "$wrapper_pat" 2>/dev/null
+        sleep 2
+        for pid in $(pgrep -f "$agent_pat" 2>/dev/null); do
+            kill -KILL -- "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null
+        done
+        pkill -KILL -f 'skill_cli.daemon' 2>/dev/null
+        pkill -KILL -f "$wrapper_pat" 2>/dev/null
+        local n_after
+        n_after=$(pgrep -f "$scan" 2>/dev/null | wc -l | tr -d ' ')
+        echo "  task agents/daemons/wrappers remaining: ${n_after:-0}"
+    fi
+}
+
+# Stop a server PID gracefully (SIGTERM -> lifespan shutdown reaps its
+# own agents), escalating to SIGKILL only if it does not exit in time.
+stop_pid_graceful() {
+    local pid="$1"
+    kill -TERM "$pid" 2>/dev/null
+    for _ in $(seq 1 20); do   # up to ~10s
+        kill -0 "$pid" 2>/dev/null || return 0
+        sleep 0.5
+    done
+    echo "  PID $pid did not exit on SIGTERM; sending SIGKILL"
+    kill -9 "$pid" 2>/dev/null
+}
 
 if [ "${1:-}" = "--all" ]; then
     echo "Stopping all vibe-seller servers..."
@@ -24,9 +78,13 @@ if [ "${1:-}" = "--all" ]; then
         echo "No running servers found."
     else
         echo "Stopping PIDs: $pids..."
-        echo "$pids" | xargs kill -9 2>/dev/null
+        for pid in $pids; do
+            stop_pid_graceful "$pid"
+        done
         echo "All servers stopped."
     fi
+
+    reap_agents
 
     # Clean up pid files
     rm -f "$SCRIPT_DIR"/.pids_*
@@ -37,14 +95,21 @@ PORT="${1:-7777}"
 
 echo "Stopping server on port $PORT..."
 
-# Kill processes using the port
-lsof -ti:"$PORT" 2>/dev/null | xargs kill -9 2>/dev/null
+# Gracefully stop processes using the port (SIGTERM first so the
+# server's shutdown handler reaps its task agents), then SIGKILL.
+for pid in $(lsof -ti:"$PORT" 2>/dev/null); do
+    stop_pid_graceful "$pid"
+done
 
-# Also kill by PID file if exists
+# Also stop by PID file if it exists
 PID_FILE="$SCRIPT_DIR/.pids_$PORT"
 if [ -f "$PID_FILE" ]; then
-    cat "$PID_FILE" | xargs kill -9 2>/dev/null
+    for pid in $(cat "$PID_FILE"); do
+        stop_pid_graceful "$pid"
+    done
     rm -f "$PID_FILE"
 fi
+
+reap_agents
 
 echo "Server on port $PORT stopped."

--- a/tests/unit/test_agent_stop_all.py
+++ b/tests/unit/test_agent_stop_all.py
@@ -1,0 +1,60 @@
+"""Unit test for ClaudeCodeBackend.stop_all().
+
+Pins the shutdown contract that prevents orphaned task agents: on
+server shutdown, every RUNNING session is stopped (each session's
+stop() killpg's its `claude -p` subtree), idle/finished sessions are
+left alone, and one session raising never blocks the rest. Orphaned
+agents keep hitting `browser/start` on the next server and thrash the
+shared Ziniao client, so this contract is load-bearing.
+"""
+
+from unittest import mock
+
+import pytest
+
+from app.ai.claude_backend_manager import ClaudeCodeBackend
+
+pytestmark = pytest.mark.unit
+
+
+def _session(running: bool):
+    s = mock.MagicMock()
+    s.running = running
+    s.stop = mock.AsyncMock()
+    return s
+
+
+@pytest.mark.asyncio
+async def test_stop_all_stops_only_running_sessions():
+    mgr = ClaudeCodeBackend()
+    run1, run2, idle = _session(True), _session(True), _session(False)
+    mgr._sessions = {'t1': run1, 't2': run2, 't3': idle}
+
+    stopped = await mgr.stop_all()
+
+    assert stopped == 2
+    run1.stop.assert_awaited_once()
+    run2.stop.assert_awaited_once()
+    idle.stop.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stop_all_is_resilient_to_one_failure():
+    mgr = ClaudeCodeBackend()
+    good, bad = _session(True), _session(True)
+    bad.stop = mock.AsyncMock(side_effect=RuntimeError('boom'))
+    mgr._sessions = {'good': good, 'bad': bad}
+
+    # Must not raise even though one session's stop() blows up.
+    stopped = await mgr.stop_all()
+
+    assert stopped == 2
+    good.stop.assert_awaited_once()
+    bad.stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_all_no_running_sessions_returns_zero():
+    mgr = ClaudeCodeBackend()
+    mgr._sessions = {'t1': _session(False)}
+    assert await mgr.stop_all() == 0

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -1,0 +1,422 @@
+"""Unit tests for the amazon-listing skill's scripts/listing_bulk.py.
+
+Pins the invariants that make the flat-file listing tool trustworthy:
+
+* **Locale-generality** — the tool keys every field by its field API
+  name (the row containing `item_sku`), never by the localised label
+  row above it. The synthetic template here puts **Chinese** labels in
+  that row and asserts every operation still works.
+* **The operation column** — `create` leaves `update_delete` blank,
+  and `update` / `partialupdate` / `delete` write their tokens.
+* **Parent-child shape** — a Parent row carries the variation theme and
+  no offer; a Child row carries `parent_sku`, the differentiator, and
+  the price; the Parent is not warned about child-level required fields.
+* **Validation** — an out-of-enum value and a missing required field
+  each raise a warning (never a hard failure), so an unseen-but-valid
+  token from a new category still writes.
+
+All test data is fabricated — no real store, brand, SKU, or ASIN.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+openpyxl = pytest.importorskip('openpyxl')
+
+_SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / 'app'
+    / 'skills'
+    / 'amazon-listing'
+    / 'scripts'
+    / 'listing_bulk.py'
+)
+_spec = importlib.util.spec_from_file_location('listing_bulk', _SKILL_PATH)
+listing_bulk = importlib.util.module_from_spec(_spec)
+sys.modules['listing_bulk'] = listing_bulk
+_spec.loader.exec_module(listing_bulk)
+
+
+# Field API names in column order. Localised labels sit one row above
+# them (Chinese here) — the tool must ignore the labels entirely.
+FIELDS = [
+    'feed_product_type',
+    'item_sku',
+    'update_delete',
+    'brand_name',
+    'external_product_id',
+    'external_product_id_type',
+    'item_name',
+    'product_description',
+    'recommended_browse_nodes',
+    'main_image_url',
+    'parent_child',
+    'relationship_type',
+    'variation_theme',
+    'parent_sku',
+    'color_name',
+    'batteries_required',
+    'are_batteries_included',
+    'fulfillment_availability#1.quantity',
+    'purchasable_offer[marketplace_id=MKTSA]#1.our_price#1.schedule#1.value_with_tax',
+]
+ZH_LABELS = {
+    'feed_product_type': '产品类型',
+    'item_sku': '卖家SKU',
+    'update_delete': '更新删除',
+    'brand_name': '品牌名称',
+    'item_name': '商品名称',
+    'color_name': '颜色',
+    'parent_child': '父子关系',
+    'variation_theme': '变体主题',
+}
+REQUIRED = {
+    'feed_product_type',
+    'item_sku',
+    'brand_name',
+    'item_name',
+    'product_description',
+    'recommended_browse_nodes',
+    'external_product_id',
+    'external_product_id_type',
+    'main_image_url',
+    'batteries_required',
+    'battery_type',  # battery_type: conditional
+    'fulfillment_availability#1.quantity',
+    'purchasable_offer[marketplace_id=MKTSA]#1.our_price#1.schedule#1.value_with_tax',
+}
+ENUMS = {
+    'update_delete': ['Update', 'partialupdate', 'delete'],
+    'parent_child': ['Parent', 'Child'],
+    'relationship_type': ['Variation'],
+    'variation_theme': ['Color', 'Size', 'color-size'],
+    'external_product_id_type': ['asin', 'upc', 'ean', 'gtin'],
+    'recommended_browse_nodes': ['111', '222', '333'],
+}
+
+
+def _make_template(path):
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = listing_bulk.TEMPLATE_SHEET
+    # Row 1: signature/group row (decorative). Row 2: localised labels.
+    # Row 3: field API names. Row 4+: data (empty in a blank template).
+    ws.append(['TemplateType=fptcustom', 'Version=test'])
+    ws.append([ZH_LABELS.get(f, f) for f in FIELDS])
+    ws.append(list(FIELDS))
+
+    # Data Definitions: header at row 2, then per-field rows.
+    dd = wb.create_sheet(listing_bulk.DEFN_SHEET)
+    dd.append(['How to complete your inventory template'])
+    dd.append([
+        'Group Name',
+        'Field Name',
+        'Local Label Name',
+        'Definition and Use',
+        'Accepted Values',
+        'Example',
+        'Required?',
+    ])
+    for f in FIELDS + ['battery_type']:
+        dd.append([
+            '',
+            f,
+            ZH_LABELS.get(f, f),
+            '',
+            '',
+            '',
+            'Required' if f in REQUIRED else 'Optional',
+        ])
+
+    # Dropdown Lists: field names on row 3, tokens below each column.
+    dl = wb.create_sheet(listing_bulk.DROPDOWN_SHEET)
+    dl.append([])
+    dl.append([])
+    enum_fields = list(ENUMS)
+    dl.append(enum_fields)
+    for i in range(max(len(v) for v in ENUMS.values())):
+        dl.append([
+            ENUMS[f][i] if i < len(ENUMS[f]) else None for f in enum_fields
+        ])
+    wb.save(path)
+
+
+@pytest.fixture
+def template(tmp_path):
+    p = tmp_path / 'template.xlsx'
+    _make_template(str(p))
+    return str(p)
+
+
+def _run(args):
+    ns = listing_bulk.argparse.Namespace
+    parser_map = {
+        'inspect': listing_bulk.cmd_inspect,
+        'fill': listing_bulk.cmd_fill,
+        'parse-feedback': listing_bulk.cmd_parse_feedback,
+    }
+    # Route through the real argv parser so the test exercises main().
+    old = sys.argv
+    sys.argv = ['listing_bulk.py'] + args
+    try:
+        listing_bulk.main()
+    finally:
+        sys.argv = old
+    return ns, parser_map  # unused; kept for clarity
+
+
+def _read_rows(path):
+    wb = openpyxl.load_workbook(path)
+    ws = wb[listing_bulk.TEMPLATE_SHEET]
+    names = [c.value for c in ws[3]]
+    idx = {n: i for i, n in enumerate(names)}
+    rows = []
+    for r in ws.iter_rows(min_row=4, values_only=True):
+        if any(c is not None for c in r):
+            rows.append({n: r[idx[n]] for n in names})
+    return rows
+
+
+def _spec(tmp_path, rows):
+    p = tmp_path / 'spec.json'
+    p.write_text(json.dumps(rows), encoding='utf-8')
+    return str(p)
+
+
+def test_header_found_by_field_name_not_localised_label(template):
+    wb = openpyxl.load_workbook(template)
+    ws = wb[listing_bulk.TEMPLATE_SHEET]
+    # Header row is row 3 (field names), NOT row 2 (Chinese labels).
+    assert listing_bulk._find_header_row(ws) == 3
+    required = listing_bulk._load_required_fields(wb)
+    assert 'item_sku' in required and 'brand_name' in required
+    valid = listing_bulk._load_valid_values(wb)
+    assert valid['parent_child'] == {'parent', 'child'}
+    assert 'delete' in valid['update_delete']
+
+
+def test_fill_operation_column(template, tmp_path):
+    spec = {
+        'product_type': 'socks',
+        'brand': 'ACME',
+        'rows': [
+            {
+                'sku': 'W-1',
+                'operation': 'create',
+                'fields': {'item_name': 'ACME Thing'},
+            },
+            {
+                'sku': 'W-2',
+                'operation': 'update',
+                'fields': {'item_name': 'ACME Thing 2'},
+            },
+            {
+                'sku': 'W-3',
+                'operation': 'partialupdate',
+                'fields': {'item_name': 'ACME Thing 3'},
+            },
+            {'sku': 'W-4', 'operation': 'delete'},
+        ],
+    }
+    out = str(tmp_path / 'out.xlsx')
+    _run(['fill', template, '--spec', _spec(tmp_path, spec), '--out', out])
+    rows = _read_rows(out)
+    by_sku = {r['item_sku']: r for r in rows}
+    assert by_sku['W-1']['update_delete'] in (None, '')  # create = blank
+    assert by_sku['W-2']['update_delete'] == 'Update'
+    assert by_sku['W-3']['update_delete'] == 'partialupdate'
+    assert by_sku['W-4']['update_delete'] == 'delete'
+    # brand default applied to every row.
+    assert all(r['brand_name'] == 'ACME' for r in rows)
+
+
+def test_parent_child_structure(template, tmp_path):
+    spec = {
+        'product_type': 'socks',
+        'brand': 'ACME',
+        'rows': [
+            {
+                'sku': 'P-1',
+                'operation': 'create',
+                'parentage': 'Parent',
+                'variation_theme': 'Color',
+                'fields': {
+                    'relationship_type': 'Variation',
+                    'item_name': 'ACME Socks',
+                    'product_description': 'desc',
+                    'recommended_browse_nodes': '111',
+                    'batteries_required': 'No',
+                    'are_batteries_included': 'No',
+                },
+            },
+            {
+                'sku': 'P-1-WHT',
+                'operation': 'create',
+                'parentage': 'Child',
+                'parent_sku': 'P-1',
+                'variation_theme': 'Color',
+                'fields': {
+                    'relationship_type': 'Variation',
+                    'color_name': 'White',
+                    'item_name': 'ACME Socks White',
+                    'product_description': 'desc',
+                    'recommended_browse_nodes': '111',
+                    'external_product_id': '00012345678905',
+                    'external_product_id_type': 'upc',
+                    'main_image_url': 'https://example.com/w.jpg',
+                    'batteries_required': 'No',
+                    'are_batteries_included': 'No',
+                    'fulfillment_availability#1.quantity': '100',
+                    'purchasable_offer[marketplace_id=MKTSA]#1.our_price'
+                    '#1.schedule#1.value_with_tax': '29.00',
+                },
+            },
+        ],
+    }
+    out = str(tmp_path / 'out.xlsx')
+    _run(['fill', template, '--spec', _spec(tmp_path, spec), '--out', out])
+    rows = _read_rows(out)
+    parent = next(r for r in rows if r['item_sku'] == 'P-1')
+    child = next(r for r in rows if r['item_sku'] == 'P-1-WHT')
+    assert parent['parent_child'] == 'Parent'
+    assert parent['variation_theme'] == 'Color'
+    assert parent['parent_sku'] in (None, '')  # parent has no parent
+    price_col = (
+        'purchasable_offer[marketplace_id=MKTSA]#1.our_price'
+        '#1.schedule#1.value_with_tax'
+    )
+    assert parent[price_col] in (None, '')  # offer is child-level
+    assert child['parent_child'] == 'Child'
+    assert child['parent_sku'] == 'P-1'
+    assert child['color_name'] == 'White'
+    assert str(child[price_col]) == '29.00'
+
+
+def test_parent_not_warned_for_child_level_required(template, tmp_path, capsys):
+    """A Parent row omitting offer/price/image/product-id must NOT be
+    flagged — those are child-level. A Child omitting them must be."""
+    spec = {
+        'product_type': 'socks',
+        'brand': 'ACME',
+        'rows': [
+            {
+                'sku': 'P-1',
+                'operation': 'create',
+                'parentage': 'Parent',
+                'variation_theme': 'Color',
+                'fields': {
+                    'relationship_type': 'Variation',
+                    'item_name': 'ACME Socks',
+                    'product_description': 'desc',
+                    'recommended_browse_nodes': '111',
+                    'batteries_required': 'No',
+                    'are_batteries_included': 'No',
+                },
+            },
+        ],
+    }
+    out = str(tmp_path / 'out.xlsx')
+    _run(['fill', template, '--spec', _spec(tmp_path, spec), '--out', out])
+    err = capsys.readouterr().err
+    # Parent: no complaint about child-level fields...
+    assert 'external_product_id' not in err
+    assert 'our_price' not in err
+    assert 'main_image_url' not in err
+    # ...and no complaint about battery_type (declared no batteries).
+    assert 'battery_type' not in err
+
+
+def test_out_of_enum_and_missing_required_warn_not_fail(
+    template, tmp_path, capsys
+):
+    spec = {
+        'product_type': 'socks',
+        'brand': 'ACME',
+        'rows': [
+            {
+                'sku': 'W-1',
+                'operation': 'create',
+                'variation_theme': 'PurpleHaze',  # not in enum
+                'fields': {'relationship_type': 'Variation'},
+            },  # missing lots
+        ],
+    }
+    out = str(tmp_path / 'out.xlsx')
+    _run(['fill', template, '--spec', _spec(tmp_path, spec), '--out', out])
+    err = capsys.readouterr().err
+    assert 'PurpleHaze' in err  # enum warning
+    assert 'not in template valid values' in err
+    assert 'missing required field' in err  # required warning
+    # File still written despite warnings.
+    assert Path(out).exists()
+    assert _read_rows(out)[0]['variation_theme'] == 'PurpleHaze'
+
+
+def test_asin_folds_into_product_id(template, tmp_path):
+    spec = {
+        'product_type': 'socks',
+        'brand': 'ACME',
+        'rows': [
+            {
+                'sku': 'W-1',
+                'operation': 'update',
+                'asin': 'B0ABCDE123',
+                'fields': {'item_name': 'x'},
+            },
+        ],
+    }
+    out = str(tmp_path / 'out.xlsx')
+    _run(['fill', template, '--spec', _spec(tmp_path, spec), '--out', out])
+    row = _read_rows(out)[0]
+    assert row['external_product_id'] == 'B0ABCDE123'
+    assert row['external_product_id_type'] == 'asin'
+
+
+def test_fill_clears_preexisting_data_rows(template, tmp_path):
+    """A reused template with a stale data row must not upload it —
+    fill clears the data area before writing the spec rows."""
+    wb = openpyxl.load_workbook(template)
+    ws = wb[listing_bulk.TEMPLATE_SHEET]
+    # Row 4 (first data row): a stale SKU from a prior run.
+    ws.append(['socks', 'STALE-SKU'] + [''] * (len(FIELDS) - 2))
+    wb.save(template)
+
+    spec = {
+        'product_type': 'socks',
+        'brand': 'ACME',
+        'rows': [
+            {
+                'sku': 'W-NEW',
+                'operation': 'create',
+                'fields': {'item_name': 'x'},
+            },
+        ],
+    }
+    out = str(tmp_path / 'out.xlsx')
+    _run(['fill', template, '--spec', _spec(tmp_path, spec), '--out', out])
+    skus = [r['item_sku'] for r in _read_rows(out)]
+    assert 'STALE-SKU' not in skus
+    assert skus == ['W-NEW']
+
+
+def test_parse_feedback(tmp_path, capsys):
+    report = tmp_path / 'report.txt'
+    report.write_text(
+        'original-record-number\tsku\terror-type\terror-code\t'
+        'error-message\n'
+        '4\tW-1\tError\t8541\tMissing required field external_product_id\n'
+        '5\tW-2\tWarning\t90220\tImage will be reviewed\n',
+        encoding='utf-8',
+    )
+    with pytest.raises(SystemExit) as ei:  # exit 1 because an error
+        _run(['parse-feedback', str(report)])
+    assert ei.value.code == 1
+    out = capsys.readouterr().out
+    assert 'W-1' in out and 'external_product_id' in out
+    assert '1 error(s), 1 warning(s)' in out

--- a/tests/unit/test_reap_task_agents.py
+++ b/tests/unit/test_reap_task_agents.py
@@ -1,0 +1,161 @@
+"""Unit test for platform.reap_task_agents().
+
+The cross-platform backstop that kills orphaned task-agent process trees
+when the server is stopped without a graceful shutdown (notably Windows
+TerminateProcess, which `vibe-seller stop` / the tray quit-restart use).
+Pins: it matches only the vibe-seller headless-agent / browser-daemon
+signatures (never an unrelated Claude session), kills each match plus its
+child tree, and never kills its own pid.
+"""
+
+from unittest import mock
+
+import pytest
+
+from app import platform as plat
+
+pytestmark = pytest.mark.unit
+
+
+def _proc(pid, cmdline):
+    p = mock.MagicMock()
+    p.info = {'pid': pid, 'cmdline': cmdline}
+    p.pid = pid
+    p.children = mock.MagicMock(return_value=[])
+    p.terminate = mock.MagicMock()
+    p.kill = mock.MagicMock()
+    return p
+
+
+@pytest.mark.asyncio
+async def test_reaps_agent_and_daemon_not_unrelated(monkeypatch):
+    agent = _proc(
+        101,
+        [
+            'claude',
+            '-p',
+            '--output-format',
+            'stream-json',
+            '--input-format',
+            'stream-json',
+        ],
+    )
+    child = _proc(102, ['browser-use', 'open', 'https://x'])
+    agent.children = mock.MagicMock(return_value=[child])
+    daemon = _proc(103, ['python', '-m', 'browser_use.skill_cli.daemon'])
+    # Orphaned wrapper poll-loop (reparented after an ungraceful -9).
+    wrapper = _proc(
+        106,
+        [
+            'bash',
+            '/home/u/.vibe-seller/bin/acme-store/browser-use',
+            'eval',
+            'var',
+        ],
+    )
+    interactive = _proc(104, ['claude'])  # a plain Claude session
+    editor = _proc(105, ['vim', 'notes.txt'])  # unrelated
+    # An editor VIEWING the wrapper script — references the path but has
+    # no browser-use subcommand, so it must NOT be reaped.
+    editor_wrapper = _proc(
+        107, ['vim', '/home/u/.vibe-seller/bin/acme-store/browser-use']
+    )
+
+    procs = [agent, child, daemon, wrapper, interactive, editor, editor_wrapper]
+    monkeypatch.setattr(plat.psutil, 'process_iter', lambda attrs=None: procs)
+    monkeypatch.setattr(
+        plat.psutil, 'wait_procs', lambda ps, timeout=None: (ps, [])
+    )
+    monkeypatch.setattr(plat.os, 'getpid', lambda: 999)
+
+    reaped = await plat.reap_task_agents()
+
+    # Three roots matched (agent + daemon + orphaned wrapper loop); the
+    # interactive claude, the editor, and an editor merely viewing the
+    # wrapper script are left alone.
+    assert reaped == 3
+    agent.terminate.assert_called_once()
+    child.terminate.assert_called_once()  # child tree of the agent
+    daemon.terminate.assert_called_once()
+    wrapper.terminate.assert_called_once()
+    interactive.terminate.assert_not_called()
+    editor.terminate.assert_not_called()
+    editor_wrapper.terminate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pids_scoping_only_reaps_given_roots(monkeypatch):
+    """With pids=, only the given roots (+ their trees) are reaped —
+    process_iter is not even scanned. Pins the multi-server safety fix:
+    `vibe-seller stop` reaps only the stopped server's own agents."""
+    mine = _proc(201, ['claude', '-p', '--output-format', 'stream-json'])
+    other = _proc(202, ['claude', '-p', '--output-format', 'stream-json'])
+
+    def _proc_by_pid(pid):
+        return {201: mine, 202: other}[pid]
+
+    monkeypatch.setattr(plat.psutil, 'Process', _proc_by_pid)
+    monkeypatch.setattr(
+        plat.psutil, 'wait_procs', lambda ps, timeout=None: (ps, [])
+    )
+    monkeypatch.setattr(plat.os, 'getpid', lambda: 999)
+    # process_iter must NOT be consulted when pids is given.
+    monkeypatch.setattr(
+        plat.psutil,
+        'process_iter',
+        lambda attrs=None: (_ for _ in ()).throw(AssertionError('scanned')),
+    )
+
+    reaped = await plat.reap_task_agents(pids={201})
+
+    assert reaped == 1
+    mine.terminate.assert_called_once()
+    other.terminate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_never_reaps_self(monkeypatch):
+    me = _proc(
+        999,
+        [
+            'claude',
+            '-p',
+            '--output-format',
+            'stream-json',
+            '--input-format',
+            'stream-json',
+        ],
+    )
+    monkeypatch.setattr(plat.psutil, 'process_iter', lambda attrs=None: [me])
+    monkeypatch.setattr(
+        plat.psutil, 'wait_procs', lambda ps, timeout=None: (ps, [])
+    )
+    monkeypatch.setattr(plat.os, 'getpid', lambda: 999)
+
+    assert await plat.reap_task_agents() == 0
+    me.terminate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_force_kills_survivors(monkeypatch):
+    agent = _proc(
+        201,
+        [
+            'claude',
+            '-p',
+            '--output-format',
+            'stream-json',
+            '--input-format',
+            'stream-json',
+        ],
+    )
+    monkeypatch.setattr(plat.psutil, 'process_iter', lambda attrs=None: [agent])
+    # Survives terminate → must be force-killed.
+    monkeypatch.setattr(
+        plat.psutil, 'wait_procs', lambda ps, timeout=None: ([], list(ps))
+    )
+    monkeypatch.setattr(plat.os, 'getpid', lambda: 999)
+
+    await plat.reap_task_agents()
+    agent.terminate.assert_called_once()
+    agent.kill.assert_called_once()


### PR DESCRIPTION
## Summary

Two changes:

1. **`amazon-listing` skill** — Amazon listing CRUD via the category
   flat-file ("Add Products via Upload"). One `.xlsm` round trip
   creates/updates/deletes a whole variation family (a parent + N
   colour/size children).
   - `scripts/listing_bulk.py`: `inspect` (fields / required / enums /
     variation cluster), `fill` (parent+child rows, per-row operation
     column create/update/partialupdate/delete, enum + required-field
     validation from the template's own metadata sheets, macros
     preserved), `parse-feedback` (per-SKU errors from the processing
     report).
   - `scripts/ocr_1688.py`: local, GPU-free OCR (rapidocr-onnxruntime)
     of supplier detail images.
   - `SKILL.md` + references (`template-round-trip`, `1688-sourcing`):
     supplier link → extract → OCR → generate copy → bilingual review →
     parent-child → fill → upload → feedback.
   - Keyed by **field API name**, so it is locale-independent (same
     principle as `amazon-ads/ads_bulk.py`).

2. **Server shutdown reaps task agents (all OSes)** — stopping/
   restarting the server used to leave running `claude -p` task-agent
   trees alive. An orphaned agent keeps calling `browser/start` on the
   next server and, because the anti-detect browser client is a single
   shared process, two orphans on different stores thrash it every ~37s
   (it presented as "the browser env crashes ~40s after launch").
   - `agent_manager.stop_all()` wired into the `lifespan` shutdown.
   - `stop.sh` SIGTERMs first (graceful path runs), then reaps leftovers.
   - Cross-platform `platform.reap_task_agents()` called from
     `vibe-seller stop` — covers native Windows + tray quit/restart,
     where `TerminateProcess` bypasses the graceful lifespan.
   - `_force_kill` uses `taskkill /F /T` on Windows to kill the whole
     tree (killpg is Unix-only).

## Testing

- New unit tests: `test_amazon_listing_bulk_skill` (locale-generality
  via a non-Latin label row, the operation column, parent/child shape,
  warn-not-fail validation), `test_agent_stop_all`, `test_reap_task_agents`.
- Full unit tier green.
- **Live end-to-end** on a real Seller Central account: generated the
  category template, filled a parent + two colour children, uploaded,
  and parsed Amazon's processing summary — **3/3 SKUs created, 0 errors
  / 0 warnings** — then deleted all three via an `operation=delete`
  round trip (**3/3, 0 errors**). Zero browser thrash throughout,
  confirming the shutdown-reap fix.

All fixtures/tests use placeholder brands/SKUs (e.g. `ACME`,
`WIDGET-001`); no account-specific data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
