### PR TITLE
fix(frontend): preserve newlines in agent question prompts

### DIFF
--- a/frontend/src/__tests__/QuestionBannerRender.test.tsx
+++ b/frontend/src/__tests__/QuestionBannerRender.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { createRef } from 'react'
+
+// The component calls useTranslation(); stub it so the test renders the
+// REAL QuestionBanner without a full i18n provider.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}))
+
+import { QuestionBanner } from '../components/QuestionBanner'
+
+function renderReal(question: string) {
+  const noop = () => {}
+  return render(
+    <QuestionBanner
+      bannerRef={createRef<HTMLDivElement>()}
+      questions={[{ header: 'H', question, options: [{ label: 'OK' }] }]}
+      selectedAnswers={{}}
+      showOtherInput={{}}
+      otherInputs={{}}
+      onSelectAnswer={noop}
+      onToggleOther={noop}
+      onSetOtherAnswer={noop}
+      onSubmitAll={noop}
+    />,
+  )
+}
+
+describe('QuestionBanner markdown rendering', () => {
+  it('preserves single-newline line breaks as <br> (the run-on-wall fix)', () => {
+    const { container } = renderReal('line A\nline B\nline C')
+    // Without preserveBreaks these collapse to one line (0 <br>).
+    expect(container.querySelectorAll('br').length).toBeGreaterThanOrEqual(2)
+    const text = container.textContent || ''
+    expect(text).toContain('line A')
+    expect(text).toContain('line C')
+  })
+
+  it('renders CommonMark bold + lists', () => {
+    const { container } = renderReal('**bold text**\n\n- item one\n- item two')
+    expect(container.querySelector('strong')?.textContent).toBe('bold text')
+    expect(container.querySelectorAll('li').length).toBe(2)
+  })
+
+  it('renders GFM tables (remark-gfm)', () => {
+    const { container } = renderReal('| C1 | C2 |\n|----|----|\n| a | b |')
+    expect(container.querySelector('table')).not.toBeNull()
+    expect(container.querySelectorAll('td').length).toBe(2)
+  })
+})

--- a/frontend/src/components/QuestionBanner.tsx
+++ b/frontend/src/components/QuestionBanner.tsx
@@ -8,7 +8,9 @@ import remarkGfm from 'remark-gfm'
 // bilingual sections, etc.). Markdown treats a single newline as a soft
 // break — it collapses to a space — so the text renders as one run-on
 // wall. Promote each newline to a hard break (two trailing spaces) so
-// the author's line structure survives, while GFM handles bold/lists/hr.
+// the author's line structure survives. (Bold/italic/lists/hr are plain
+// CommonMark; remark-gfm below adds the GFM extensions — tables,
+// strikethrough, task lists, autolinks.)
 function preserveBreaks(text: string): string {
   return (text || '').replace(/\n/g, '  \n')
 }

--- a/frontend/src/components/QuestionBanner.tsx
+++ b/frontend/src/components/QuestionBanner.tsx
@@ -2,6 +2,16 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { RefObject } from 'react'
 import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+// Agents write question text with single "\n" line breaks (bullets,
+// bilingual sections, etc.). Markdown treats a single newline as a soft
+// break — it collapses to a space — so the text renders as one run-on
+// wall. Promote each newline to a hard break (two trailing spaces) so
+// the author's line structure survives, while GFM handles bold/lists/hr.
+function preserveBreaks(text: string): string {
+  return (text || '').replace(/\n/g, '  \n')
+}
 
 interface Question {
   header?: string
@@ -55,7 +65,9 @@ export function QuestionBanner({
                     </span>
                   )}
                   <div className="text-sm font-medium text-gray-800 prose prose-sm max-w-none prose-p:my-1 prose-li:my-0.5 prose-ul:my-1 prose-headings:text-sm prose-headings:my-1">
-                    <Markdown>{q.question}</Markdown>
+                    <Markdown remarkPlugins={[remarkGfm]}>
+                      {preserveBreaks(q.question)}
+                    </Markdown>
                   </div>
                 </div>
                 {/* Options */}


### PR DESCRIPTION
## Problem
Agent `AskUserQuestion` prompts (e.g. the amazon-listing **bilingual review**) are written with single `\n` line breaks. `QuestionBanner` rendered them via `<Markdown>` with no plugins, and Markdown treats a single newline as a *soft break* (collapses to a space) — so a multi-line prompt (bullets, bilingual sections, proposed parent-child) rendered as **one run-on wall with no line breaks**.

## Fix
- Promote each newline to a Markdown **hard break** (two trailing spaces) so the author's line structure survives.
- Pass `remarkGfm` (already a dependency, used by every other Markdown render in the app) so bold / lists / horizontal rules render too.

**No backend change** — the API already returns the formatted text with newlines; only the render was dropping them.

## Testing
- `tsc -b` clean (the QuestionBanner change type-checks; only pre-existing unrelated errors remain).
- The existing `QuestionBanner.test.tsx` uses a mock component and is unaffected.
- Full build + frontend-test run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)