### PR TITLE
fix(ziniao): actionable localized hint for new-device login check

### DIFF
--- a/app/routers/ziniao_accounts.py
+++ b/app/routers/ziniao_accounts.py
@@ -205,6 +205,15 @@ async def list_browsers(
     # whatever Ziniao says, pass it through.
     if status_code != '0':
         err_msg = (result.get('err') or '').strip()
+        if '新终端登录' in err_msg:
+            # Ziniao's new-device security check. Not a WebDriver /
+            # credentials problem — the user must approve the device by
+            # logging into Ziniao manually once. Surface a structured
+            # status so the UI shows a localized, actionable hint.
+            raise HTTPException(
+                status_code=502,
+                detail=json.dumps({'status': 'new_terminal_login'}),
+            )
         if status_code == '-10003':
             # Keep the structured "no_permission" status so the UI can
             # still show the "enable WebDriver" link, but include the

--- a/app/routers/ziniao_accounts.py
+++ b/app/routers/ziniao_accounts.py
@@ -198,11 +198,15 @@ async def list_browsers(
         )
 
     status_code = str(result.get('statusCode', ''))
-    # Surface Ziniao's own error message ("err" field) verbatim. The
-    # statusCode is not 1:1 with a single failure mode — Ziniao reuses
-    # -10003 for both "BOSS account hasn't enabled WebDriver" and
-    # "wrong company name", and other codes have similar overlap. So
-    # whatever Ziniao says, pass it through.
+    # Default: surface Ziniao's own error message ("err" field)
+    # verbatim. The statusCode is not 1:1 with a single failure mode —
+    # Ziniao reuses -10003 for both "BOSS account hasn't enabled
+    # WebDriver" and "wrong company name", and other codes have similar
+    # overlap. So whatever Ziniao says, pass it through — EXCEPT for a
+    # few signatures below (new-device login check) that we deliberately
+    # map to structured statuses so the UI can show a localized,
+    # actionable hint instead of a raw Chinese string. Keep those
+    # mappings when refactoring.
     if status_code != '0':
         err_msg = (result.get('err') or '').strip()
         if '新终端登录' in err_msg:

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -462,6 +462,12 @@ function ZiniaoSection(props: {
               <button onClick={() => p.fetchBrowserProfiles(p.selectedZiniaoAccountId)} className="px-3 py-1 bg-red-600 text-white rounded text-xs hover:bg-red-700">{t('common.refresh')}</button>
             </div>
           </div>
+        ) : zs?.status === 'new_terminal_login' ? (
+          // Ziniao new-device security check: manual login approval needed.
+          <div className="flex flex-col items-center justify-center py-6 px-4 bg-amber-50 rounded-lg border border-amber-200">
+            <p className="text-sm font-medium text-amber-700 mb-3 break-words text-center">{t('settings.ziniaoNewTerminalLogin')}</p>
+            <button onClick={() => p.fetchBrowserProfiles(p.selectedZiniaoAccountId)} className="px-3 py-1 bg-amber-600 text-white rounded text-xs hover:bg-amber-700">{t('common.refresh')}</button>
+          </div>
         ) : p.browserFetchError === 'connect_error' || (zs && !['no_profiles'].includes(zs.status)) ? (
           // Fallback connect error. Platform UI keys off serverPlatform.
           <div className="flex flex-col items-center justify-center py-6 px-4 bg-red-50 rounded-lg border border-red-200">

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -364,6 +364,7 @@
     "ziniaoDownloadZiniao": "Download Ziniao",
     "ziniaoNoPermission": "WebDriver is not enabled for this account.",
     "ziniaoNoPermissionHint": "The BOSS account must enable WebDriver in the developer console.",
+    "ziniaoNewTerminalLogin": "Ziniao detected a login from a new device. Please open Ziniao manually to complete login verification, then come back and retry.",
     "ziniaoEnableWebDriver": "How to enable WebDriver",
     "ziniaoRestartFailed": "Failed to restart. Please close Ziniao manually and try again.",
     "ziniaoConnectErrorMac": "Cannot connect to Ziniao. Please check if Ziniao is installed.",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -364,6 +364,7 @@
     "ziniaoDownloadZiniao": "下载紫鸟",
     "ziniaoNoPermission": "此账号未开通 WebDriver 权限。",
     "ziniaoNoPermissionHint": "需要由 BOSS 主账号在开发者控制台中开启 WebDriver。",
+    "ziniaoNewTerminalLogin": "系统检测到您在新终端登录，请人工打开紫鸟进行登录验证后回到本系统重试。",
     "ziniaoEnableWebDriver": "如何开通 WebDriver",
     "ziniaoRestartFailed": "重启失败，请手动关闭紫鸟后重试。",
     "ziniaoConnectErrorMac": "无法连接紫鸟，请检查是否已安装。",


### PR DESCRIPTION
## What

When Ziniao's **new-device security check** triggers during store binding, its `getBrowserList` response returns a Chinese `err` string (`系统检测到您在新终端登录`). Previously `list_browsers` passed this through raw as `Ziniao API error: …`, so the UI showed an unclassified, non-actionable message in Chinese only — even for English users.

This detects the new-terminal signature and surfaces a **localized, actionable hint** telling the user to open Ziniao manually, complete login verification, then retry.

## Why (design)

The failure mode was leaking to the UI as an unclassified passthrough string. This moves the contract into code: the backend now returns a **typed status** (`new_terminal_login`), matching the existing `no_permission` / `credentials_error` pattern, and the frontend renders it deliberately with i18n rather than dumping raw text.

## Changes

- **`app/routers/ziniao_accounts.py`** — `list_browsers` detects `新终端登录` in Ziniao's `err` and returns structured `{status: new_terminal_login}` instead of the raw `Ziniao API error: …` string.
- **`frontend/src/components/Sidebar.tsx`** — dedicated render branch for `new_terminal_login` (amber panel + Refresh), placed before the generic connect-error fallback so it isn't swallowed. `App.tsx` already forwards any structured `status.status` through, so no change needed there.
- **i18n** — new `settings.ziniaoNewTerminalLogin` key:
  - **zh**: `系统检测到您在新终端登录，请人工打开紫鸟进行登录验证后回到本系统重试。`
  - **en**: `Ziniao detected a login from a new device. Please open Ziniao manually to complete login verification, then come back and retry.`

Matches on the substring `新终端登录` to tolerate slight wording variants (`系统检测到…` vs `检测到…`).

## Test plan

- [ ] Bind a store on an account that trips Ziniao's new-device check → amber hint shown (not raw `Ziniao API error`).
- [ ] Verify hint text switches between zh / en with UI language.
- [ ] Existing `no_permission` / connect-error / normal-mode branches unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)