### PR TITLE
ci: rename 'Release to PyPI' workflow to 'Release'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release to PyPI
+name: Release
 
 # Triggered by a `v*` tag. Seven stages, fail-fast:
 #


### PR DESCRIPTION
The release workflow does more than publish to PyPI — it runs the Windows in-place upgrade gate, builds wheels, builds the Windows installer, publishes to TestPyPI + verifies, publishes to PyPI + verifies, and drafts the GitHub Release with assets. `Release to PyPI` was confusing/underselling.

Changes only the workflow `name:` (display label). File path (`release.yml`) and the `v*` tag trigger are unchanged, so the release mechanism is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)