### PR TITLE
feat(skills_v2): add qianniu (Taobao/Tmall) skill family

### DIFF
--- a/app/skills_v2/MANIFEST.txt
+++ b/app/skills_v2/MANIFEST.txt
@@ -37,3 +37,11 @@ noon-ads/SKILL.md
 noon-ads/references/ads-creation.md
 noon-ads/references/ads-tuning.md
 noon-ads/references/ads-keyword-research.md
+qianniu-shared/SKILL.md
+qianniu-listing/SKILL.md
+qianniu-listing/scripts/listing_bulk.py
+qianniu-listing/requirements.txt
+qianniu-ads/SKILL.md
+qianniu-ads/references/mechanics.md
+qianniu-ads/scripts/ads_report.py
+qianniu-ads/requirements.txt

--- a/app/skills_v2/qianniu-ads/SKILL.md
+++ b/app/skills_v2/qianniu-ads/SKILL.md
@@ -61,5 +61,6 @@ plan table, and export the 报表 for the same window.
 ## What this skill is NOT
 
 - Not listings — that's `qianniu-listing` (商品 Excel round trip).
-- Not 生意参谋 retail reports — that's `qianniu-reports`.
+- Not 生意参谋 (sycm) retail reports — a separate concern (no skill ships for
+  it yet).
 - Never applies a 计划 change; the human reviews and executes every write.

--- a/app/skills_v2/qianniu-ads/SKILL.md
+++ b/app/skills_v2/qianniu-ads/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: qianniu-ads
+description: "Taobao/Tmall 万相台无界 (one.alimama.com) ad analysis + campaign (计划) CRUD for a 千牛 store. Load before any browser-use action that reviews, audits, tunes, or reports on 万相台 计划 — 广告优化 / 每日(每周)广告优化 / 'review the ads' / adjust 计划. Analysis is bulk-first: download 报表 exports and parse them, rather than scraping the UI. Plan create/edit/delete is surfaced for HUMAN review, never auto-executed. Decision thresholds live in the store's ads-rules.md, never in this skill. Requires qianniu-shared for login + navigation."
+allowed-tools: Bash(browser-use:*)
+requires: [qianniu-shared]
+---
+
+# Qianniu (Taobao/Tmall) Ads — 万相台无界 catalog
+
+> **PREREQUISITE:** `../qianniu-shared/SKILL.md` — 万相台 is reached by **SSO
+> from the 千牛 session** (no second login); the popup-close rule and the 0.13
+> heredoc CLI apply.
+
+This is a **catalog**: procedure + report shape live in the references. The
+loop is — pull the performance data, find the 计划 worth scaling and the
+products bleeding money, and **recommend** the change; **the human applies
+it**. **Analysis is read-only; this skill never auto-executes a 计划 change.**
+
+## Bulk-first: analyze from 报表 exports, not the UI
+
+万相台's **报表** exports are the performance source of truth (the plan list
+itself warns 「页面数据仅供参考，历史推广数据以报表数据为准」). Default flow:
+
+1. **Download the 报表** for the audit window (`报表` on `one.alimama.com`;
+   export lands in `~/.vibe-seller/downloads/<slug>/`, GB18030 CSV or `.xlsx`).
+2. **Parse it** — `scripts/ads_report.py FILE` normalises the rows (计划/宝贝
+   × 花费/成交/ROI/点击…) into TSV for the analysis.
+3. Read the **live plan list** (`references/mechanics.md`) only for *current
+   state* (状态 / 每日预算 / 出价 / target) that the report doesn't carry.
+
+The plan-list DOM scrape in `mechanics.md` is the **fallback** for state the
+report lacks — not the primary data path.
+
+## References — load what the task needs
+
+| File | When |
+|---|---|
+| [`references/mechanics.md`](references/mechanics.md) | any 万相台 read: routes (`#!/manage/onesite` etc.), date-window selector, plan-list extraction per 场景, the 报表 export flow, and the APPLY-phase (write) actions kept for review. |
+
+## Decision thresholds are per-store, not here
+
+What counts as "scale" (加投) or "cut" (删除) — ROI floors, spend caps,
+lookback — is **store-specific** and lives in `stores/<slug>/ads-rules.md`
+(same pattern as `amazon-ads`). This skill carries **mechanics only**; read
+the store's rules for the numbers. Do not bake thresholds into the skill.
+
+## Safety rails ⚠️
+
+- **Analysis/audit phases are read-only.** Toggling a 计划, editing 每日预算,
+  changing 出价, deleting a product — all **writes**. Surface them as a
+  recommendation for the user to review; **never auto-execute.**
+- Never click a promo CTA (开通/升级/领取/报名…) — see `qianniu-shared § 4`.
+- Save exports/captures to `/tmp/<task>/`; never `knowledge/` or `stores/`.
+
+## Default analysis window
+
+Last 30 days unless the user specifies otherwise. Set the 万相台 date selector
+(今日 / 昨日 / 过去 7 天 / 过去 15 天 / 自定义) to match **before** reading the
+plan table, and export the 报表 for the same window.
+
+## What this skill is NOT
+
+- Not listings — that's `qianniu-listing` (商品 Excel round trip).
+- Not 生意参谋 retail reports — that's `qianniu-reports`.
+- Never applies a 计划 change; the human reviews and executes every write.

--- a/app/skills_v2/qianniu-ads/references/mechanics.md
+++ b/app/skills_v2/qianniu-ads/references/mechanics.md
@@ -1,0 +1,93 @@
+# 万相台无界 — mechanics (routes, date window, plan-list read, 报表 export)
+
+How to *read* live 万相台 state on `one.alimama.com`. All APPLY actions
+(toggle / 预算 edit / delete) are at the end and are **writes — forbidden
+during analysis; surface for review, never auto-execute.** Drive everything
+with the 0.13 heredoc CLI (`qianniu-shared`): `new_tab`, `js(...)`,
+`click_at_xy`, `cdp(...)`. Run the popup-close loop after every load.
+
+## 1. Routes (hash SPA — `new_tab` then wait ~5-8 s)
+
+| Page | Route |
+|---|---|
+| 万相台 home | `https://one.alimama.com/index.html` |
+| 报表 (reports) | open from the home nav 报表 (route varies by version) |
+| 货品全站推广 plan list | `#!/manage/onesite` |
+| 关键词推广 plan list | `#!/manage/search` |
+| 人群推广 plan list | `#!/manage/display` |
+| 店铺直达 plan list | `#!/manage/shop` |
+| 内容营销 plan list | `#!/manage/content` |
+| plan detail | `#!/manage/onesite-detail?...&campaignId=<计划ID>` |
+
+SSO from the 千牛 session (`qianniu-shared`); no separate login. A redirect to
+the Taobao login means the session died → **human step** (QR / slider+SMS).
+
+## 2. Date window
+
+Above the KPI block: 今日 / 昨日 / 过去 7 天 / 过去 15 天 / 自定义. Select the
+one matching the audit window **before** reading the plan table — the per-plan
+metric columns follow this selector. Export the 报表 for the same window.
+
+## 3. 报表 export (the performance source of truth — DEFAULT)
+
+The plan list warns 「页面数据仅供参考，历史推广数据以报表数据为准」, so treat
+the **报表 export** as truth for performance and the plan list as *live state*
+(状态 / 预算 / 出价). Flow:
+
+1. Open 报表 from the 万相台 nav; pick the report (e.g. 计划报表 / 商品报表) and
+   the date window.
+2. Trigger the export/download (a **read**). It lands in
+   `~/.vibe-seller/downloads/<slug>/` — CSV is **GB18030** (`qianniu-shared § 5`),
+   `.xlsx` is fine.
+3. Parse with `scripts/ads_report.py FILE` → normalised TSV (计划/宝贝 ×
+   花费/成交金额/ROI/点击/展现…), keyed by the export's own headers.
+
+## 4. Plan-list extraction (fallback — for state the report lacks)
+
+The list renders as TWO `<table>`s: the one whose text contains `宝贝信息` is
+the header; the **next** table is the body. Data rows contain `计划ID`; total
+is `共 N 项数据` (page size 40 — paginate for N > 40). Run via `js(...)`:
+
+```bash
+~/.vibe-seller/bin/<slug>/browser-use <<'PY'
+print(js(r"""
+var tables=[...document.querySelectorAll('table')];
+var hi=tables.findIndex(function(t){return (t.innerText||'').indexOf('宝贝信息')>=0});
+var body=tables[hi+1]; var out=[];
+[...body.querySelectorAll('tbody tr')].forEach(function(r){
+  var t=r.innerText; if(t.indexOf('计划ID')<0) return;
+  var td=[...r.querySelectorAll('td')].map(c=>c.innerText.replace(/\s+/g,' ').trim());
+  out.push({
+    product_id:(t.match(/宝贝ID：(\d+)/)||[])[1],
+    campaign_id:(t.match(/计划ID：(\d+)/)||[])[1],
+    name:(t.match(/计划：\d+丨([^\n]+)/)||[])[1]||'',
+    budget:td[5], bid_mode:td[6], goal:td[7], roi:td[8], spend:td[10]
+  });
+});
+return JSON.stringify({count:out.length, plans:out});
+"""))
+PY
+```
+
+**§4's snippet is `#!/manage/onesite` ONLY.** Other 场景 have different DOM:
+
+| Route | Body table | Plan ↔ product |
+|---|---|---|
+| `onesite` 货品全站推广 | `tables[hi+1]`; row text has 宝贝ID：/计划ID： | 1 plan ↔ 1 宝贝 |
+| `search` 关键词推广 | no 宝贝信息 header; plan_id = trailing digits | keywords, not one 宝贝 |
+| `display` 人群推广 | `tables[3]`; plan_id in `campaignId=` attr | group / multi-product |
+| `shop` 店铺直达 | `tables[1]`; plan_id in `campaignId=` attr | store-level |
+| `content` 内容营销 | `tables[1]`; plan_id in `campaignId=` attr | content |
+
+## 5. Promo overlays
+
+万相台 pops 大促/公告 overlays that eat clicks — run the `qianniu-shared § 4`
+close loop after every route change; if a synthetic `.click()` fails, dispatch
+a trusted `cdp('Input.dispatchMouseEvent', ...)` at the X's centre.
+
+## 6. APPLY actions — WRITES (surface for review, never auto-execute)
+
+Toggling 状态, editing 每日预算 / 出价, adding/removing a product or keyword,
+新建计划, and 自动规则 changes are all **writes**. During an audit they are
+**forbidden**: produce a recommendation (which 计划, what change, why, per the
+store's `ads-rules.md`) and let the human apply it in the visible window.

--- a/app/skills_v2/qianniu-ads/requirements.txt
+++ b/app/skills_v2/qianniu-ads/requirements.txt
@@ -1,0 +1,1 @@
+openpyxl

--- a/app/skills_v2/qianniu-ads/requirements.txt
+++ b/app/skills_v2/qianniu-ads/requirements.txt
@@ -1,1 +1,1 @@
-openpyxl
+openpyxl>=3.1

--- a/app/skills_v2/qianniu-ads/scripts/ads_report.py
+++ b/app/skills_v2/qianniu-ads/scripts/ads_report.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Parse a 万相台无界 报表 export into normalised TSV.
+
+Reads a 计划/商品 report exported from one.alimama.com (a GB18030 CSV or an
+`.xlsx`), locates the header row by its own Chinese labels, and emits a
+normalised, tab-separated table (stable English keys) to stdout for the
+audit. Header-keyed, so it survives column reordering / new columns.
+
+Usage
+-----
+  ads_report.py REPORT.csv            # or REPORT.xlsx
+  ads_report.py REPORT.csv --raw      # dump the detected headers + first rows
+
+Note: Taobao/Tmall CSV exports are GB18030, not UTF-8 (see qianniu-shared).
+Requires: openpyxl (only for .xlsx).
+"""
+
+import argparse
+import csv
+import sys
+
+try:
+    import openpyxl
+except ImportError:  # only needed for .xlsx reports
+    openpyxl = None
+
+# Normalised key <- any header substring that denotes it. First match wins.
+FIELD_MAP = [
+    ('campaign_id', ('计划ID', '计划 ID')),
+    ('campaign', ('计划名', '计划名称', '计划')),
+    ('product_id', ('宝贝ID', '商品ID')),
+    ('spend', ('花费', '消耗')),
+    ('gmv', ('成交金额', '总成交金额', '净成交金额')),
+    ('roi', ('投产比', 'ROI', 'roi')),
+    ('orders', ('成交笔数', '总成交笔数')),
+    ('clicks', ('点击量', '点击数')),
+    ('ctr', ('点击率',)),
+    ('impressions', ('展现量', '展现数')),
+    ('cpc', ('平均点击花费', '点击花费')),
+]
+HEADER_TOKENS = ('花费', '成交', '计划', '宝贝', '点击', '展现', '投产比')
+
+
+def _rows_from_file(path):
+    """Yield the raw rows (list of str) from a CSV (gb18030) or xlsx."""
+    if path.lower().endswith(('.xlsx', '.xlsm')):
+        if openpyxl is None:
+            raise SystemExit(
+                'error: openpyxl is required for .xlsx (pip install openpyxl)'
+            )
+        wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+        ws = wb[wb.sheetnames[0]]
+        for row in ws.iter_rows(values_only=True):
+            yield [('' if c is None else str(c)) for c in row]
+        wb.close()
+        return
+    # CSV — Taobao exports are GB18030; fall back to utf-8-sig.
+    for enc in ('gb18030', 'utf-8-sig'):
+        try:
+            with open(path, encoding=enc, newline='') as fh:
+                yield from csv.reader(fh)
+            return
+        except UnicodeDecodeError:
+            continue
+    raise SystemExit('error: could not decode CSV as GB18030 or UTF-8')
+
+
+def _find_header(rows, max_scan=8):
+    for i, r in enumerate(rows[:max_scan]):
+        if sum(any(tok in c for tok in HEADER_TOKENS) for c in r) >= 2:
+            return i
+    raise SystemExit('error: could not locate the report header row')
+
+
+def _col_index(headers):
+    """Map normalised key -> column index (first header substring match)."""
+    out = {}
+    for key, needles in FIELD_MAP:
+        for i, h in enumerate(headers):
+            if any(n in h for n in needles):
+                out[key] = i
+                break
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    ap.add_argument('file')
+    ap.add_argument('--raw', action='store_true', help='dump headers + sample')
+    args = ap.parse_args()
+
+    rows = list(_rows_from_file(args.file))
+    if not rows:
+        raise SystemExit('error: empty report')
+    hi = _find_header(rows)
+    headers = [c.strip() for c in rows[hi]]
+    if args.raw:
+        print('header row', hi, ':', ' | '.join(h for h in headers if h))
+        for r in rows[hi + 1 : hi + 4]:
+            print('  ', ' | '.join(r))
+        return
+
+    idx = _col_index(headers)
+    keys = [k for k, _ in FIELD_MAP if k in idx]
+    if not keys:
+        raise SystemExit(
+            'error: no known metric columns found — run with --raw to see the '
+            'actual headers and extend FIELD_MAP'
+        )
+    w = csv.writer(sys.stdout, delimiter='\t', lineterminator='\n')
+    w.writerow(keys)
+    n = 0
+    for r in rows[hi + 1 :]:
+        if not any(c.strip() for c in r):
+            continue
+        vals = [r[idx[k]].strip() if idx[k] < len(r) else '' for k in keys]
+        if not any(vals):
+            continue
+        w.writerow(vals)
+        n += 1
+    print(f'# {n} rows, columns: {", ".join(keys)}', file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/app/skills_v2/qianniu-listing/SKILL.md
+++ b/app/skills_v2/qianniu-listing/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: qianniu-listing
+description: "Taobao/Tmall 千牛 listing (商品) CRUD via the Excel bulk round trip — 商品管理 → 更多批量操作 → excel商品批量导出 (export) → edit the workbook → excel商品批量编辑 / 批量导入 (import). One round trip creates/edits many 商品 at once (price, stock, title, attributes). Load before any browser-use action that lists, edits, prices, restocks, or bulk-updates 商品 on a 千牛 store. Prefer this bulk flow over per-item clicking; the single-item 发布商品 wizard is the fallback. Requires qianniu-shared for login + navigation."
+allowed-tools: Bash(browser-use:*)
+requires: [qianniu-shared]
+---
+
+# Qianniu (Taobao/Tmall) — Listing CRUD (Excel bulk round trip)
+
+> **PREREQUISITE:** `../qianniu-shared/SKILL.md` (chrome login is a HUMAN
+> step; the popup-close rule; page map; per-store download dir; GB18030 CSV;
+> the 0.13 heredoc CLI + `cdp()`-not-in-`js()` gotcha).
+
+千牛 **商品管理** has a first-class **Excel bulk** surface — the batch
+equivalent of the per-item 发布/编辑 wizard, and the default for touching
+more than one 商品. Entry point (verified live 2026-07-03): 商品管理 (`https://
+myseller.taobao.com/home.htm/SellManage/on_sale`) → **更多批量操作** →
+
+| Menu item | Purpose |
+|---|---|
+| **excel商品批量导出** | **download** the selected/all 商品 as an `.xlsx` workbook |
+| **excel商品批量编辑** | download the editable workbook (edit → re-upload) |
+| **批量导入** | **upload** the edited workbook to apply changes |
+| 批量编辑商品属性 / 批量设置运费 | scoped batch edits (attributes / shipping) |
+
+## Work it like a human: export → inspect → edit → import → verify
+
+The workbook's exact columns are **category-specific and change over time** —
+do NOT hardcode them. Run the loop a human runs (same philosophy as
+`amazon-listing`):
+
+1. **Export a fresh workbook** (`excel商品批量导出`) for the target 商品. It
+   lands in `~/.vibe-seller/downloads/<slug>/`.
+2. **`inspect` it** — `listing_bulk.py inspect WORKBOOK.xlsx` dumps the header
+   row + the columns actually present (商品ID, 商品标题, 价格, 库存, the SKU
+   sub-table, etc.). The header names are the ground truth, not this doc.
+3. **`fill`** — set values **by header name** for the rows you're changing
+   (`listing_bulk.py fill … --spec spec.json --out out.xlsx`). Touch only the
+   columns you mean to change; leave the rest as exported.
+4. **Import** the edited workbook (`批量导入`) — **a WRITE; only after the user
+   has reviewed the diff.** Then read the import result.
+5. **Verify on the source of truth, not the submit toast:** re-open 商品管理
+   (or the 商品 detail) and confirm the change landed. Import results also
+   surface a per-row success/failure list — read it and fix exactly the rows/
+   fields it flags, then re-import (self-correct loop).
+
+> **Read-only vs write.** Export + inspect + verify are reads. **Import
+> (`批量导入`) is a write** — surface the intended change for the user to
+> review before uploading; never auto-import.
+
+## The script
+
+```bash
+S=<skills>/qianniu-listing/scripts
+PY=<project-venv>/bin/python3     # needs openpyxl
+```
+
+- **`listing_bulk.py`** — header-keyed Excel round-trip helper (locale-robust:
+  keys by the export's own column headers, never by position):
+  - `inspect WORKBOOK.xlsx` — find the header row, dump every column name + the
+    row count; flags the identity column (商品ID/宝贝ID) and the SKU sub-table.
+  - `fill WORKBOOK.xlsx --spec SPEC.json --out OUT.xlsx` — for each spec row
+    (matched by 商品ID), set the named columns; preserve every other cell
+    verbatim so the import only changes what you intended.
+  - `parse-import RESULT.xlsx` — summarise the import result workbook into
+    per-row 成功/失败 + the failure reason (the self-correct signal).
+
+`SPEC.json` shape (values keyed by the workbook's **own** header names, from
+`inspect`; use realistic placeholders — never a real 商品ID/SKU/brand):
+
+```json
+{
+  "rows": [
+    { "商品ID": "600000000001", "fields": { "价格": "199.00", "库存": "50" } },
+    { "商品ID": "600000000002", "fields": { "价格": "89.00" } }
+  ]
+}
+```
+
+## Single-item fallback
+
+For a one-off change with no bulk column, use the UI: 商品管理 → the row's
+编辑, or 发布商品 for a new 商品 (a multi-step wizard). Drive it with the 0.13
+CLI (`click_at_xy` after a screenshot; `js(...)` to read state) per
+`qianniu-shared`. Still a **write** → user review first.
+
+## What this skill is NOT
+
+- Not ads — that's `qianniu-ads` (万相台无界).
+- Not 生意参谋 reports — that's `qianniu-reports`.
+- Never auto-imports or publishes; the human reviews every write.

--- a/app/skills_v2/qianniu-listing/SKILL.md
+++ b/app/skills_v2/qianniu-listing/SKILL.md
@@ -13,8 +13,8 @@ requires: [qianniu-shared]
 
 千牛 **商品管理** has a first-class **Excel bulk** surface — the batch
 equivalent of the per-item 发布/编辑 wizard, and the default for touching
-more than one 商品. Entry point (verified live 2026-07-03): 商品管理 (`https://
-myseller.taobao.com/home.htm/SellManage/on_sale`) → **更多批量操作** →
+more than one 商品. Entry point (verified live 2026-07-03): 商品管理
+(`https://myseller.taobao.com/home.htm/SellManage/on_sale`) → **更多批量操作** →
 
 | Menu item | Purpose |
 |---|---|
@@ -87,5 +87,6 @@ CLI (`click_at_xy` after a screenshot; `js(...)` to read state) per
 ## What this skill is NOT
 
 - Not ads — that's `qianniu-ads` (万相台无界).
-- Not 生意参谋 reports — that's `qianniu-reports`.
+- Not 生意参谋 (sycm) retail reports — a separate concern (no skill ships for
+  it yet).
 - Never auto-imports or publishes; the human reviews every write.

--- a/app/skills_v2/qianniu-listing/requirements.txt
+++ b/app/skills_v2/qianniu-listing/requirements.txt
@@ -1,0 +1,1 @@
+openpyxl

--- a/app/skills_v2/qianniu-listing/requirements.txt
+++ b/app/skills_v2/qianniu-listing/requirements.txt
@@ -1,1 +1,1 @@
-openpyxl
+openpyxl>=3.1

--- a/app/skills_v2/qianniu-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/qianniu-listing/scripts/listing_bulk.py
@@ -147,7 +147,9 @@ def cmd_fill(args):
             spec_row.get('商品ID') or spec_row.get(id_name) or ''
         ).strip()
         if not ident:
-            raise SystemExit(f'error: spec row {i} has no 商品ID')
+            raise SystemExit(
+                f'error: spec row {i} has no {id_name} (identity value)'
+            )
         r = row_of.get(ident)
         if not r:
             warnings.append(f'row {i}: {id_name}={ident} not in the export')

--- a/app/skills_v2/qianniu-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/qianniu-listing/scripts/listing_bulk.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Taobao/Tmall 千牛 商品 Excel bulk round-trip helper.
+
+Drives the 商品管理 → 更多批量操作 → excel商品批量导出 / excel商品批量编辑 /
+批量导入 loop: inspect an exported workbook, fill edits keyed by the
+workbook's OWN column headers, and summarise the import result.
+
+Why header-keyed (vs positional)
+--------------------------------
+The 商品 export's column set is category-specific and changes over time,
+and the header labels are localised Chinese. Keying every value by the
+export's own header string (discovered with `inspect`) keeps the tool
+robust across categories and template revisions -- the same philosophy
+as the amazon-listing flat-file tool. `fill` copies the exported
+workbook verbatim and only overwrites the named cells, so an import
+changes exactly what you intended and nothing else.
+
+Usage
+-----
+  listing_bulk.py inspect       WORKBOOK.xlsx
+  listing_bulk.py fill          WORKBOOK.xlsx --spec SPEC.json --out OUT.xlsx
+  listing_bulk.py parse-import  RESULT.xlsx
+
+Requires: openpyxl.
+"""
+
+import argparse
+import json
+import shutil
+import sys
+
+try:
+    import openpyxl
+except ImportError:
+    sys.exit('error: openpyxl is required (pip install openpyxl)')
+
+
+# Tokens that identify the header row and the per-商品 identity column.
+# Taobao/Tmall exports label the identity column one of these.
+IDENTITY_TOKENS = ('商品ID', '宝贝ID', '商品编码', '数字ID', 'itemId', '商品id')
+# Substrings that mark a plausible header row (any one is enough).
+HEADER_TOKENS = IDENTITY_TOKENS + ('商品标题', '标题', '价格', '一口价', '库存')
+
+
+def _find_header_row(ws, max_scan=12):
+    """Return (row_index_1based, [header strings]) for the header row.
+
+    Picks the first of the first `max_scan` rows that contains a known
+    header token; falls back to the row with the most non-empty string
+    cells. Taobao exports sometimes carry a title/notice row above the
+    real header, so we scan rather than assume row 1.
+    """
+    best = None
+    for r in range(1, max_scan + 1):
+        vals = [
+            ws.cell(row=r, column=c).value for c in range(1, ws.max_column + 1)
+        ]
+        strs = [str(v).strip() for v in vals if v not in (None, '')]
+        joined = ' '.join(strs)
+        if any(tok in joined for tok in HEADER_TOKENS):
+            return r, [('' if v is None else str(v).strip()) for v in vals]
+        # track the densest row as a fallback
+        if best is None or len(strs) > best[0]:
+            best = (
+                len(strs),
+                r,
+                [('' if v is None else str(v).strip()) for v in vals],
+            )
+    if best:
+        return best[1], best[2]
+    raise SystemExit('error: could not locate a header row in the workbook')
+
+
+def _identity_col(headers):
+    """1-based column index of the 商品 identity column, or None."""
+    for tok in IDENTITY_TOKENS:
+        for i, h in enumerate(headers):
+            if h and tok in h:
+                return i + 1
+    return None
+
+
+def _sheet(wb):
+    return wb[wb.sheetnames[0]]
+
+
+def cmd_inspect(args):
+    wb = openpyxl.load_workbook(args.file, read_only=True, data_only=True)
+    ws = _sheet(wb)
+    header_row, headers = _find_header_row(ws)
+    cols = [h for h in headers if h]
+    id_col = _identity_col(headers)
+    id_name = headers[id_col - 1] if id_col else None
+    n_data = sum(
+        1
+        for r in range(header_row + 1, ws.max_row + 1)
+        if any(
+            ws.cell(row=r, column=c).value not in (None, '')
+            for c in range(1, ws.max_column + 1)
+        )
+    )
+    print(f'sheet        : {wb.sheetnames[0]}')
+    print(f'header row   : {header_row} (data starts row {header_row + 1})')
+    print(
+        f'identity col : {id_name or "<<none found — check IDENTITY_TOKENS>>"}'
+    )
+    print(f'data rows    : {n_data}')
+    print(f'columns ({len(cols)}):')
+    for h in cols:
+        print(f'  {h}')
+    wb.close()
+
+
+def _load_spec(path):
+    with open(path, encoding='utf-8') as fh:
+        spec = json.load(fh)
+    rows = spec.get('rows') or []
+    if not rows:
+        raise SystemExit('error: spec has no rows')
+    return rows
+
+
+def cmd_fill(args):
+    rows = _load_spec(args.spec)
+    shutil.copyfile(args.file, args.out)
+    wb = openpyxl.load_workbook(args.out)  # keep styles/other cells verbatim
+    ws = _sheet(wb)
+    header_row, headers = _find_header_row(ws)
+    col_of = {h: i + 1 for i, h in enumerate(headers) if h}
+    id_col = _identity_col(headers)
+    if not id_col:
+        raise SystemExit(
+            'error: no identity column (商品ID/宝贝ID/…) — cannot match rows'
+        )
+    id_name = headers[id_col - 1]
+
+    # Map identity value -> worksheet row.
+    row_of = {}
+    for r in range(header_row + 1, ws.max_row + 1):
+        v = ws.cell(row=r, column=id_col).value
+        if v not in (None, ''):
+            row_of[str(v).strip()] = r
+
+    warnings, written = [], 0
+    for i, spec_row in enumerate(rows):
+        ident = str(
+            spec_row.get('商品ID') or spec_row.get(id_name) or ''
+        ).strip()
+        if not ident:
+            raise SystemExit(f'error: spec row {i} has no 商品ID')
+        r = row_of.get(ident)
+        if not r:
+            warnings.append(f'row {i}: {id_name}={ident} not in the export')
+            continue
+        for col_name, val in (spec_row.get('fields') or {}).items():
+            if col_name not in col_of:
+                warnings.append(
+                    f'row {i} ({ident}): column {col_name!r} not in the export'
+                )
+                continue
+            ws.cell(row=r, column=col_of[col_name]).value = val
+            written += 1
+
+    wb.save(args.out)
+    for w in warnings:
+        print(f'warning: {w}', file=sys.stderr)
+    print(
+        f'wrote {written} cell(s) across {len(rows)} spec row(s) -> {args.out}'
+    )
+    print('IMPORT IS A WRITE — have the user review the diff before 批量导入.')
+
+
+def cmd_parse_import(args):
+    """Summarise the import-result workbook: per-row 成功/失败 + reason."""
+    wb = openpyxl.load_workbook(args.file, read_only=True, data_only=True)
+    ws = _sheet(wb)
+    header_row, headers = _find_header_row(ws)
+
+    def find(*needles):
+        for i, h in enumerate(headers):
+            if h and any(n in h for n in needles):
+                return i + 1
+        return None
+
+    c_id = _identity_col(headers)
+    c_status = find('结果', '状态', '成功', '是否成功')
+    c_reason = find('原因', '失败原因', '错误', '备注', 'message')
+
+    def cell(r, c):
+        return str(ws.cell(row=r, column=c).value or '').strip() if c else ''
+
+    n_ok = n_fail = 0
+    for r in range(header_row + 1, ws.max_row + 1):
+        ident = cell(r, c_id)
+        status = cell(r, c_status)
+        reason = cell(r, c_reason)
+        if not (ident or status or reason):
+            continue
+        fail = (
+            ('失败' in status)
+            or ('错误' in status)
+            or bool(reason and '成功' not in status)
+        )
+        if fail:
+            n_fail += 1
+        else:
+            n_ok += 1
+        print(f'  [{status or "?"}] {ident}{": " + reason if reason else ""}')
+    print(f'\nsummary: {n_ok} ok, {n_fail} failed')
+    if n_fail:
+        sys.exit(1)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    sub = ap.add_subparsers(dest='cmd', required=True)
+    p = sub.add_parser('inspect', help='dump header row + columns + row count')
+    p.add_argument('file')
+    p.set_defaults(func=cmd_inspect)
+    p = sub.add_parser('fill', help='set cells by header name, keyed by 商品ID')
+    p.add_argument('file')
+    p.add_argument('--spec', required=True)
+    p.add_argument('--out', required=True)
+    p.set_defaults(func=cmd_fill)
+    p = sub.add_parser(
+        'parse-import', help='summarise an import-result workbook'
+    )
+    p.add_argument('file')
+    p.set_defaults(func=cmd_parse_import)
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/app/skills_v2/qianniu-shared/SKILL.md
+++ b/app/skills_v2/qianniu-shared/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qianniu-shared
-description: "Common Taobao/Tmall 千牛 (Qianniu) seller mechanics — chrome-backend login (QR scan or slider-captcha + SMS is a HUMAN step; NO auto-captcha), wrong-account guard (verify the logged-in 店铺名 matches the bound store, else ask), promo/公告/安全提示 popup detect-and-close on every page load, the 千牛 / 生意参谋 (sycm) / 万相台无界 (one.alimama.com) page map + SSO, per-store download dir, and GB18030 CSV caveat. Prerequisite: every other qianniu-* skill (qianniu-listing, qianniu-ads, qianniu-reports) expects this loaded for auth + navigation. Load before any browser-use action on a Taobao/Tmall (千牛) store."
+description: "Common Taobao/Tmall 千牛 (Qianniu) seller mechanics — chrome-backend login (QR scan or slider-captcha + SMS is a HUMAN step; NO auto-captcha), wrong-account guard (verify the logged-in 店铺名 matches the bound store, else ask), promo/公告/安全提示 popup detect-and-close on every page load, the 千牛 / 生意参谋 (sycm) / 万相台无界 (one.alimama.com) page map + SSO, per-store download dir, and GB18030 CSV caveat. Prerequisite: every other qianniu-* skill (qianniu-listing, qianniu-ads) expects this loaded for auth + navigation. Load before any browser-use action on a Taobao/Tmall (千牛) store."
 ---
 
 # Qianniu (Taobao/Tmall) — Shared (auth, navigation, common patterns)
@@ -8,7 +8,7 @@ description: "Common Taobao/Tmall 千牛 (Qianniu) seller mechanics — chrome-b
 What every 千牛 seller task needs: the workbench login (chrome backend,
 human-in-the-loop), the 生意参谋 / 万相台无界 page map + SSO, the per-store
 download directory, and the CSV encoding caveat. Operation-specific skills
-(`qianniu-listing`, `qianniu-ads`, `qianniu-reports`) load this first.
+(`qianniu-listing`, `qianniu-ads`) load this first.
 
 > These stores run on the **chrome** browser backend (not Ziniao) — check
 > `stores.browser_backend`. There is **no auto-captcha** here: the slider

--- a/app/skills_v2/qianniu-shared/SKILL.md
+++ b/app/skills_v2/qianniu-shared/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: qianniu-shared
+description: "Common Taobao/Tmall 千牛 (Qianniu) seller mechanics — chrome-backend login (QR scan or slider-captcha + SMS is a HUMAN step; NO auto-captcha), wrong-account guard (verify the logged-in 店铺名 matches the bound store, else ask), promo/公告/安全提示 popup detect-and-close on every page load, the 千牛 / 生意参谋 (sycm) / 万相台无界 (one.alimama.com) page map + SSO, per-store download dir, and GB18030 CSV caveat. Prerequisite: every other qianniu-* skill (qianniu-listing, qianniu-ads, qianniu-reports) expects this loaded for auth + navigation. Load before any browser-use action on a Taobao/Tmall (千牛) store."
+---
+
+# Qianniu (Taobao/Tmall) — Shared (auth, navigation, common patterns)
+
+What every 千牛 seller task needs: the workbench login (chrome backend,
+human-in-the-loop), the 生意参谋 / 万相台无界 page map + SSO, the per-store
+download directory, and the CSV encoding caveat. Operation-specific skills
+(`qianniu-listing`, `qianniu-ads`, `qianniu-reports`) load this first.
+
+> These stores run on the **chrome** browser backend (not Ziniao) — check
+> `stores.browser_backend`. There is **no auto-captcha** here: the slider
+> captcha and SMS are HUMAN steps (§ 2).
+
+> **browser-use 0.13 CLI (heredoc).** Drive the wrapper by piping a Python
+> snippet: `~/.vibe-seller/bin/<slug>/browser-use <<'PY' … PY`. Pre-imported
+> helpers: `new_tab(url)` (**first navigation**, not `goto`), `page_info()`,
+> `js("<javascript>")` (runs JS in the page, returns the value; pierce open
+> shadow roots via `.shadowRoot`), `click_at_xy(x, y)`, `capture_screenshot(path)`,
+> `wait_for_load()`, `cdp("Domain.method", ...)` (raw CDP). See the
+> `browser-harness` skill. **Gotcha:** `cdp(...)` / `click_at_xy(...)` are
+> **Python** helpers in the heredoc scope — do NOT call them inside a
+> `js("…")` string (that runs in the page, where they're undefined).
+
+> **First-run on a fresh box:** the chrome backend needs Playwright's headed
+> Chromium ("Chrome for Testing"). If `browser/start` fails with
+> *"Executable doesn't exist at …/chromium-<v>/…Google Chrome for Testing"*,
+> install it once: `.venv/bin/python3 -m playwright install chromium`.
+
+## 1. Surfaces & URLs
+
+| Surface | URL | Notes |
+|---|---|---|
+| 千牛工作台 (workbench home) | `https://myseller.taobao.com/` | redirects to `loginmyseller.taobao.com` when logged out |
+| 商品管理 (listings) | `https://myseller.taobao.com/home.htm/SellManage/on_sale` | tabs: 全部 / 出售中 / 仓库中 / 预售 / 已售空 / 违规 |
+| 生意参谋 (Business Advisor) | `https://sycm.taobao.com/` | retail big-data; product/traffic/transaction reports |
+| 万相台无界 (Alimama, ad platform) | `https://one.alimama.com/index.html` | hash-route SPA `#!/...`; ad plans + 报表 live here |
+
+`生意参谋` and `万相台无界` are **separate apps** but share the 千牛 login
+session (**SSO**). Once 千牛 is logged in, opening `sycm.taobao.com` or
+`one.alimama.com` does **not** need a second login. If the session is dead
+they redirect to the Taobao login — that is a **human step** (§ 2).
+
+## 2. Login (chrome backend — human-in-the-loop)
+
+There is **no auto-captcha**. Two human paths; QR is simplest:
+
+**QR scan (preferred).** Open `https://myseller.taobao.com/`, run the
+popup-close loop (§ 4), switch the login card to **扫码登录** (click the QR
+toggle if it opens on 密码登录), then ask the human to scan with the
+手机淘宝/千牛 app and wait until the workbench home renders.
+
+```bash
+~/.vibe-seller/bin/<slug>/browser-use <<'PY'
+import time
+new_tab("https://myseller.taobao.com/")
+time.sleep(6)
+print("url:", js("return location.href"))          # loginmyseller… = logged out
+# (popup-close loop from § 4 here)
+capture_screenshot("/tmp/qn_login.png")             # show the operator the QR
+PY
+```
+
+Then hand off with `AskUserQuestion` ("scan the QR / complete slider+SMS in
+the visible window, then continue"). **Never drag the slider
+programmatically** — Taobao flags automated drags and burns attempts.
+
+Password login (fallback) fills the `havanalogin.taobao.com` iframe
+(`#fm-login-id`, `#fm-login-password`, `button[type=submit]`) via `js(...)`,
+but still lands on the slider + SMS human step. Credentials, when used, come
+from the store profile (`stores/<slug>/STORE.md`), format `店铺名:子账号名`.
+
+The chrome **profile persists** at `~/.vibe-seller/browser_profiles/<slug>/`,
+so login survives restarts — re-login is only needed when the session expires.
+
+### 2.1 Wrong-account guard ⚠️ HARD GATE
+
+The chrome profile persists, and a human may have left the window logged into
+the **wrong seller account**. Data pulled from the wrong account is silently
+wrong. **Before any read/export, confirm the active 店铺名 matches the bound
+store.** The workbench header renders the sub-account as `店铺名:子账号名`.
+
+```bash
+~/.vibe-seller/bin/<slug>/browser-use <<'PY'
+print(js(r"""
+var t=(document.body.innerText||'').replace(/ /g,' ');
+var m=t.match(/([一-龥A-Za-z0-9]{2,40})[:：]([一-龥A-Za-z0-9_]{1,24})/g)||[];
+return JSON.stringify(m.slice(0,12));
+"""))
+PY
+```
+
+Compare the extracted `店铺名` (before the `:`/`：`) to the bound store's
+店铺名. **If it does not match, do NOT proceed** — surface via
+`AskUserQuestion` (human decision; never auto-continue). Never write the
+detected 店铺名 into code, commits, or PRs — it is store-identifying data.
+
+## 3. Headed vs headless (so a human can log in / scan)
+
+**Wrapper-managed — NEVER pass `--headed`/`--headless`, never `close`+reopen
+to "switch to headed".** Window visibility is decided by the backend:
+`chrome` (mac/Linux Playwright) is visible when a display exists; if it's
+invisible, an admin flips `browser_headless=false` and restarts the store
+browser (see `debug-store`). Just open the login page and have the human scan.
+
+## 4. Promo / 公告 / 安全提示 popups — close on sight ⚠️
+
+千牛, the login pages, 生意参谋, and 万相台 pop **ad / 活动 / 公告 / 安全提示
+modals** on load that **eat clicks** (an element that won't respond usually
+has an invisible overlay on top). **Standing rule: after every page load or
+route change on a Taobao/千牛 domain, run the detect-and-close loop before
+any other interaction**, and re-run whenever a click doesn't register.
+
+**Close via X / 关闭 / 知道了 / 我知道了 / 稍后 only — NEVER click a promo CTA**
+(开通 / 立即开通 / 升级 / 立即参加 / 领取 / 报名 / 马上抢 / 一键…): those
+subscribe the store to a paid service or join an activity (a **write** — out
+of scope unless the user asked).
+
+```bash
+~/.vibe-seller/bin/<slug>/browser-use <<'PY'
+print(js(r"""
+var closed=0;
+document.querySelectorAll('.baxia-dialog-close,.next-dialog-close,.next-overlay-wrapper .next-icon-close').forEach(function(e){if(e.offsetParent){e.click();closed++}});
+var BAD=/开通|升级|参加|报名|抢|领取|去逛|立即|马上|一键|体验|试用/;
+var OK=/^(知道了|我知道了|关闭|稍后再说|稍后|以后再说|不再提示|跳过|取消|×|✕|✖|x|X)$/;
+document.querySelectorAll('[class*=dialog] *,[class*=modal] *,[class*=popup] *,[class*=Dialog] *,[class*=Modal] *').forEach(function(e){
+  if(!e.offsetParent||e.children.length)return;
+  var t=(e.innerText||e.getAttribute('aria-label')||'').trim();
+  if(OK.test(t)&&!BAD.test(t)){e.click();closed++}
+});
+return 'closed '+closed;
+"""))
+PY
+```
+
+- **Loop until clean** (re-run until it returns `closed 0`, cap ~4 rounds) —
+  closing one modal can reveal another.
+- **Verify by re-detecting, not by screenshot** (a background tab can show a
+  stale frame). If a synthetic `.click()` won't dismiss it, dispatch a trusted
+  CDP click at the X's center (`cdp('Input.dispatchMouseEvent', ...)`). If a
+  blocking dialog exposes no close affordance, `js("location.reload()")` and
+  re-run.
+
+## 5. Per-store download dir & CSV encoding
+
+Exports (Excel/CSV) the browser downloads land in the vibe-seller-monitored
+per-store dir `~/.vibe-seller/downloads/<slug>/` (list newest first with
+`ls -lt`). Save any live capture (exports, screenshots, scraped rows) under
+`/tmp/<task>/` — **never** under `~/.vibe-seller/knowledge/` (curated facts
+only) or `stores/` (per the capture rule).
+
+> **CSV encoding:** Taobao/Tmall CSV exports are **GB18030**, not UTF-8.
+> Decode with `encoding='gb18030'` (pandas/`open`) or headers/values render
+> as mojibake. Excel (`.xlsx`) exports are fine as-is.
+
+## 6. Common "always load X first" pattern
+
+Every qianniu-* operation skill lists `requires: [qianniu-shared]` and opens
+by loading this for login + the page map + the popup-close rule. Load the
+operation skill for the actual task (listing round trip, ads audit, reports).
+
+## See also
+
+- `qianniu-listing` — CRUD listings via the Excel bulk round trip.
+- `qianniu-ads` — 万相台 report export (analysis) + plan CRUD (review-first).
+- `browser-harness` — the browser-use 0.13 heredoc CLI + helper reference.

--- a/docs/subsystems.md
+++ b/docs/subsystems.md
@@ -164,6 +164,8 @@ Skills can declare `requires: [<prereq-skill-name>]` in their YAML frontmatter. 
 
 Several skills are layered: e.g. `noon-ads` needs `noon-shared`'s login flow and URL map before any ad work makes sense. A prose `> **PREREQUISITE:** Read ../noon-shared/SKILL.md` line in the dependent's SKILL.md is the *spec*, but non-Claude models (and Claude under load) sometimes skip it and run with a partial context. The hook turns that prose into a mechanism.
 
+Each e-commerce platform ships as one such family: `amazon-shared` + `amazon-{ads,listing}`, `noon-shared` + `noon-{ads,…}`, and — for Taobao/Tmall — `qianniu-shared` + `qianniu-{listing,ads}`. Qianniu differs from the Amazon/Noon (Ziniao) families in its browser layer: it runs on the **chrome** backend with a **human-in-the-loop login** (QR scan or slider-captcha + SMS — no auto-captcha), a wrong-account hard gate, and a promo/公告 popup-close loop; its exports are GB18030-encoded CSV. All writes (Excel `批量导入`, ad-plan changes) are surfaced for human review, never auto-executed.
+
 ### Frontmatter format
 
 ```yaml


### PR DESCRIPTION
## What

Generalizes the customer-specific qianniu plugin into a reusable **platform** skill family, mirroring the existing `amazon-*` / `noon-*` structure (shared prerequisite + per-domain operation skills, bulk-first, click-fallback).

Three new skills under `app/skills_v2/`:

| Skill | Purpose |
|---|---|
| **qianniu-shared** | Prerequisite for the family: chrome-backend **human** login (QR / slider+SMS — no auto-captcha), wrong-account **HARD GATE**, promo/公告 popup close loop, 千牛 / 生意参谋 / 万相台无界 page map + SSO, per-store download dir, GB18030 CSV caveat. |
| **qianniu-listing** | 商品 CRUD via the Excel **bulk round trip** (`excel商品批量导出` → edit → `批量导入`). Ships `listing_bulk.py` (`inspect` / `fill` / `parse-import`) — header-keyed so it survives category-specific, localised columns. |
| **qianniu-ads** | 万相台无界 analysis, **bulk-first**: `报表` export → `ads_report.py` normalises GB18030/xlsx → TSV. Plan-list DOM scrape is the fallback. 计划 CRUD surfaced for review. Thresholds live in per-store `ads-rules.md`, not the skill. |

## Safety model

- **All analysis is read-only.** Every write (Excel `批量导入`, any 计划 create/edit/delete, promo CTA) is **surfaced for human review — never auto-executed**. This is enforced in the skill docs and echoed by the scripts (`fill` prints an explicit "IMPORT IS A WRITE — review first" line).
- Wrong-account guard blocks any read/export until the active 店铺名 is confirmed to match the bound store.

## Design

- Same **header-keyed** philosophy as `amazon-listing`'s flat-file tool: never positional, robust to localised/reordered columns; `fill` copies the workbook verbatim and overwrites only the named cells.
- `qianniu-ads` is a thin catalog → `references/mechanics.md` (routes, date window, 报表 flow, per-场景 plan scrape, write actions).

## Verification

- Both scripts lint clean (`ruff check` / `ruff format`).
- Functionally smoke-tested: `inspect` finds the header row past a notice row; `fill` edits matched rows by 商品ID while preserving untouched rows; `parse-import` summarises 成功/失败 + reason (exit 1 on failure); `ads_report.py` parses a GB18030 CSV into normalised TSV.
- Registered in `MANIFEST.txt`.

## No sensitive data

Skill files and examples use realistic **placeholders only** (`ACME Widget`, `600000000001`) — no real store / SKU / brand / ASIN / operator data. The staged diff was scanned before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)