### PR TITLE
fix(ad-audit): reliability hardening — bulk-download reuse, drill-completeness enforcement, PDF export

### DIFF
--- a/app/ai/bash_safety.py
+++ b/app/ai/bash_safety.py
@@ -482,7 +482,21 @@ def check_review_status(task_dir) -> str | None:
     except OSError:
         audit_text = ''
     if _is_server_reviewed(audit_text):
-        return None
+        # amazon/noon audits are reviewed server-side at set_task_result,
+        # so we skip the legacy REVIEW-file/format loop here. But an agent
+        # can finish by ENDING ITS TURN (persisting the streaming result
+        # ungated) instead of calling set_task_result — the 3/24 bypass.
+        # Enforce the core "drill everything" invariant on this path too,
+        # so ending the turn is gated by the same rule (bounded fail-open).
+        # Lazy import: bash_safety is imported by the stop_gates package
+        # chain, so a top-level import here would cycle.
+        from app.ai.stop_gates import (  # noqa: PLC0415
+            ad_completeness_review,
+        )
+
+        return ad_completeness_review.drill_incomplete_reason(
+            audit_text, task_dir.name
+        )
 
     try:
         review_files = sorted(task_dir.glob(_REVIEW_FILE_GLOB))

--- a/app/ai/bash_safety.py
+++ b/app/ai/bash_safety.py
@@ -467,32 +467,20 @@ def check_review_status(task_dir) -> str | None:
     if not audit_files:
         return None  # Not an ads-tuning task; nothing to gate.
 
-    # amazon/noon audits are reviewed SERVER-SIDE at set_task_result
-    # (``ad_completeness_review`` — the constructive what's-missing
-    # loop). Running this legacy REVIEW-file gate on top of it forced
-    # the agent into redundant ``ads-format-review`` subagent
-    # iterations at every Stop attempt — burning rounds on format
-    # polish instead of drilling (the 1/46-stuck-on-review failure).
-    # Skip when the newest audit's content carries amazon/noon combo
-    # headers; platforms the server reviewer can't parse keep this gate
-    # as their only enforcement.
+    # amazon/noon audits are reviewed SERVER-SIDE (``ad_completeness_review``),
+    # not by the legacy REVIEW-file/format loop below. But an agent can finish
+    # by ENDING ITS TURN (streaming result persisted ungated) instead of
+    # calling set_task_result — the 3/24 bypass. So run the completeness
+    # backstop on this path too, gating the ending-turn under the same
+    # contract (bounded fail-open). Other platforms keep the REVIEW loop.
     newest_audit = max(audit_files, key=lambda p: p.stat().st_mtime)
     try:
         audit_text = newest_audit.read_text(encoding='utf-8')
     except OSError:
         audit_text = ''
     if _is_server_reviewed(audit_text):
-        # amazon/noon audits are reviewed server-side at set_task_result,
-        # so we skip the legacy REVIEW-file/format loop here. But an agent
-        # can finish by ENDING ITS TURN (persisting the streaming result
-        # ungated) instead of calling set_task_result — the 3/24 bypass.
-        # Enforce the core "drill everything" invariant on this path too,
-        # so ending the turn is gated by the same rule (bounded fail-open).
-        # Lazy import: bash_safety is imported by the stop_gates package
-        # chain, so a top-level import here would cycle.
-        from app.ai.stop_gates import (  # noqa: PLC0415
-            ad_completeness_review,
-        )
+        # Lazy import: a top-level import would cycle (stop_gates → here).
+        from app.ai.stop_gates import ad_completeness_review  # noqa: PLC0415
 
         return ad_completeness_review.drill_incomplete_reason(
             audit_text, task_dir.name

--- a/app/ai/stop_gates/ad_completeness_review.py
+++ b/app/ai/stop_gates/ad_completeness_review.py
@@ -74,6 +74,12 @@ _total_high: dict[str, int] = {}
 _last_len: dict[str, int] = {}
 _stall_rounds: dict[str, int] = {}
 
+# Stop-path backstop: how many times we've blocked an end-of-turn while
+# the audit was still under-drilled, per task. Bounds the stop-path deny
+# so a genuinely-stuck agent (can't drill more) isn't trapped forever —
+# fails open after STALL_CAP blocks, mirroring the set_task_result stall.
+_stop_blocks: dict[str, int] = {}
+
 
 def reset_progress(task_id: str) -> None:
     """Drop the per-task progress/stall state (call on terminal success)."""
@@ -82,6 +88,7 @@ def reset_progress(task_id: str) -> None:
     _total_high.pop(task_id, None)
     _last_len.pop(task_id, None)
     _stall_rounds.pop(task_id, None)
+    _stop_blocks.pop(task_id, None)
 
 
 def is_stalled(task_id: str) -> bool:
@@ -93,6 +100,62 @@ def is_stalled(task_id: str) -> bool:
     use this to accept the best report instead of denying forever.
     """
     return _stall_rounds.get(task_id, 0) >= STALL_CAP
+
+
+def drill_incomplete_reason(
+    result_text: str,
+    task_id: str | None = None,
+) -> str | None:
+    """Stop-path backstop: deny reason if the audit isn't fully drilled.
+
+    Unifies the two completion paths. ``set_task_result`` runs the full
+    :func:`check`; but an agent can also finish by simply ENDING ITS TURN,
+    which persists the streaming result WITHOUT that gate (the 3/24 bypass
+    — see ``claude_backend_stream._save_result``). The Stop hook calls
+    this so ending the turn is gated by the SAME "drill everything" rule.
+
+    Deliberately lightweight — it only enforces the core completeness
+    invariant (every ``## <Platform> <Country>`` section reports
+    ``drilled A/A``), NOT the per-block format/reconcile checks that
+    :func:`check` runs. Running the heavy review at every Stop attempt
+    burned rounds on format polish instead of drilling; this asks only
+    "did you drill them all?".
+
+    Bounded: after ``STALL_CAP`` blocks for a task it fails open, so an
+    agent that genuinely cannot drill more is not trapped. Returns None
+    when complete, when there are no combo sections, or once stalled.
+    """
+    if not result_text or not isinstance(result_text, str):
+        return None
+    under: list[str] = []
+    for part in re.split(r'(?m)^##\s+', result_text)[1:]:
+        if not part.strip():
+            continue
+        head = part.splitlines()[0].strip()
+        if not _COMBO_HEADER_RE.search(head):
+            continue
+        m = _PROGRESS_RE.search(part)
+        if not m:
+            under.append(f'「{head}」缺少 进度 行')
+            continue
+        drilled, active = int(m.group(1)), int(m.group(2))
+        if drilled < active:
+            under.append(f'「{head}」只 drill 了 {drilled}/{active}')
+    if not under:
+        return None
+    if task_id is not None:
+        n = _stop_blocks.get(task_id, 0) + 1
+        _stop_blocks[task_id] = n
+        if n > STALL_CAP:
+            return None  # fail open — don't trap a stuck agent
+    return (
+        '还不能结束：审计尚未 drill 完所有 active campaign——'
+        + '；'.join(under)
+        + '。每个 combo 的 进度 必须达到 A/A（把尚未 drill 的 campaign '
+        '逐个打开、把表格 APPEND 进 AD_AUDIT_*.md），全部 drill 完再结束。'
+        '不要留待“下一轮/下次审计”。补完后继续（或调用 '
+        'vibe_seller_set_task_result 复核）。'
+    )
 
 
 # A "## <Platform> <Country>" combo section header, e.g.
@@ -330,8 +393,11 @@ def check(
         if drilled < active:
             gaps.append(
                 f'[完整性] 「{head}」仅 drill {drilled}/{active} 个 active，'
-                f'还差 {active - drilled} 个未逐 campaign drill（缺失可接受，'
-                '本轮尽量补；逐轮收敛）'
+                f'还差 {active - drilled} 个未逐 campaign drill——必须把这 '
+                f'{active - drilled} 个全部逐一 drill 完（进度达到 '
+                f'{active}/{active}）才能结束本任务；本轮尽量多补，未 drill 完'
+                '不可提交完成，也不可结束本轮对话（server 会拦截）。不要留待'
+                '“下一轮/下次审计”——没有下一轮。'
             )
         elif drilled > active:
             # Over-report: more drills than the active set. The model
@@ -522,7 +588,9 @@ def check(
     body = '\n'.join('- ' + g for g in gaps[:12])
     extra = '' if len(gaps) <= 12 else f'\n…还有 {len(gaps) - 12} 项'
     reason = (
-        '本轮审计报告仍有缺口（缺失可接受——逐轮补全即可，不必一次做完）。\n'
+        '本轮审计报告仍有缺口——逐轮补全，直到每个 combo 的 进度 都达到 '
+        'D==A（所有 active campaign 全部 drill 完）才算完成；未 drill 完不可'
+        '结束任务（server 会拦截提交与结束对话）。\n'
         '**这是续作（RESUME，不是重做）**：你已经 drill 的数据、已写的 '
         'AD_AUDIT 报告和 per-campaign TSV 都还在——保留它们，只去补下面列出的'
         '缺失部分（打开尚未 drill 的 campaign 详情页、把它们的表格 APPEND 进报告）。'

--- a/app/ai/stop_gates/ad_completeness_review.py
+++ b/app/ai/stop_gates/ad_completeness_review.py
@@ -106,42 +106,32 @@ def drill_incomplete_reason(
     result_text: str,
     task_id: str | None = None,
 ) -> str | None:
-    """Stop-path backstop: deny reason if the audit isn't fully drilled.
+    """Stop-path backstop: deny reason if the audit isn't complete.
 
     Unifies the two completion paths. ``set_task_result`` runs the full
     :func:`check`; but an agent can also finish by simply ENDING ITS TURN,
     which persists the streaming result WITHOUT that gate (the 3/24 bypass
     — see ``claude_backend_stream._save_result``). The Stop hook calls
-    this so ending the turn is gated by the SAME "drill everything" rule.
+    this so ending the turn is gated by the SAME contract as
+    ``set_task_result``.
 
-    Deliberately lightweight — it only enforces the core completeness
-    invariant (every ``## <Platform> <Country>`` section reports
-    ``drilled A/A``), NOT the per-block format/reconcile checks that
-    :func:`check` runs. Running the heavy review at every Stop attempt
-    burned rounds on format polish instead of drilling; this asks only
-    "did you drill them all?".
+    Delegates to :func:`check` with ``task_id=None`` — that path is PURE
+    (it mutates no ``_max_drilled`` / stall state), so calling it on every
+    Stop attempt can't perturb the ``set_task_result`` convergence
+    accounting. This enforces the FULL contract (not just the ``D==A``
+    count but the two-layer per-campaign completeness), closing the hole
+    where a report with ``进度 D==A`` but missing search-term / targeting
+    layers slipped through the count-only check on the ending-turn path.
 
     Bounded: after ``STALL_CAP`` blocks for a task it fails open, so an
-    agent that genuinely cannot drill more is not trapped. Returns None
-    when complete, when there are no combo sections, or once stalled.
+    agent that genuinely cannot finish is not trapped. Returns None when
+    :func:`check` passes, or once this task has been blocked ``STALL_CAP``
+    times.
     """
     if not result_text or not isinstance(result_text, str):
         return None
-    under: list[str] = []
-    for part in re.split(r'(?m)^##\s+', result_text)[1:]:
-        if not part.strip():
-            continue
-        head = part.splitlines()[0].strip()
-        if not _COMBO_HEADER_RE.search(head):
-            continue
-        m = _PROGRESS_RE.search(part)
-        if not m:
-            under.append(f'「{head}」缺少 进度 行')
-            continue
-        drilled, active = int(m.group(1)), int(m.group(2))
-        if drilled < active:
-            under.append(f'「{head}」只 drill 了 {drilled}/{active}')
-    if not under:
+    deny = check(result_text, None, None)  # pure: task_id=None → no mutation
+    if deny is None:
         return None
     if task_id is not None:
         n = _stop_blocks.get(task_id, 0) + 1
@@ -149,12 +139,9 @@ def drill_incomplete_reason(
         if n > STALL_CAP:
             return None  # fail open — don't trap a stuck agent
     return (
-        '还不能结束：审计尚未 drill 完所有 active campaign——'
-        + '；'.join(under)
-        + '。每个 combo 的 进度 必须达到 A/A（把尚未 drill 的 campaign '
-        '逐个打开、把表格 APPEND 进 AD_AUDIT_*.md），全部 drill 完再结束。'
-        '不要留待“下一轮/下次审计”。补完后继续（或调用 '
-        'vibe_seller_set_task_result 复核）。'
+        '还不能结束：审计报告尚未完成（未 drill 完所有 active campaign，'
+        '或部分 campaign 缺少定向/搜索词层）。请补齐下列缺口后再结束；'
+        '不要留待“下一轮/下次审计”：\n' + deny.reason
     )
 
 

--- a/app/skills_v2/MANIFEST.txt
+++ b/app/skills_v2/MANIFEST.txt
@@ -14,6 +14,7 @@ amazon-ads/references/output-spec.md
 amazon-ads/references/reviewer-loop.md
 amazon-ads/references/tuning-history.md
 amazon-ads/scripts/ads_bulk.py
+amazon-ads/scripts/md_to_pdf.py
 amazon-ads/requirements.txt
 amazon-listing/SKILL.md
 amazon-listing/references/template-round-trip.md

--- a/app/skills_v2/amazon-ads/references/audit-quickref.md
+++ b/app/skills_v2/amazon-ads/references/audit-quickref.md
@@ -188,6 +188,22 @@ report — don't burn them on cosmetics).
   *completes onto the last*; you only start a fresh report on a task
   retry, never mid-task.
 
+## Step 5 — export the PDF (once the report is complete)
+
+After every combo is `drilled A/A` and the server accepts the result,
+render the report to a PDF for the user (better than reading raw
+markdown):
+
+```bash
+PY=<project-venv>/bin/python3            # needs `markdown` (requirements.txt)
+S=<skills>/amazon-ads/scripts/md_to_pdf.py
+$PY "$S" ./AD_AUDIT_<date>.md            # writes AD_AUDIT_<date>.pdf next to it
+```
+
+It renders CJK + tables via headless Chrome (throwaway profile — safe to
+run while the store browser is up) and fails loudly if the PDF has no
+pages. Mention the `.pdf` path in your result summary.
+
 ## Reference index (load on demand only)
 
 - `output-spec.md` — the report contract (read first).

--- a/app/skills_v2/amazon-ads/references/audit-quickref.md
+++ b/app/skills_v2/amazon-ads/references/audit-quickref.md
@@ -44,9 +44,14 @@ set before drilling.
 - **Amazon**: open Campaign Manager via the in-page menu (not a typed
   URL). **Clear the "Find a campaign" search box** (a stale term hides
   most campaigns) and set the date to 30 days. The grid virtualizes —
-  do NOT count DOM rows; use **Bulk Operations → Download campaigns**
-  (set the date range to 30 days, it defaults to 2), then parse the
-  XLSX for the full list. Details/selectors: load `mechanics.md` §2.
+  do NOT count DOM rows; use **Bulk Operations**. On that page, **reuse
+  the newest existing export first** — walk shadow roots for the
+  `<a download …/bulk-operations/download/…xlsx>` links and, if the
+  newest one's filename date range covers your window, just click it
+  (no modal, no 5–15 min wait). Only generate a fresh export
+  (`Download campaigns` — a shadow-DOM button, not a plain `<button>`)
+  when no recent file covers the window. Then parse the XLSX for the
+  full list. Selectors + the reuse/shadow-DOM details: `mechanics.md` §2d.
 - **noon**: open the Ad Manager home. The list is **paginated ~15/page**
   — page through ALL pages and union the campaign ids. Click the
   page-number anchor with dispatched events (the chevron doesn't work):

--- a/app/skills_v2/amazon-ads/references/audit-quickref.md
+++ b/app/skills_v2/amazon-ads/references/audit-quickref.md
@@ -8,12 +8,21 @@ then run this.
 
 ## Loop shape (important)
 
-You do NOT have to produce a perfect report in one pass. Do your best,
-call `vibe_seller_set_task_result("./AD_AUDIT_<date>.md")`, and the
+You build the report **across several rounds**, not in one pass: do a
+batch, call `vibe_seller_set_task_result("./AD_AUDIT_<date>.md")`, and the
 server's completeness reviewer replies with a short **"what's still
 missing"** list. Fix the top gaps, write to the file, call
-set_task_result again. Repeat — the report converges. Missing is
-acceptable each round.
+set_task_result again. Repeat — the report converges.
+
+**But the task is NOT done until EVERY active campaign is drilled** — the
+`进度` line of every `## <Platform> <Country>` section must read
+`drilled <A>/<A>` (D == A). The server **blocks finishing while any
+active campaign is still un-drilled** — this includes simply ending your
+turn, not just `set_task_result`. So keep drilling and re-submitting
+until D == A for every combo. **Do NOT stop early, and never defer
+campaigns to a "next round" / "next audit"** — there is no next round;
+finish them now. "Missing this round" is fine only as an *intermediate*
+state on the way to a full drill, never as the final report.
 
 ## Step 0 — scope + scaffold with append-markers
 

--- a/app/skills_v2/amazon-ads/references/mechanics.md
+++ b/app/skills_v2/amazon-ads/references/mechanics.md
@@ -188,12 +188,14 @@ brand-new export. The bulk-operations page keeps recent completed jobs
 with live download links, and the shadow-root walk below finds those
 `<a download>` links for *already-generated* files too. So the default
 first action on this page is: run the download-link walk (the code block
-below), and **if `a[0]` exists and its filename date range covers your
-audit window, just click it — you are done.** The filename encodes the
-range: `bulk-<entity>-<START>-<END>-<epoch>.xlsx` (e.g.
-`…-20260602-20260702-…` = Jun 2–Jul 2). Generating a fresh export (a
-5–15 min job) is the **fallback**, only when no recent file covers your
-window. This avoids the flaky `下载广告活动` modal entirely.
+below). It clicks the newest link (`a[0]`) and **returns its filename** —
+then **verify that filename's date range covers your audit window**; if
+it does, you are done. The filename encodes the range:
+`bulk-<entity>-<START>-<END>-<epoch>.xlsx` (e.g. `…-20260602-20260702-…`
+= Jun 2–Jul 2). If `a[0]` is `NO_LINK`, or its range does **not** cover
+your window, generate a fresh export (the 5–15 min job below) — that is
+the **fallback**. Reusing a recent file avoids the flaky `下载广告活动`
+modal entirely.
 
 **Only if there is no recent export**, generate one: click
 `Download campaigns` (`下载广告活动`) to open the modal. ⚠️ **This trigger

--- a/app/skills_v2/amazon-ads/references/mechanics.md
+++ b/app/skills_v2/amazon-ads/references/mechanics.md
@@ -182,8 +182,33 @@ The "Total: N" cell in the table footer is the authoritative count.
 
 ### 2d. Bulk download (cross-campaign capture)
 
-Bulk Operations → `Download campaigns` (`下载广告活动`). The modal
-has these checkboxes (default all checked for "Enabled & Paused"):
+**FIRST, reuse the newest existing export — do NOT generate a fresh job
+by default.** For a read-only audit you need a recent snapshot, not a
+brand-new export. The bulk-operations page keeps recent completed jobs
+with live download links, and the shadow-root walk below finds those
+`<a download>` links for *already-generated* files too. So the default
+first action on this page is: run the download-link walk (the code block
+below), and **if `a[0]` exists and its filename date range covers your
+audit window, just click it — you are done.** The filename encodes the
+range: `bulk-<entity>-<START>-<END>-<epoch>.xlsx` (e.g.
+`…-20260602-20260702-…` = Jun 2–Jul 2). Generating a fresh export (a
+5–15 min job) is the **fallback**, only when no recent file covers your
+window. This avoids the flaky `下载广告活动` modal entirely.
+
+**Only if there is no recent export**, generate one: click
+`Download campaigns` (`下载广告活动`) to open the modal. ⚠️ **This trigger
+button is inside the `<bulk-storm-dashboard>` custom element's shadow
+DOM** — a top-level `document.querySelector('button')` / text match will
+**not find it**, and a coordinate/`.click()` on a look-alike top-level
+element **silently no-ops** (the common failure: repeated click attempts,
+"let me try a more reliable click", switching strategies). It is the
+dashboard's **2nd header button** (fixed order: 1st = Upload,
+2nd = Download); find it by **walking shadow roots** (same `walk()` as
+below) and click the shadow element directly (`el.click()`), or
+`click_at_xy` on its `getBoundingClientRect()` centre. See
+`bulk-operations.md` → "drive it by language-INDEPENDENT selectors" for
+the full structural anchor table. The modal then has these checkboxes
+(default all checked for "Enabled & Paused"):
 
 - Terminated campaigns
 - Paused campaigns
@@ -213,7 +238,7 @@ reads "Download"):
 # Preferred: click the real <a download> via JS (the grid is an ag-Grid
 # inside a web-component shadow root, so walk shadow roots to find it).
 browser-use <<'PY'
-js("""
+js(r"""
 (function(){
   function walk(root,acc){root.querySelectorAll('*').forEach(function(e){
     if(e.shadowRoot)walk(e.shadowRoot,acc);

--- a/app/skills_v2/amazon-ads/requirements.txt
+++ b/app/skills_v2/amazon-ads/requirements.txt
@@ -1,1 +1,2 @@
 openpyxl>=3.1
+markdown>=3.4

--- a/app/skills_v2/amazon-ads/scripts/md_to_pdf.py
+++ b/app/skills_v2/amazon-ads/scripts/md_to_pdf.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Render an ad-audit ``AD_AUDIT_<date>.md`` to a CJK-ready PDF next to it.
+
+Pipeline: python-markdown (tables ext) -> styled HTML -> headless Chrome
+``--print-to-pdf``. A throwaway profile in a temp dir is used, so this is
+safe to run while the store browser is up (no session is touched).
+
+Usage:
+  python3 md_to_pdf.py AD_AUDIT_2026-06-05.md [-o OUT.pdf]
+
+Chrome discovery order: $AUDIT_PDF_CHROME, google-chrome / chromium(-browser)
+on PATH, then the playwright/puppeteer caches (mac + linux).
+Exit 0 on success (prints the pdf path), 1 on failure.
+"""
+
+import argparse
+import glob
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+try:
+    import markdown
+except ImportError:
+    print('ERROR: python-markdown missing (pip install markdown)')
+    sys.exit(1)
+
+_LIST_START = re.compile(r'^ {0,3}([-*+]|\d+\.) ')
+_INDENTED = re.compile(r'^ {2,}')
+
+
+def normalize_md(text: str) -> str:
+    """Insert the blank line python-markdown needs before a list.
+
+    GFM renderers (the web UI, GitHub) tolerate a list that starts
+    directly under a paragraph line; python-markdown does not — it folds
+    the items into the paragraph and the PDF shows a wall of run-on text.
+    Normalizing here makes the sanctioned renderer immune to that
+    authoring slip instead of hoping every agent remembers the blank line.
+    """
+    out: list[str] = []
+    prev = ''
+    for line in text.splitlines():
+        starts_list = bool(_LIST_START.match(line))
+        prev_is_listish = bool(_LIST_START.match(prev) or _INDENTED.match(prev))
+        if starts_list and prev.strip() and not prev_is_listish:
+            out.append('')
+        out.append(line)
+        prev = line
+    return '\n'.join(out)
+
+
+_CSS = """
+@page { size: A4; margin: 18mm 14mm; }
+body { font-family: 'PingFang SC', 'Noto Sans SC', 'DengXian',
+       'Microsoft JhengHei', sans-serif; font-size: 11px;
+       line-height: 1.5; color: #222; }
+h1 { font-size: 17px; border-bottom: 2px solid #444; padding-bottom: 4px; }
+h2 { font-size: 14px; margin-top: 18px; border-bottom: 1px solid #999;
+     padding-bottom: 2px; }
+h3 { font-size: 12px; margin-top: 12px; }
+table { border-collapse: collapse; width: 100%; margin: 6px 0; }
+/* Long tables MUST break across pages; repeat the header row on each. */
+thead { display: table-header-group; }
+tr { page-break-inside: avoid; }
+th, td { border: 1px solid #bbb; padding: 3px 5px; text-align: left;
+         word-break: break-all; }
+th { background: #f0f0f0; }
+code { background: #f5f5f5; padding: 0 3px; font-size: 10px; }
+pre { background: #f5f5f5; padding: 6px; overflow-x: hidden;
+      white-space: pre-wrap; font-size: 10px; }
+blockquote { border-left: 3px solid #ccc; margin-left: 0;
+             padding-left: 10px; color: #555; }
+"""
+
+
+def find_chrome():
+    """Locate a Chrome/Chromium binary across Linux and macOS."""
+    if os.environ.get('AUDIT_PDF_CHROME'):
+        return os.environ['AUDIT_PDF_CHROME']
+    for name in ('google-chrome', 'chromium', 'chromium-browser'):
+        path = shutil.which(name)
+        if path:
+            return path
+    home = os.path.expanduser('~')
+    mac_app = '/Contents/MacOS/Google Chrome for Testing'
+    for pat in (
+        # Linux caches
+        f'{home}/.cache/ms-playwright/chromium-*/chrome-linux64/chrome',
+        f'{home}/.cache/puppeteer/chrome/*/chrome-linux64/chrome',
+        f'{home}/.cache/puppeteer/chrome-headless-shell/*/'
+        'chrome-headless-shell-linux64/chrome-headless-shell',
+        # macOS — headless-shell first (purpose-built for printing, never
+        # conflicts with a running store browser).
+        f'{home}/Library/Caches/ms-playwright/chromium_headless_shell-*/'
+        'chrome-headless-shell-mac-arm64/chrome-headless-shell',
+        f'{home}/Library/Caches/ms-playwright/chromium_headless_shell-*/'
+        'chrome-headless-shell-mac-x64/chrome-headless-shell',
+        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        '/Applications/Chromium.app/Contents/MacOS/Chromium',
+        # Chrome for Testing LAST: hangs in headless print while the same
+        # binary runs the store browser.
+        f'{home}/Library/Caches/ms-playwright/chromium-*/'
+        f'chrome-mac-arm64/Google Chrome for Testing.app{mac_app}',
+        f'{home}/Library/Caches/ms-playwright/chromium-*/'
+        f'chrome-mac/Google Chrome for Testing.app{mac_app}',
+    ):
+        hits = sorted(glob.glob(pat))
+        if hits:
+            return hits[-1]
+    return None
+
+
+def headless_flag():
+    """``--headless=new`` hangs >120 s on macOS Chrome; legacy
+    ``--headless`` prints fine there. Linux keeps ``=new``."""
+    return '--headless' if sys.platform == 'darwin' else '--headless=new'
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('audit_md')
+    ap.add_argument('-o', '--output')
+    args = ap.parse_args(argv)
+
+    src = pathlib.Path(args.audit_md)
+    if not src.is_file():
+        print(f'ERROR: {src} not found')
+        return 1
+    out = pathlib.Path(args.output) if args.output else src.with_suffix('.pdf')
+
+    chrome = find_chrome()
+    if not chrome:
+        print('ERROR: no chrome/chromium binary found (set AUDIT_PDF_CHROME)')
+        return 1
+
+    body = markdown.markdown(
+        normalize_md(src.read_text(encoding='utf-8')),
+        extensions=['tables', 'fenced_code'],
+    )
+    html = (
+        '<!DOCTYPE html><html><head><meta charset="utf-8">'
+        f'<style>{_CSS}</style></head><body>{body}</body></html>'
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        html_path = pathlib.Path(tmp) / 'audit.html'
+        html_path.write_text(html, encoding='utf-8')
+        cmd = [
+            chrome,
+            headless_flag(),
+            '--disable-gpu',
+            '--no-sandbox',
+            f'--user-data-dir={tmp}/profile',
+            f'--print-to-pdf={out.resolve()}',
+            '--no-pdf-header-footer',
+            html_path.resolve().as_uri(),
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    if proc.returncode != 0 or not out.is_file():
+        print(f'ERROR: chrome print failed rc={proc.returncode}')
+        print(proc.stderr[-500:])
+        return 1
+    # Sanity gate: a real multi-section audit never prints to a single
+    # page. A 1-page PDF means the HTML failed to render (e.g. raw
+    # markdown) — fail loudly instead of shipping a broken file.
+    raw = out.read_bytes()
+    pages = raw.count(b'/Type /Page') - raw.count(b'/Type /Pages')
+    if pages < 1:
+        print('ERROR: output PDF has no pages — rendering failed')
+        return 1
+    print(f'wrote {out} ({out.stat().st_size} bytes, ~{pages} pages)')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -57,8 +57,10 @@ browser-use --doctor    # verify installation / CDP connectivity
 
 ## Core Workflow
 
-1. **Navigate**: `new_tab(url)` for the first page (then `page.goto(url)` /
-   click to move around).
+1. **Navigate**: `new_tab(url)` — for the first page **and every later
+   navigation**. There is **no `page` object** in the heredoc scope, so
+   `page.goto(url)` raises `NameError`; use `new_tab(url)` (or click a link)
+   to move around.
 2. **Understand visible state**: `capture_screenshot()` — screenshot first.
 3. **Inspect / extract**: `page_info()` for a structured summary; `js("...")`
    for DOM queries when coordinates are the wrong tool.
@@ -81,6 +83,14 @@ ensure_real_tab()  # switch off a stale/internal (chrome://) tab
 js('<javascript>')  # run JS in the page; returns the result
 cdp('Domain.method', ...)  # raw Chrome DevTools Protocol call
 ```
+
+Only the helpers above (plus Python builtins) are in scope — the heredoc
+runs as a plain Python script. **`time`, `json`, `re`, etc. are NOT
+pre-imported; `import` them yourself.** Bare `sleep 3` is a `SyntaxError`
+and `time.sleep(3)` without `import time` is a `NameError`. **Prefer
+`wait_for_load()` over sleeping** — reach for `import time; time.sleep(n)`
+only when you must wait on something `wait_for_load()` can't observe (e.g.
+an async in-page render after a click).
 
 Multiple statements run in one heredoc (this replaces `&&` chaining):
 
@@ -128,6 +138,10 @@ The wrapper rejects these — do not use them:
 2. **`new_tab(url)` is the first navigation**, not `goto`.
 3. Prefer `page_info()` / `js(...)` over screenshots for text extraction.
 4. **CLI aliases**: `bu` and `browser` also invoke the wrapper.
+5. **Raw-string your `js()` when it contains backslashes** (regex like
+   `/foo\/bar/`, `\d`, `\.`): `js(r"""…""")`. A plain triple-quoted string
+   makes Python emit `SyntaxWarning: invalid escape sequence` and can
+   corrupt the JS before it reaches the page.
 
 ## Troubleshooting
 

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -74,7 +74,7 @@ browser-use --doctor    # verify installation / CDP connectivity
 Helpers are pre-imported into the heredoc namespace:
 
 ```python
-new_tab(url)  # open a new tab and navigate (first navigation)
+new_tab(url)  # open a new tab and navigate (use for EVERY navigation)
 page_info()  # structured summary of the current page
 capture_screenshot()  # screenshot the visible viewport (understand state)
 click_at_xy(x, y)  # click at pixel coordinates
@@ -135,7 +135,8 @@ The wrapper rejects these — do not use them:
 
 1. **Screenshot first**, then act on what you see — `capture_screenshot()`
    before `click_at_xy`.
-2. **`new_tab(url)` is the first navigation**, not `goto`.
+2. **`new_tab(url)` is how you navigate — every time**, not `goto` (there
+   is no `page` object in the heredoc scope).
 3. Prefer `page_info()` / `js(...)` over screenshots for text extraction.
 4. **CLI aliases**: `bu` and `browser` also invoke the wrapper.
 5. **Raw-string your `js()` when it contains backslashes** (regex like

--- a/app/skills_v2/noon-ads/SKILL.md
+++ b/app/skills_v2/noon-ads/SKILL.md
@@ -295,7 +295,10 @@ low-performing queries (add as negatives).
 Both Targets tab and Customer Queries tab have **Export Data** button
 at top-right. Triggers CSV download of the current filtered view.
 **Unreliable in this environment** — see § 4 caveat. Prefer DOM eval
-extraction.
+extraction. ⚠️ **If the file doesn't land within ~10 s, do NOT re-click
+or retry** — a no-op export button is an environment quirk, not a
+transient miss. Switch to DOM eval extraction (§ 4 / § 5) immediately;
+retrying just burns steps.
 
 ```bash
 browser-use <<'PY'

--- a/tests/unit/test_review_stop_gate.py
+++ b/tests/unit/test_review_stop_gate.py
@@ -21,14 +21,29 @@ class TestReviewStopGate:
         assert check_review_status(tmp_path) is None
 
     def test_amazon_noon_audit_skips_legacy_gate(self, tmp_path):
-        # Server-reviewed report (amazon/noon combo headers): the Stop
-        # hook must NOT demand a REVIEW file / format-review subagent.
+        # Server-reviewed report (amazon/noon combo headers) that is
+        # FULLY drilled (D==A): the Stop hook must NOT demand a REVIEW
+        # file / format-review subagent, and must allow the stop.
+        (tmp_path / 'AD_AUDIT_2026-06-10.md').write_text(
+            '# 广告优化建议\n\n## Amazon US\n\n**进度**: drilled 31/31 active\n'
+            '\n## noon EG\n\n**进度**: drilled 39/39 active\n',
+            encoding='utf-8',
+        )
+        assert check_review_status(tmp_path) is None
+
+    def test_amazon_noon_audit_underdrilled_blocks(self, tmp_path):
+        # The 3/24 bypass: an under-drilled amazon/noon audit must block
+        # the stop (drill-completeness backstop), NOT via the legacy
+        # ads-format-review path.
         (tmp_path / 'AD_AUDIT_2026-06-10.md').write_text(
             '# 广告优化建议\n\n## Amazon US\n\n**进度**: drilled 4/31 active\n'
             '\n## noon EG\n\n**进度**: drilled 2/39 active\n',
             encoding='utf-8',
         )
-        assert check_review_status(tmp_path) is None
+        deny = check_review_status(tmp_path)
+        assert deny is not None
+        assert 'ads-format-review' not in deny
+        assert '4/31' in deny and '2/39' in deny
 
     def test_unrecognized_audit_keeps_gate(self, tmp_path):
         # An audit no server gate recognizes (some other platform) still

--- a/tests/unit/test_review_stop_gate.py
+++ b/tests/unit/test_review_stop_gate.py
@@ -13,6 +13,7 @@ server gate) keeps the REVIEW-file loop as its fallback enforcement.
 import pytest
 
 from app.ai.bash_safety import check_review_status
+from app.ai.stop_gates import ad_completeness_review
 
 
 @pytest.mark.unit
@@ -20,10 +21,18 @@ class TestReviewStopGate:
     def test_no_audit_no_gate(self, tmp_path):
         assert check_review_status(tmp_path) is None
 
-    def test_amazon_noon_audit_skips_legacy_gate(self, tmp_path):
-        # Server-reviewed report (amazon/noon combo headers) that is
-        # FULLY drilled (D==A): the Stop hook must NOT demand a REVIEW
-        # file / format-review subagent, and must allow the stop.
+    def test_amazon_noon_audit_skips_legacy_gate(self, tmp_path, monkeypatch):
+        # Server-reviewed report where the completeness check PASSES: the
+        # Stop hook must NOT demand a legacy REVIEW file / format-review
+        # subagent — it defers to the server completeness reviewer, which
+        # is satisfied, so the stop is allowed. A real full report is
+        # large; stub the pure check to "passes" so this test targets the
+        # wiring (legacy gate skipped, stop allowed) without a brittle
+        # fixture. drill_incomplete_reason delegates to check(text, None,
+        # None).
+        monkeypatch.setattr(
+            ad_completeness_review, 'check', lambda *a, **k: None
+        )
         (tmp_path / 'AD_AUDIT_2026-06-10.md').write_text(
             '# 广告优化建议\n\n## Amazon US\n\n**进度**: drilled 31/31 active\n'
             '\n## noon EG\n\n**进度**: drilled 39/39 active\n',
@@ -33,7 +42,7 @@ class TestReviewStopGate:
 
     def test_amazon_noon_audit_underdrilled_blocks(self, tmp_path):
         # The 3/24 bypass: an under-drilled amazon/noon audit must block
-        # the stop (drill-completeness backstop), NOT via the legacy
+        # the stop (completeness backstop), NOT via the legacy
         # ads-format-review path.
         (tmp_path / 'AD_AUDIT_2026-06-10.md').write_text(
             '# 广告优化建议\n\n## Amazon US\n\n**进度**: drilled 4/31 active\n'
@@ -44,6 +53,25 @@ class TestReviewStopGate:
         assert deny is not None
         assert 'ads-format-review' not in deny
         assert '4/31' in deny and '2/39' in deny
+
+    def test_underdrilled_stop_path_fails_open(self, tmp_path):
+        # Bounded: an agent that keeps ending its turn on an incomplete
+        # report is blocked, but only up to STALL_CAP times, then the
+        # stop-path fails open so it is not trapped forever.
+        acr = ad_completeness_review
+
+        txt = (
+            '# 广告优化建议\n\n## Amazon US\n\n**进度**: drilled 1/31 active\n'
+        )
+        tid = 'stoppath-failopen'
+        acr.reset_progress(tid)
+        outs = [
+            acr.drill_incomplete_reason(txt, tid)
+            for _ in range(acr.STALL_CAP + 2)
+        ]
+        assert outs[0] is not None
+        assert outs[-1] is None  # failed open after STALL_CAP blocks
+        acr.reset_progress(tid)
 
     def test_unrecognized_audit_keeps_gate(self, tmp_path):
         # An audit no server gate recognizes (some other platform) still


### PR DESCRIPTION
Hardens the Amazon/noon ad-audit skill + server gate end-to-end, from a live run that had been completing at **drilled 3/24**.

## 1. Bulk-download thrash (skills_v2) — `10de98e`
Root-caused from an audit transcript: the agent thrashed ~12 steps on the Amazon Bulk Operations download. Fixes: reuse the newest existing export first (shadow-root walk); documented that `下载广告活动` is a `<bulk-storm-dashboard>` shadow-DOM button; `browser-harness` `page.goto`→`new_tab` bug + `import time` + raw-string `js()` gotchas. (Full detail in the original PR description.)

## 2. Drill-completeness bypass (3/24 → 119/119) — `379fb95`, `84f3eb3`
**Root cause (lifecycle-ownership split):** completion had two paths but only one gate. `set_task_result` was gated by `ad_completeness_review`, but an agent that simply **ends its turn** persists the streaming result *ungated* (`_save_result`), and the Stop-hook gate deliberately abstained for amazon/noon. Plus the skill/gate messaging ("Missing is acceptable each round", "缺失可接受") licensed early stop.

Fixes:
- Rewrote the permissive messaging → "the task is not done until every active campaign is drilled (D==A); no next round."
- `drill_incomplete_reason()` bounded stop-path backstop; `check_review_status` runs it for amazon/noon audits so **ending the turn is gated by the same contract** as `set_task_result`.
- Unified the two paths: `drill_incomplete_reason` delegates to `check(text, None, None)` (verified pure — no stall mutation), enforcing not just the D==A **count** but the **two-layer per-campaign** completeness (targeting + search-term/对账). Bounded fail-open prevents trapping a stuck agent.

**Validated live:** a fresh infino audit went 3/24 → the gate rejected ~20 partial submits and forced the agent through **all 119 campaigns (every combo D==A, full targeting tables)**. It then surfaced real secondary gaps (27 SA campaigns missing search-term layer) — caught by the anti-gaming check.

## 3. PDF export (goal: better UX) — `6b84706`
`md_to_pdf.py` renders `AD_AUDIT_<date>.md` → CJK-ready PDF (python-markdown + headless Chrome, table page-breaks, page-count sanity gate). Quickref "Step 5". Produced a 34-page PDF from the live report.

## Tests
Stop-gate + prompt-assembly suites green; new tests pin: under-drilled amazon/noon audit blocks the stop (not via legacy ads-format-review), a check()-passing report allows it, and the stop-path fails open after `STALL_CAP`.

skills_v2 only (`app/skills` is frozen 0.12). No live-account data in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)