### PR TITLE
fix(scheduler): interval schedules never fire — restart-reset + ignored interval_value

### DIFF
--- a/app/routers/schedules.py
+++ b/app/routers/schedules.py
@@ -296,6 +296,7 @@ async def create_schedule(
             plan_mode=schedule.plan_mode,
             ai_profile_id=schedule.ai_profile_id,
             phase_mode=schedule.phase_mode,
+            created_at=schedule.created_at,
         )
     except Exception as e:
         logger.exception(
@@ -470,6 +471,7 @@ async def update_schedule(
                 plan_mode=schedule.plan_mode,
                 ai_profile_id=schedule.ai_profile_id,
                 phase_mode=schedule.phase_mode,
+                created_at=schedule.created_at,
             )
         except Exception as e:
             logger.exception(
@@ -566,6 +568,7 @@ async def resume_schedule(
             plan_mode=schedule.plan_mode,
             ai_profile_id=schedule.ai_profile_id,
             phase_mode=schedule.phase_mode,
+            created_at=schedule.created_at,
         )
     except Exception as e:
         logger.exception('Failed to resume job for schedule %s', schedule.id)

--- a/app/routers/schedules.py
+++ b/app/routers/schedules.py
@@ -37,7 +37,7 @@ from app.routers.schedule_planning import (
     validate_finalize_description,
 )
 from app.scheduler.cron import (
-    add_schedule_job,
+    add_schedule_job_for,
     get_schedule_next_run,
     pause_schedule_job,
     remove_schedule_job,
@@ -283,21 +283,7 @@ async def create_schedule(
 
     # Register APScheduler job
     try:
-        add_schedule_job(
-            schedule_id=schedule.id,
-            task_title=schedule.title,
-            schedule_type=schedule.schedule_type,
-            schedule_time=schedule.schedule_time,
-            schedule_day=schedule.schedule_day,
-            interval_value=schedule.interval_value,
-            timezone=schedule.timezone,
-            store_id=schedule.store_id,
-            description=schedule.description,
-            plan_mode=schedule.plan_mode,
-            ai_profile_id=schedule.ai_profile_id,
-            phase_mode=schedule.phase_mode,
-            created_at=schedule.created_at,
-        )
+        add_schedule_job_for(schedule)
     except Exception as e:
         logger.exception(
             'Failed to add APScheduler job for schedule %s',
@@ -458,21 +444,7 @@ async def update_schedule(
     remove_schedule_job(schedule.id)
     if schedule.is_active:
         try:
-            add_schedule_job(
-                schedule_id=schedule.id,
-                task_title=schedule.title,
-                schedule_type=schedule.schedule_type,
-                schedule_time=schedule.schedule_time,
-                schedule_day=schedule.schedule_day,
-                interval_value=schedule.interval_value,
-                timezone=schedule.timezone,
-                store_id=schedule.store_id,
-                description=schedule.description,
-                plan_mode=schedule.plan_mode,
-                ai_profile_id=schedule.ai_profile_id,
-                phase_mode=schedule.phase_mode,
-                created_at=schedule.created_at,
-            )
+            add_schedule_job_for(schedule)
         except Exception as e:
             logger.exception(
                 'Failed to recreate job for schedule %s',
@@ -555,21 +527,7 @@ async def resume_schedule(
     # Re-add the job (in case it was removed rather than paused)
     remove_schedule_job(schedule.id)
     try:
-        add_schedule_job(
-            schedule_id=schedule.id,
-            task_title=schedule.title,
-            schedule_type=schedule.schedule_type,
-            schedule_time=schedule.schedule_time,
-            schedule_day=schedule.schedule_day,
-            interval_value=schedule.interval_value,
-            timezone=schedule.timezone,
-            store_id=schedule.store_id,
-            description=schedule.description,
-            plan_mode=schedule.plan_mode,
-            ai_profile_id=schedule.ai_profile_id,
-            phase_mode=schedule.phase_mode,
-            created_at=schedule.created_at,
-        )
+        add_schedule_job_for(schedule)
     except Exception as e:
         logger.exception('Failed to resume job for schedule %s', schedule.id)
         raise HTTPException(

--- a/app/scheduler/cron.py
+++ b/app/scheduler/cron.py
@@ -5,7 +5,7 @@ Uses MemoryJobStore — the Schedule DB table is the source of truth;
 APScheduler jobs are rebuilt on startup via rebuild_schedule_jobs().
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 from zoneinfo import ZoneInfo
 
@@ -322,6 +322,60 @@ def _interval_start(
     return start
 
 
+def _weekly_start(
+    anchor: datetime | None,
+    tz: ZoneInfo,
+    schedule_day: int | None,
+    hour: int,
+    minute: int,
+) -> datetime | None:
+    """``start_date`` for an every-N-weeks IntervalTrigger.
+
+    Cron cannot express "every N weeks" (its day-of-week field has no
+    multi-week stride), so weekly schedules with ``interval_value > 1``
+    use an IntervalTrigger of ``weeks=N``. Its grid must be pinned to
+    the chosen ISO weekday at HH:MM and anchored to a fixed reference
+    (``created_at``) so it neither drifts off the weekday nor resets on
+    restart — same rationale as :func:`_interval_start`.
+
+    Returns ``None`` when no anchor is available (legacy floating
+    fallback for direct callers).
+    """
+    if anchor is None:
+        return None
+    start = anchor.astimezone(tz).replace(
+        hour=hour, minute=minute, second=0, microsecond=0
+    )
+    if schedule_day is not None:
+        # Shift within the anchor's own week onto the target ISO weekday
+        # (Mon=1..Sun=7). Any such date is a valid grid origin; the
+        # N-week stride then keeps every fire on that weekday.
+        start += timedelta(days=schedule_day - start.isoweekday())
+    return start
+
+
+def _monthly_months(anchor: datetime | None, interval_value: int) -> str:
+    """Cron ``month`` field for an every-N-months schedule.
+
+    Months have no fixed length, so an IntervalTrigger can't express
+    "every N months". Instead we emit a CronTrigger whose ``month``
+    field lists the months on the N-step grid anchored at the schedule's
+    creation month, within a single 12-month cycle. This is wall-clock
+    anchored (hence restart-safe by construction) and gives an exact
+    N-month cadence whenever ``N`` divides 12 (2, 3, 4, 6, 12). For
+    other ``N`` the pattern repeats each calendar year, so the
+    year-boundary gap differs from N — an accepted, documented limit for
+    a rare case, still far better than the old behaviour of ignoring N
+    and firing every month.
+    """
+    base = anchor.month if anchor else 1
+    months = sorted(
+        {((base - 1 + k * interval_value) % 12) + 1
+         for k in range(0, (11 // interval_value) + 1)}
+    )
+    return ','.join(str(m) for m in months)
+
+
 def build_trigger(
     schedule_type: str,
     schedule_time: str,
@@ -332,11 +386,14 @@ def build_trigger(
 ) -> CronTrigger | IntervalTrigger:
     """Build an APScheduler trigger from schedule params.
 
-    Returns CronTrigger for weekly/monthly (both wall-clock anchored and
-    thus restart-safe by construction), IntervalTrigger for
-    minutes/hours/days>1. ``anchor`` (the schedule's ``created_at``) is
-    used as the interval ``start_date`` so the fire grid is independent
-    of process-start time — see :func:`_interval_start`.
+    Trigger selection:
+    - minutes / hours / days>1 / weeks>1 → IntervalTrigger, anchored via
+      ``anchor`` (the schedule's ``created_at``) so the fire grid is a
+      function of the schedule definition, not process-start time.
+    - daily / weekly (N=1) / monthly → CronTrigger, wall-clock anchored
+      and thus restart-safe by construction. ``interval_value`` for
+      monthly is honoured by restricting the cron ``month`` field
+      (see :func:`_monthly_months`).
     """
     tz = ZoneInfo(timezone or get_server_timezone())
 
@@ -368,21 +425,28 @@ def build_trigger(
         parts = schedule_time.split(':')
         hour = int(parts[0])
         minute = int(parts[1]) if len(parts) > 1 else 0
-        kwargs: dict = {
-            'hour': hour,
-            'minute': minute,
-            'timezone': tz,
-        }
+        if schedule_day is not None and not 1 <= schedule_day <= 7:
+            # DB stores ISO weekday (Mon=1..Sun=7). Range-check explicitly
+            # so bad input fails loudly instead of being silently wrapped
+            # to a different weekday.
+            raise ValueError(
+                f'weekly schedule_day must be 1..7 (ISO weekday, '
+                f'Mon=1..Sun=7); got {schedule_day}'
+            )
+        if interval_value > 1:
+            # Every N weeks: cron has no N-week stride, so anchor an
+            # IntervalTrigger to the chosen weekday at HH:MM.
+            return IntervalTrigger(
+                weeks=interval_value,
+                start_date=_weekly_start(
+                    anchor, tz, schedule_day, hour, minute
+                ),
+                timezone=tz,
+            )
+        # Every week: CronTrigger fires at local HH:MM (DST-safe).
+        kwargs: dict = {'hour': hour, 'minute': minute, 'timezone': tz}
         if schedule_day is not None:
-            # DB stores ISO weekday (Mon=1..Sun=7) but APScheduler's
-            # CronTrigger uses Mon=0..Sun=6 — translate at the boundary.
-            # Range-check explicitly so bad input fails loudly instead of
-            # being silently wrapped to a different weekday.
-            if not 1 <= schedule_day <= 7:
-                raise ValueError(
-                    f'weekly schedule_day must be 1..7 (ISO weekday, '
-                    f'Mon=1..Sun=7); got {schedule_day}'
-                )
+            # APScheduler's CronTrigger uses Mon=0..Sun=6 — translate.
             kwargs['day_of_week'] = schedule_day - 1
         return CronTrigger(**kwargs)
     if schedule_type == 'monthly':
@@ -396,6 +460,10 @@ def build_trigger(
         }
         if schedule_day is not None:
             kwargs['day'] = schedule_day
+        if interval_value > 1:
+            # Every N months: restrict the cron month field to the
+            # N-step grid anchored at the creation month.
+            kwargs['month'] = _monthly_months(anchor, interval_value)
         return CronTrigger(**kwargs)
 
     # Fallback: daily

--- a/app/scheduler/cron.py
+++ b/app/scheduler/cron.py
@@ -354,7 +354,9 @@ def _weekly_start(
     return start
 
 
-def _monthly_months(anchor: datetime | None, interval_value: int) -> str:
+def _monthly_months(
+    anchor: datetime | None, tz: ZoneInfo, interval_value: int
+) -> str:
     """Cron ``month`` field for an every-N-months schedule.
 
     Months have no fixed length, so an IntervalTrigger can't express
@@ -367,8 +369,13 @@ def _monthly_months(anchor: datetime | None, interval_value: int) -> str:
     year-boundary gap differs from N — an accepted, documented limit for
     a rare case, still far better than the old behaviour of ignoring N
     and firing every month.
+
+    The anchor month is taken in the schedule's ``tz`` (the CronTrigger
+    fires there), not in ``created_at``'s stored UTC — otherwise a
+    schedule created near a month boundary would anchor to the wrong
+    month (e.g. 2026-06-30 23:00Z is already July in Asia/Shanghai).
     """
-    base = anchor.month if anchor else 1
+    base = anchor.astimezone(tz).month if anchor else 1
     months = sorted({
         ((base - 1 + k * interval_value) % 12) + 1
         for k in range(0, (11 // interval_value) + 1)
@@ -462,8 +469,8 @@ def build_trigger(
             kwargs['day'] = schedule_day
         if interval_value > 1:
             # Every N months: restrict the cron month field to the
-            # N-step grid anchored at the creation month.
-            kwargs['month'] = _monthly_months(anchor, interval_value)
+            # N-step grid anchored at the creation month (in tz).
+            kwargs['month'] = _monthly_months(anchor, tz, interval_value)
         return CronTrigger(**kwargs)
 
     # Fallback: daily
@@ -620,6 +627,31 @@ def add_schedule_job(
     )
 
 
+def add_schedule_job_for(sched: Schedule) -> None:
+    """Register the APScheduler job for a Schedule row.
+
+    Thin adapter over :func:`add_schedule_job` that maps every field
+    from the ORM object. The single mapping point for create / update /
+    activate / rebuild, so the argument list can't drift between paths
+    (it once did — ``interval_value`` was silently dropped on update).
+    """
+    add_schedule_job(
+        schedule_id=sched.id,
+        task_title=sched.title,
+        schedule_type=sched.schedule_type,
+        schedule_time=sched.schedule_time,
+        schedule_day=sched.schedule_day,
+        interval_value=sched.interval_value,
+        timezone=sched.timezone,
+        store_id=sched.store_id,
+        description=sched.description,
+        plan_mode=sched.plan_mode,
+        ai_profile_id=sched.ai_profile_id,
+        phase_mode=sched.phase_mode,
+        created_at=sched.created_at,
+    )
+
+
 def remove_schedule_job(schedule_id: str) -> bool:
     """Remove the APScheduler job for a schedule."""
     job_id = f'schedule_{schedule_id}'
@@ -678,21 +710,7 @@ async def rebuild_schedule_jobs():
     count = 0
     for sched in schedules:
         try:
-            add_schedule_job(
-                schedule_id=sched.id,
-                task_title=sched.title,
-                schedule_type=sched.schedule_type,
-                schedule_time=sched.schedule_time,
-                schedule_day=sched.schedule_day,
-                interval_value=sched.interval_value,
-                timezone=sched.timezone,
-                store_id=sched.store_id,
-                description=sched.description,
-                plan_mode=sched.plan_mode,
-                ai_profile_id=sched.ai_profile_id,
-                phase_mode=sched.phase_mode,
-                created_at=sched.created_at,
-            )
+            add_schedule_job_for(sched)
             count += 1
         except Exception:
             logger.exception('Failed to rebuild job for schedule %s', sched.id)

--- a/app/scheduler/cron.py
+++ b/app/scheduler/cron.py
@@ -5,6 +5,7 @@ Uses MemoryJobStore — the Schedule DB table is the source of truth;
 APScheduler jobs are rebuilt on startup via rebuild_schedule_jobs().
 """
 
+from datetime import datetime
 import logging
 from zoneinfo import ZoneInfo
 
@@ -283,24 +284,74 @@ async def _run_task_job(
                 )
 
 
+def _interval_start(
+    anchor: datetime | None,
+    tz: ZoneInfo,
+    hour: int | None = None,
+    minute: int | None = None,
+) -> datetime | None:
+    """Compute a stable ``start_date`` for an IntervalTrigger.
+
+    APScheduler's IntervalTrigger, given no ``start_date``, anchors its
+    first fire to ``now + interval`` at the moment the job is *added*.
+    Because the job store is in-memory and every server start rebuilds
+    all jobs (:func:`rebuild_schedule_jobs`), that makes the next-fire
+    time a function of process-start time: each restart re-anchors the
+    countdown, so an interval longer than the restart cadence never
+    elapses and the schedule never fires. See the fire-cadence tests.
+
+    Anchoring ``start_date`` to a fixed reference (the schedule's
+    ``created_at``) instead makes the fire grid ``start + k*interval``
+    a pure function of the schedule definition — identical on every
+    rebuild, so restarts no longer reset the clock. When ``hour``/
+    ``minute`` are given (day-granularity schedules) the anchor's
+    time-of-day is pinned to the configured HH:MM so fires land at the
+    wall-clock time the user chose, not at whatever minute the anchor
+    happened to carry.
+
+    Returns ``None`` when no anchor is available, preserving the legacy
+    floating behaviour for direct callers that don't supply one.
+    """
+    if anchor is None:
+        return None
+    start = anchor.astimezone(tz)
+    if hour is not None:
+        start = start.replace(
+            hour=hour, minute=minute or 0, second=0, microsecond=0
+        )
+    return start
+
+
 def build_trigger(
     schedule_type: str,
     schedule_time: str,
     schedule_day: int | None = None,
     interval_value: int = 1,
     timezone: str | None = None,
+    anchor: datetime | None = None,
 ) -> CronTrigger | IntervalTrigger:
     """Build an APScheduler trigger from schedule params.
 
-    Returns CronTrigger for weekly/monthly, IntervalTrigger for
-    minutes/hours/days.
+    Returns CronTrigger for weekly/monthly (both wall-clock anchored and
+    thus restart-safe by construction), IntervalTrigger for
+    minutes/hours/days>1. ``anchor`` (the schedule's ``created_at``) is
+    used as the interval ``start_date`` so the fire grid is independent
+    of process-start time — see :func:`_interval_start`.
     """
     tz = ZoneInfo(timezone or get_server_timezone())
 
     if schedule_type == 'minutes':
-        return IntervalTrigger(minutes=max(1, interval_value), timezone=tz)
+        return IntervalTrigger(
+            minutes=max(1, interval_value),
+            start_date=_interval_start(anchor, tz),
+            timezone=tz,
+        )
     if schedule_type == 'hours':
-        return IntervalTrigger(hours=max(1, interval_value), timezone=tz)
+        return IntervalTrigger(
+            hours=max(1, interval_value),
+            start_date=_interval_start(anchor, tz),
+            timezone=tz,
+        )
     if schedule_type == 'days':
         parts = schedule_time.split(':')
         hour = int(parts[0])
@@ -308,7 +359,11 @@ def build_trigger(
         if interval_value == 1:
             # Exact daily at HH:MM via cron
             return CronTrigger(hour=hour, minute=minute, timezone=tz)
-        return IntervalTrigger(days=interval_value, timezone=tz)
+        return IntervalTrigger(
+            days=interval_value,
+            start_date=_interval_start(anchor, tz, hour, minute),
+            timezone=tz,
+        )
     if schedule_type == 'weekly':
         parts = schedule_time.split(':')
         hour = int(parts[0])
@@ -412,6 +467,7 @@ def add_schedule_job(
     plan_mode: bool = False,
     ai_profile_id: str | None = 'default',
     phase_mode: str = 'fanout',
+    created_at: str | None = None,
 ) -> None:
     """Add an APScheduler job for a Schedule record.
 
@@ -420,13 +476,29 @@ def add_schedule_job(
       (two_phase handled inside the fanout runner).
     - ``'single'``: route to ``run_single_job`` — one no-store task
       per tick, no fan-out.
+
+    ``created_at`` (the schedule's ISO creation timestamp) anchors
+    interval triggers so their fire grid survives restarts — always
+    pass it from the Schedule row. See :func:`_interval_start`.
     """
+    anchor: datetime | None = None
+    if created_at:
+        try:
+            anchor = datetime.fromisoformat(created_at)
+        except ValueError:
+            logger.warning(
+                'Schedule %s: unparseable created_at %r; interval fires '
+                'will float from process-start time',
+                schedule_id,
+                created_at,
+            )
     trigger = build_trigger(
         schedule_type,
         schedule_time,
         schedule_day,
         interval_value,
         timezone or get_server_timezone(),
+        anchor=anchor,
     )
 
     job_id = f'schedule_{schedule_id}'
@@ -551,6 +623,7 @@ async def rebuild_schedule_jobs():
                 plan_mode=sched.plan_mode,
                 ai_profile_id=sched.ai_profile_id,
                 phase_mode=sched.phase_mode,
+                created_at=sched.created_at,
             )
             count += 1
         except Exception:

--- a/app/scheduler/cron.py
+++ b/app/scheduler/cron.py
@@ -369,10 +369,10 @@ def _monthly_months(anchor: datetime | None, interval_value: int) -> str:
     and firing every month.
     """
     base = anchor.month if anchor else 1
-    months = sorted(
-        {((base - 1 + k * interval_value) % 12) + 1
-         for k in range(0, (11 // interval_value) + 1)}
-    )
+    months = sorted({
+        ((base - 1 + k * interval_value) % 12) + 1
+        for k in range(0, (11 // interval_value) + 1)
+    })
     return ','.join(str(m) for m in months)
 
 

--- a/frontend/src/__tests__/scheduleBadge.test.ts
+++ b/frontend/src/__tests__/scheduleBadge.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import enTranslation from '../i18n/locales/en/translation.json'
+import { formatScheduleBadge } from '../lib/scheduleBadge'
+import type { Schedule } from '../types'
+
+const inst = i18n.createInstance()
+inst.use(initReactI18next).init({
+  resources: { en: { translation: enTranslation } },
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false },
+})
+const t = (k: string) => inst.t(k)
+
+function sched(overrides: Partial<Schedule>): Schedule {
+  return {
+    id: 's',
+    store_id: null,
+    title: 'x',
+    description: null,
+    platform: null,
+    country: null,
+    plan: null,
+    schedule_type: 'days',
+    schedule_time: '04:00',
+    schedule_day: null,
+    interval_value: 1,
+    timezone: 'UTC',
+    is_active: true,
+    plan_mode: false,
+    ai_profile_id: null,
+    created_by: 'u',
+    created_at: '',
+    updated_at: '',
+    next_run: null,
+    child_task_count: 0,
+    last_run_status: null,
+    ...overrides,
+  } as Schedule
+}
+
+describe('formatScheduleBadge — honours interval_value for every type', () => {
+  it('weekly every 2 weeks reads "Every 2 weeks", not "Weekly"', () => {
+    const badge = formatScheduleBadge(
+      sched({ schedule_type: 'weekly', interval_value: 2, schedule_day: 1 }),
+      t,
+    )
+    // The bug: this used to render "Weekly Mon 04:00", hiding the 2.
+    expect(badge).toBe('Every 2 weeks Monday 04:00')
+    expect(badge).not.toMatch(/^Weekly/)
+  })
+
+  it('weekly every 1 week still reads "Weekly"', () => {
+    expect(
+      formatScheduleBadge(
+        sched({ schedule_type: 'weekly', interval_value: 1, schedule_day: 3 }),
+        t,
+      ),
+    ).toBe('Weekly Wednesday 04:00')
+  })
+
+  it('monthly every 3 months reads "Every 3 months", not "Monthly"', () => {
+    const badge = formatScheduleBadge(
+      sched({ schedule_type: 'monthly', interval_value: 3, schedule_day: 15 }),
+      t,
+    )
+    expect(badge).toBe('Every 3 months 15 04:00')
+    expect(badge).not.toMatch(/^Monthly/)
+  })
+
+  it('monthly every 1 month still reads "Monthly"', () => {
+    expect(
+      formatScheduleBadge(
+        sched({ schedule_type: 'monthly', interval_value: 1, schedule_day: 1 }),
+        t,
+      ),
+    ).toBe('Monthly 1 04:00')
+  })
+
+  it('days/minutes/hours unchanged', () => {
+    expect(
+      formatScheduleBadge(
+        sched({ schedule_type: 'days', interval_value: 3 }),
+        t,
+      ),
+    ).toBe('Every 3 days 04:00')
+    expect(
+      formatScheduleBadge(
+        sched({ schedule_type: 'days', interval_value: 1 }),
+        t,
+      ),
+    ).toBe('Daily 04:00')
+    expect(
+      formatScheduleBadge(
+        sched({ schedule_type: 'minutes', interval_value: 15 }),
+        t,
+      ),
+    ).toBe('Every 15 minutes')
+  })
+})

--- a/frontend/src/components/ScheduleForm.tsx
+++ b/frontend/src/components/ScheduleForm.tsx
@@ -129,8 +129,8 @@ export function ScheduleForm({
             <option value="minutes">{t('schedules.minutes')}</option>
             <option value="hours">{t('schedules.hours')}</option>
             <option value="days">{t('schedules.days')}</option>
-            <option value="weekly">{t('schedules.weekly')}</option>
-            <option value="monthly">{t('schedules.monthly')}</option>
+            <option value="weekly">{t('schedules.weeks')}</option>
+            <option value="monthly">{t('schedules.months')}</option>
           </select>
         </div>
       </div>

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -617,6 +617,8 @@
     "minutes": "minutes",
     "hours": "hours",
     "days": "days",
+    "weeks": "weeks",
+    "months": "months",
     "daily": "Daily",
     "weekly": "Weekly",
     "monthly": "Monthly",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -617,6 +617,8 @@
     "minutes": "分钟",
     "hours": "小时",
     "days": "天",
+    "weeks": "周",
+    "months": "个月",
     "daily": "每天",
     "weekly": "每周",
     "monthly": "每月",

--- a/frontend/src/lib/scheduleBadge.ts
+++ b/frontend/src/lib/scheduleBadge.ts
@@ -51,8 +51,6 @@ export function formatScheduleBadge(s: BadgeFields, t: TFunc): string {
         ? `${t('schedules.monthly')} ${dom} ${time}`
         : `${every} ${n} ${t('schedules.months')} ${dom} ${time}`
     }
-    case 'daily':
-      return `${t('schedules.daily')} ${time}`
     default:
       return `${s.schedule_type} ${time}`
   }

--- a/frontend/src/lib/scheduleBadge.ts
+++ b/frontend/src/lib/scheduleBadge.ts
@@ -1,0 +1,59 @@
+import type { Schedule } from '../types'
+
+type TFunc = (key: string) => string
+
+type BadgeFields = Pick<
+  Schedule,
+  'schedule_type' | 'schedule_time' | 'schedule_day' | 'interval_value'
+>
+
+/**
+ * Human-readable frequency badge for a schedule.
+ *
+ * Honours `interval_value` for every schedule type — including weekly
+ * and monthly, which previously always rendered "Weekly"/"Monthly" and
+ * hid the fact that a user had asked for "every 2 weeks" / "every 3
+ * months". Kept as a pure function (no React) so the cadence wording is
+ * unit-testable and can't silently drift from the backend trigger.
+ */
+export function formatScheduleBadge(s: BadgeFields, t: TFunc): string {
+  const time = s.schedule_time?.slice(0, 5) || '00:00'
+  const n = s.interval_value || 1
+  const DAYS = [
+    t('schedules.mon'),
+    t('schedules.tue'),
+    t('schedules.wed'),
+    t('schedules.thu'),
+    t('schedules.fri'),
+    t('schedules.sat'),
+    t('schedules.sun'),
+  ]
+  const every = t('schedules.every')
+
+  switch (s.schedule_type) {
+    case 'minutes':
+      return `${every} ${n} ${t('schedules.minutes')}`
+    case 'hours':
+      return `${every} ${n} ${t('schedules.hours')}`
+    case 'days':
+      return n === 1
+        ? `${t('schedules.daily')} ${time}`
+        : `${every} ${n} ${t('schedules.days')} ${time}`
+    case 'weekly': {
+      const day = DAYS[(s.schedule_day || 1) - 1]
+      return n === 1
+        ? `${t('schedules.weekly')} ${day} ${time}`
+        : `${every} ${n} ${t('schedules.weeks')} ${day} ${time}`
+    }
+    case 'monthly': {
+      const dom = s.schedule_day || 1
+      return n === 1
+        ? `${t('schedules.monthly')} ${dom} ${time}`
+        : `${every} ${n} ${t('schedules.months')} ${dom} ${time}`
+    }
+    case 'daily':
+      return `${t('schedules.daily')} ${time}`
+    default:
+      return `${s.schedule_type} ${time}`
+  }
+}

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { api } from '../api'
 import { sendEvent, ageBucket } from '../lib/telemetry'
 import { FrontendEvent } from '../lib/telemetryEvents'
+import { formatScheduleBadge } from '../lib/scheduleBadge'
 import { StatusBadge } from '../components/ui'
 import { ConversationStream } from '../components/conversation/ConversationStream'
 import { ScheduleList } from '../components/ScheduleList'
@@ -243,18 +244,7 @@ export function TasksView({
     } catch { /* ignore */ }
   }
 
-  const DAYS = [t('schedules.mon'), t('schedules.tue'), t('schedules.wed'), t('schedules.thu'), t('schedules.fri'), t('schedules.sat'), t('schedules.sun')]
-  const getScheduleBadge = (s: Schedule) => {
-    const time = s.schedule_time?.slice(0, 5) || '00:00'
-    const n = s.interval_value || 1
-    if (s.schedule_type === 'minutes') return `${t('schedules.every')} ${n} ${t('schedules.minutes')}`
-    if (s.schedule_type === 'hours') return `${t('schedules.every')} ${n} ${t('schedules.hours')}`
-    if (s.schedule_type === 'days') return n === 1 ? `${t('schedules.daily')} ${time}` : `${t('schedules.every')} ${n} ${t('schedules.days')} ${time}`
-    if (s.schedule_type === 'weekly') return `${t('schedules.weekly')} ${DAYS[(s.schedule_day || 1) - 1]} ${time}`
-    if (s.schedule_type === 'monthly') return `${t('schedules.monthly')} ${s.schedule_day || 1} ${time}`
-    if (s.schedule_type === 'daily') return `${t('schedules.daily')} ${time}`
-    return `${s.schedule_type} ${time}`
-  }
+  const getScheduleBadge = (s: Schedule) => formatScheduleBadge(s, t)
 
   const onetimeTasks = tasks.filter(task => !task.schedule_id)
 

--- a/tests/unit/test_scheduler_fire_cadence.py
+++ b/tests/unit/test_scheduler_fire_cadence.py
@@ -112,7 +112,7 @@ class TestFiresAtConfiguredCadence:
         fires = _fires_in_window(trig, start, timedelta(days=28))
 
         assert len(fires) == 4, fires
-        assert all(f.strftime('%A') == 'Monday' for f in fires), fires
+        assert all(f.isoweekday() == 1 for f in fires), fires  # Monday
         assert all(f.hour == 4 for f in fires), fires
         gaps = {(b - a) for a, b in zip(fires, fires[1:])}
         assert gaps == {timedelta(days=7)}, gaps
@@ -144,7 +144,7 @@ class TestWeeklyMonthlyInterval:
         gaps = [b - a for a, b in zip(fires, fires[1:])]
         assert min(gaps) >= timedelta(days=14), gaps
         assert set(gaps) == {timedelta(days=14)}, gaps
-        assert all(f.strftime('%A') == 'Monday' for f in fires), fires
+        assert all(f.isoweekday() == 1 for f in fires), fires  # Monday
         assert all(f.hour == 4 and f.minute == 0 for f in fires), fires
 
     def test_every_3_weeks_fires_21_days_apart(self):
@@ -163,7 +163,7 @@ class TestWeeklyMonthlyInterval:
         assert {b - a for a, b in zip(fires, fires[1:])} == {
             timedelta(days=21)
         }, fires
-        assert all(f.strftime('%A') == 'Wednesday' for f in fires), fires
+        assert all(f.isoweekday() == 3 for f in fires), fires  # Wednesday
 
     def test_weekly_interval_1_still_fires_every_7_days(self):
         trig = cron_mod.build_trigger(
@@ -200,6 +200,32 @@ class TestWeeklyMonthlyInterval:
         # Consecutive fires advance by exactly N calendar months.
         idx = [f.year * 12 + f.month for f in fires]
         assert {b - a for a, b in zip(idx, idx[1:])} == {n}, fires
+
+    def test_every_n_months_anchors_month_in_schedule_tz_not_utc(self):
+        """Month grid is anchored in the schedule tz, not stored UTC.
+
+        A schedule created 2026-06-30 23:00Z is already 2026-07-01 in
+        Asia/Shanghai. The every-2-months grid must anchor to July
+        (odd months) — anchoring to the UTC month (June) would fire on
+        the wrong months. Regression for the tz-vs-UTC anchor bug.
+        """
+        utc_anchor = datetime(2026, 6, 30, 23, 0, tzinfo=ZoneInfo('UTC'))
+        assert utc_anchor.astimezone(TZ).month == 7  # sanity: local July
+        trig = cron_mod.build_trigger(
+            'monthly',
+            '04:00',
+            schedule_day=15,
+            interval_value=2,
+            timezone=TZ_NAME,
+            anchor=utc_anchor,
+        )
+        start = datetime(2026, 7, 1, 0, 0, tzinfo=TZ)
+        fires = _fires_in_window(trig, start, timedelta(days=400))
+
+        assert len(fires) >= 3, fires
+        # July-anchored every-2-months → odd months only.
+        assert all(f.month % 2 == 1 for f in fires), [f.month for f in fires]
+        assert fires[0].month == 7 and fires[0].day == 15, fires
 
     def test_monthly_interval_1_still_fires_every_month(self):
         trig = cron_mod.build_trigger(

--- a/tests/unit/test_scheduler_fire_cadence.py
+++ b/tests/unit/test_scheduler_fire_cadence.py
@@ -1,0 +1,221 @@
+"""Fire-cadence + restart-invariance guards for the scheduler.
+
+These pin the behaviour that CI previously never checked: that a
+schedule actually fires at its configured wall-clock cadence, and that
+the next-fire time does NOT move when the job is rebuilt (which happens
+on every server start, since the job store is in-memory).
+
+The original bug: ``build_trigger`` returned a bare ``IntervalTrigger``
+for ``minutes``/``hours``/``days>1`` with no ``start_date``. APScheduler
+then anchored the first fire to ``now + interval`` at job-add time, so:
+  * the configured HH:MM was ignored (a 04:00 "every 3 days" fired at
+    whatever o'clock the server booted), and
+  * every restart re-anchored the countdown to ``restart + interval`` —
+    an interval longer than the restart cadence therefore NEVER elapsed
+    and the schedule fired exactly zero times after creation.
+
+We drive ``trigger.get_next_fire_time`` with a simulated clock (exactly
+what APScheduler does internally), which makes "mock time passing"
+deterministic and clock-free. One live-scheduler test then confirms an
+anchored interval trigger really fires and runs its side effect.
+"""
+
+import asyncio
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+import pytest
+
+from app.scheduler import cron as cron_mod
+
+pytestmark = pytest.mark.unit
+
+TZ_NAME = 'Asia/Shanghai'
+TZ = ZoneInfo(TZ_NAME)
+# A fixed creation anchor at an awkward time-of-day (12:20) — proves the
+# fire time is pinned to the configured HH:MM, not inherited from when
+# the schedule happened to be created / the server happened to boot.
+ANCHOR = datetime(2026, 6, 22, 12, 20, 15, tzinfo=TZ)
+
+
+def _fires_in_window(trigger, start_now, window):
+    """Enumerate the fire times a trigger produces as the clock advances.
+
+    Mirrors APScheduler's own loop: after each fire, the simulated clock
+    jumps to that fire time and asks for the next one. Returns every fire
+    at or before ``start_now + window``.
+    """
+    fires = []
+    prev = None
+    now = start_now
+    end = start_now + window
+    # Bound the loop defensively so a broken (never-advancing) trigger
+    # can't spin forever.
+    for _ in range(10_000):
+        nxt = trigger.get_next_fire_time(prev, now)
+        if nxt is None or nxt > end:
+            break
+        fires.append(nxt)
+        prev = nxt
+        now = nxt
+    return fires
+
+
+class TestFiresAtConfiguredCadence:
+    """Simulated time passes → the schedule fires on the right grid."""
+
+    def test_every_3_days_fires_at_configured_hhmm_every_3_days(self):
+        trig = cron_mod.build_trigger(
+            'days', '04:00', interval_value=3, timezone=TZ_NAME, anchor=ANCHOR
+        )
+        start = datetime(2026, 6, 23, 9, 0, tzinfo=TZ)
+        fires = _fires_in_window(trig, start, timedelta(days=30))
+
+        assert len(fires) >= 8, fires
+        # Every fire lands at the configured 04:00 — not at boot o'clock.
+        assert all(f.hour == 4 and f.minute == 0 for f in fires), fires
+        # ...and consecutive fires are exactly 3 days apart.
+        gaps = {(b - a) for a, b in zip(fires, fires[1:])}
+        assert gaps == {timedelta(days=3)}, gaps
+
+    def test_hourly_fires_every_hour(self):
+        trig = cron_mod.build_trigger(
+            'hours', '00:00', interval_value=1, timezone=TZ_NAME, anchor=ANCHOR
+        )
+        start = datetime(2026, 6, 23, 9, 5, tzinfo=TZ)
+        fires = _fires_in_window(trig, start, timedelta(hours=24))
+
+        assert len(fires) >= 23, fires
+        gaps = {(b - a) for a, b in zip(fires, fires[1:])}
+        assert gaps == {timedelta(hours=1)}, gaps
+
+    def test_daily_fires_once_a_day_at_hhmm(self):
+        trig = cron_mod.build_trigger(
+            'days', '04:00', interval_value=1, timezone=TZ_NAME, anchor=ANCHOR
+        )
+        start = datetime(2026, 6, 23, 9, 0, tzinfo=TZ)
+        fires = _fires_in_window(trig, start, timedelta(days=7))
+
+        assert len(fires) == 7, fires
+        assert all(f.hour == 4 and f.minute == 0 for f in fires), fires
+        gaps = {(b - a) for a, b in zip(fires, fires[1:])}
+        assert gaps == {timedelta(days=1)}, gaps
+
+    def test_weekly_fires_once_a_week_on_configured_day(self):
+        # schedule_day=1 → Monday (ISO). 2026-06-22 is a Monday.
+        trig = cron_mod.build_trigger(
+            'weekly', '04:00', schedule_day=1, timezone=TZ_NAME, anchor=ANCHOR
+        )
+        start = datetime(2026, 6, 23, 9, 0, tzinfo=TZ)
+        fires = _fires_in_window(trig, start, timedelta(days=28))
+
+        assert len(fires) == 4, fires
+        assert all(f.strftime('%A') == 'Monday' for f in fires), fires
+        assert all(f.hour == 4 for f in fires), fires
+        gaps = {(b - a) for a, b in zip(fires, fires[1:])}
+        assert gaps == {timedelta(days=7)}, gaps
+
+
+class TestRestartInvariance:
+    """Rebuilding the job (== a server restart) must not move next-fire.
+
+    This is the core regression guard. Before the fix, rebuilding an
+    interval trigger re-anchored its first fire to ``now + interval``,
+    so frequent restarts pushed a long-interval schedule's next fire
+    perpetually into the future and it never fired.
+    """
+
+    @pytest.mark.parametrize(
+        'kind,kwargs',
+        [
+            ('hours', {'schedule_type': 'hours', 'interval_value': 6}),
+            ('daily', {'schedule_type': 'days', 'interval_value': 1}),
+            ('every_3_days', {'schedule_type': 'days', 'interval_value': 3}),
+            (
+                'weekly',
+                {'schedule_type': 'weekly', 'schedule_day': 1},
+            ),
+        ],
+    )
+    def test_next_fire_is_identical_across_rebuilds(self, kind, kwargs):
+        # First build (initial job registration) and first-fire query.
+        trig_a = cron_mod.build_trigger(
+            schedule_time='04:00', timezone=TZ_NAME, anchor=ANCHOR, **kwargs
+        )
+        now0 = datetime(2026, 6, 23, 3, 0, tzinfo=TZ)
+        fire_a = trig_a.get_next_fire_time(None, now0)
+        assert fire_a is not None
+
+        # Simulate a later server restart that lands STILL BEFORE that
+        # fire (halfway to it) — rebuild the job from the same schedule
+        # row and re-query. The pending fire must not have drifted.
+        # (Advancing past the fire would legitimately move it; that's
+        # firing, not drift, so we stay before it.)
+        trig_b = cron_mod.build_trigger(
+            schedule_time='04:00', timezone=TZ_NAME, anchor=ANCHOR, **kwargs
+        )
+        now1 = now0 + (fire_a - now0) / 2
+        fire_b = trig_b.get_next_fire_time(None, now1)
+
+        assert fire_b is not None
+        assert fire_a == fire_b, (kind, fire_a, fire_b)
+
+    def test_repeated_restarts_never_starve_a_long_interval(self):
+        """A 3-day schedule restarted every few hours still fires.
+
+        Reproduces the reported failure directly: without the anchor,
+        each rebuild reset the 3-day clock and the fire never arrived.
+        """
+        first_fire = None
+        now = datetime(2026, 6, 23, 3, 0, tzinfo=TZ)
+        # Restart every 5 hours for ~4 simulated days.
+        for _ in range(20):
+            trig = cron_mod.build_trigger(
+                'days',
+                '04:00',
+                interval_value=3,
+                timezone=TZ_NAME,
+                anchor=ANCHOR,
+            )
+            nxt = trig.get_next_fire_time(None, now)
+            if first_fire is None:
+                first_fire = nxt
+                assert first_fire is not None
+            # While the clock hasn't reached the fire, restarts must NOT
+            # push it out (the old bug did exactly that). Once the clock
+            # crosses it, it has fired — stop asserting.
+            if now < first_fire:
+                assert nxt == first_fire, (now, nxt, first_fire)
+            now += timedelta(hours=5)
+        # The clock eventually crosses the fire — i.e. it really fires,
+        # instead of being perpetually deferred by the restarts.
+        assert now > first_fire
+
+
+class TestLiveSchedulerActuallyFires:
+    """End-to-end: an anchored interval trigger fires under a real
+    AsyncIOScheduler and runs its side effect (writes a file)."""
+
+    async def test_anchored_interval_job_runs_and_writes_file(self, tmp_path):
+        marker = tmp_path / 'fired.txt'
+        fired = asyncio.Event()
+
+        def job():
+            marker.write_text('fired')
+            fired.set()
+
+        sched = AsyncIOScheduler()
+        # start_date in the immediate past → the 1s grid's next point is
+        # ~1s away; the same anchoring pattern build_trigger now uses.
+        start = datetime.now(TZ) - timedelta(seconds=10)
+        trig = IntervalTrigger(seconds=1, start_date=start, timezone=TZ)
+        sched.add_job(job, trig, id='fire-test', max_instances=1)
+        sched.start()
+        try:
+            await asyncio.wait_for(fired.wait(), timeout=5.0)
+        finally:
+            sched.shutdown(wait=False)
+
+        assert marker.read_text() == 'fired'

--- a/tests/unit/test_scheduler_fire_cadence.py
+++ b/tests/unit/test_scheduler_fire_cadence.py
@@ -118,6 +118,104 @@ class TestFiresAtConfiguredCadence:
         assert gaps == {timedelta(days=7)}, gaps
 
 
+class TestWeeklyMonthlyInterval:
+    """``interval_value`` must be honoured for weekly/monthly.
+
+    Regression: weekly/monthly ignored ``interval_value`` entirely, so a
+    schedule the user set to "every 2 weeks" fired every *1* week — more
+    often than the configured interval. These pin the actual cadence.
+    """
+
+    def test_every_2_weeks_does_not_fire_more_often_than_14_days(self):
+        # 2026-06-22 is a Monday; schedule_day=1 → Monday.
+        trig = cron_mod.build_trigger(
+            'weekly',
+            '04:00',
+            schedule_day=1,
+            interval_value=2,
+            timezone=TZ_NAME,
+            anchor=ANCHOR,
+        )
+        start = datetime(2026, 6, 23, 9, 0, tzinfo=TZ)
+        fires = _fires_in_window(trig, start, timedelta(days=70))
+
+        assert len(fires) >= 4, fires
+        # The whole point: no two fires closer than the 2-week interval.
+        gaps = [b - a for a, b in zip(fires, fires[1:])]
+        assert min(gaps) >= timedelta(days=14), gaps
+        assert set(gaps) == {timedelta(days=14)}, gaps
+        assert all(f.strftime('%A') == 'Monday' for f in fires), fires
+        assert all(f.hour == 4 and f.minute == 0 for f in fires), fires
+
+    def test_every_3_weeks_fires_21_days_apart(self):
+        trig = cron_mod.build_trigger(
+            'weekly',
+            '04:00',
+            schedule_day=3,  # Wednesday
+            interval_value=3,
+            timezone=TZ_NAME,
+            anchor=ANCHOR,
+        )
+        start = datetime(2026, 6, 23, 9, 0, tzinfo=TZ)
+        fires = _fires_in_window(trig, start, timedelta(days=90))
+
+        assert len(fires) >= 3, fires
+        assert {b - a for a, b in zip(fires, fires[1:])} == {
+            timedelta(days=21)
+        }, fires
+        assert all(f.strftime('%A') == 'Wednesday' for f in fires), fires
+
+    def test_weekly_interval_1_still_fires_every_7_days(self):
+        trig = cron_mod.build_trigger(
+            'weekly',
+            '04:00',
+            schedule_day=1,
+            interval_value=1,
+            timezone=TZ_NAME,
+            anchor=ANCHOR,
+        )
+        start = datetime(2026, 6, 23, 9, 0, tzinfo=TZ)
+        fires = _fires_in_window(trig, start, timedelta(days=35))
+        assert {b - a for a, b in zip(fires, fires[1:])} == {
+            timedelta(days=7)
+        }, fires
+
+    @pytest.mark.parametrize('n', [2, 3, 4, 6])
+    def test_every_n_months_steps_by_n_months(self, n):
+        # anchor month = June (6). N that divide 12 give an exact,
+        # seam-free N-month cadence including across the year boundary.
+        trig = cron_mod.build_trigger(
+            'monthly',
+            '04:00',
+            schedule_day=15,
+            interval_value=n,
+            timezone=TZ_NAME,
+            anchor=ANCHOR,
+        )
+        start = datetime(2026, 6, 1, 0, 0, tzinfo=TZ)
+        fires = _fires_in_window(trig, start, timedelta(days=800))
+
+        assert len(fires) >= 3, fires
+        assert all(f.day == 15 and f.hour == 4 for f in fires), fires
+        # Consecutive fires advance by exactly N calendar months.
+        idx = [f.year * 12 + f.month for f in fires]
+        assert {b - a for a, b in zip(idx, idx[1:])} == {n}, fires
+
+    def test_monthly_interval_1_still_fires_every_month(self):
+        trig = cron_mod.build_trigger(
+            'monthly',
+            '04:00',
+            schedule_day=15,
+            interval_value=1,
+            timezone=TZ_NAME,
+            anchor=ANCHOR,
+        )
+        start = datetime(2026, 6, 1, 0, 0, tzinfo=TZ)
+        fires = _fires_in_window(trig, start, timedelta(days=200))
+        idx = [f.year * 12 + f.month for f in fires]
+        assert {b - a for a, b in zip(idx, idx[1:])} == {1}, fires
+
+
 class TestRestartInvariance:
     """Rebuilding the job (== a server restart) must not move next-fire.
 
@@ -136,6 +234,22 @@ class TestRestartInvariance:
             (
                 'weekly',
                 {'schedule_type': 'weekly', 'schedule_day': 1},
+            ),
+            (
+                'every_2_weeks',
+                {
+                    'schedule_type': 'weekly',
+                    'schedule_day': 1,
+                    'interval_value': 2,
+                },
+            ),
+            (
+                'every_2_months',
+                {
+                    'schedule_type': 'monthly',
+                    'schedule_day': 15,
+                    'interval_value': 2,
+                },
             ),
         ],
     )


### PR DESCRIPTION
## Summary

Two related scheduler defects that both cause interval-based schedules to fire at the wrong cadence — or never at all. Found while debugging a live "every 3 days" schedule that fired exactly once (at creation) and never again.

### 1. Interval triggers reset their countdown on every restart

`build_trigger` returned a bare `IntervalTrigger` (no `start_date`) for `minutes`/`hours`/`days>1`. APScheduler then anchors the first fire to `now + interval` at job-add time. Because the job store is in-memory and every server start rebuilds all jobs (`rebuild_schedule_jobs`), each restart re-anchored the countdown to `restart_time + interval`. An interval longer than the restart cadence therefore **never elapsed** — the reported "every 3 days" schedule fired once and never again (the server restarts far more often than every 3 days). The configured HH:MM was also ignored (fires landed at boot-o'clock; a 04:00 schedule showed a 22:39 next-run).

**Fix:** derive an explicit `start_date` from the schedule's `created_at` (pinned to the configured HH:MM for day-granularity). The fire grid `start + k*interval` becomes a pure function of the schedule definition — identical on every rebuild — so restarts no longer reset the clock. Live schedules self-heal on the next restart.

### 2. Weekly/monthly ignored `interval_value` entirely

The weekly branch always built a plain weekly `CronTrigger` and monthly a plain monthly one, so "every 2 weeks" fired every week and "every 3 months" every month. The frontend mirrored the bug: the badge hardcoded "Weekly"/"Monthly" and the dropdown read "Every 2 weekly".

**Fix:**
- weekly N>1 → anchored `IntervalTrigger(weeks=N)` pinned to the chosen ISO weekday + HH:MM. N=1 keeps the DST-safe `CronTrigger`.
- monthly N>1 → `CronTrigger` with the `month` field restricted to the N-step grid anchored at the creation month (wall-clock anchored → restart-safe). Exact cadence when N divides 12; for other N the pattern repeats yearly with a documented year-boundary seam.
- Frontend: extracted the inline badge formatter into a pure, testable `lib/scheduleBadge.ts` that renders "Every N weeks/months" for N>1; fixed the dropdown grammar and added `weeks`/`months` i18n (en + zh).

## Why CI missed it

Existing scheduler tests only asserted trigger **type / timezone / interval-length** — never *when* a schedule fires or whether the fire survives a rebuild. Those are exactly the two broken properties.

## Tests (TDD — verified red against the buggy behavior, then green)

New `tests/unit/test_scheduler_fire_cadence.py`:
- **Cadence** with a simulated clock: hourly/daily/every-3-days/weekly/every-2-weeks/every-3-weeks/every-N-months fire at the right wall-clock grid.
- **Restart-invariance**: rebuilding the job (== a server restart) before the fire must not move next-fire — includes `test_repeated_restarts_never_starve_a_long_interval`, the direct repro of the reported bug.
- **`every-2-weeks` must not fire closer than 14 days** — catches the "fires more often than the interval" regression.
- Live-`AsyncIOScheduler` smoke test: an anchored interval job fires and writes a file.

New `frontend/src/__tests__/scheduleBadge.test.ts`: badge renders the interval for weekly/monthly (was hidden before).

Verification runs:
- Backend: 69 passed (fire-cadence, timezone, workflow schedule suites), ruff clean.
- Frontend: 331 passed, eslint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)