### PR TITLE
feat(tasks): 继续 (Continue) button — resume a failed task without wiping context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -464,31 +464,24 @@ export default function App() {
     }
   }
 
-  // ─── Agent helpers ─────────────────────────────────
   const stopAgent = async () => { if (!selectedTask) return; try { await api.post(`/api/tasks/${selectedTask.id}/agent/stop`) } catch { /* ignore */ }; setPendingQuestions(null) }
+  const handlerDeps = {
+    api,
+    profileId: selectedProfileId,
+    setTasks,
+    setSelectedTask,
+    setScheduleTasks,
+  }
   const retryTask = (taskId: string) =>
     retryTaskHandler(taskId, {
-      api,
-      profileId: selectedProfileId,
-      setTasks,
-      setSelectedTask,
-      setScheduleTasks,
+      ...handlerDeps,
       onCleared: () => {
         setSteps([]); setScreenshots({}); setAgentMessages([]); setTodoItems([]); setLogs([]); setConversationItems([]); setPendingQuestions(null); setSelectedAnswers({}); setOtherInputs({}); setShowOtherInput({})
       },
     })
-  // Continue (继续): non-destructive resume — keep the task's context
-  // (plan / history / session) and re-run via the /messages path.
   const continueTask = (taskId: string) =>
-    continueTaskHandler(taskId, {
-      api,
-      profileId: selectedProfileId,
-      setTasks,
-      setSelectedTask,
-      setScheduleTasks,
-    })
+    continueTaskHandler(taskId, handlerDeps)
   const deleteTask = async (taskId: string) => {
-    // Probe for children so the confirm warns about cascade.
     let childCount = 0
     try {
       const kids = await api.get(`/api/tasks?parent_task_id=${encodeURIComponent(taskId)}`) as Task[]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import { replanSchedule as replanScheduleHandler } from './handlers/replanSchedu
 import { selectSchedule as selectScheduleHandler } from './handlers/selectSchedule'
 import { submitCreateTask as submitCreateTaskHandler } from './handlers/submitCreateTask'
 import { retryTask as retryTaskHandler } from './handlers/retryTask'
+import { continueTask as continueTaskHandler } from './handlers/continueTask'
 import type {
   Store, Task, TaskStep, AgentMessage, TodoItem, AuthUser, Profile,
   ServerPlatform,
@@ -476,6 +477,16 @@ export default function App() {
         setSteps([]); setScreenshots({}); setAgentMessages([]); setTodoItems([]); setLogs([]); setConversationItems([]); setPendingQuestions(null); setSelectedAnswers({}); setOtherInputs({}); setShowOtherInput({})
       },
     })
+  // Continue (继续): non-destructive resume — keep the task's context
+  // (plan / history / session) and re-run via the /messages path.
+  const continueTask = (taskId: string) =>
+    continueTaskHandler(taskId, {
+      api,
+      profileId: selectedProfileId,
+      setTasks,
+      setSelectedTask,
+      setScheduleTasks,
+    })
   const deleteTask = async (taskId: string) => {
     // Probe for children so the confirm warns about cascade.
     let childCount = 0
@@ -689,7 +700,7 @@ export default function App() {
           profiles={profiles} selectedProfileId={selectedProfileId} setSelectedProfileId={setSelectedProfileId}
           currentUser={currentUser} showAllTasks={showAllTasks}
           openCreateModal={() => setShowCreateTask(true)} selectTask={selectTask}
-          stopAgent={stopAgent} retryTask={retryTask} deleteTask={deleteTask}
+          stopAgent={stopAgent} retryTask={retryTask} continueTask={continueTask} deleteTask={deleteTask}
           selectAnswer={selectAnswer} toggleOtherInput={toggleOtherInput}
           setOtherAnswer={setOtherAnswer} submitAllAnswers={submitAllAnswers} sendChatMessage={sendChatMessage}
           setSelectedTask={setSelectedTask} setTasks={setTasks} setCurrentUser={setCurrentUser}

--- a/frontend/src/__tests__/continueTask.test.tsx
+++ b/frontend/src/__tests__/continueTask.test.tsx
@@ -1,15 +1,16 @@
 /**
- * continueTask handler: the 继续 (Continue) button.
+ * continueTask handler: the Continue button.
  *
  * Contract (contrasts with retryTask, which wipes context):
- *  - POSTs /api/tasks/{id}/messages with the canned CONTINUE_MESSAGE
- *    (the same resume path the chat send-box uses) — NOT /retry.
+ *  - POSTs /api/tasks/{id}/messages with the canned continue message
+ *    (from i18n `tasks.continueMessage`, the same resume path the chat
+ *    send-box uses) — NOT /retry.
  *  - The optimistic patch advances status only; it must NOT clear
  *    error / plan / plan_history, so the task keeps its context while
  *    the resumed run streams in.
  */
 import { describe, it, expect, vi } from 'vitest'
-import { continueTask, CONTINUE_MESSAGE } from '../handlers/continueTask'
+import { continueTask, continueMessage } from '../handlers/continueTask'
 import type { Task } from '../types'
 
 function makeTask(extra: Partial<Task> = {}): Task {
@@ -35,7 +36,7 @@ function makeTask(extra: Partial<Task> = {}): Task {
   } as Task
 }
 
-describe('continueTask (继续 — non-destructive resume)', () => {
+describe('continueTask (Continue — non-destructive resume)', () => {
   it('posts the canned message to /messages, not /retry', async () => {
     const api = {
       post: vi.fn().mockResolvedValue({}),
@@ -49,7 +50,7 @@ describe('continueTask (继续 — non-destructive resume)', () => {
       setScheduleTasks: vi.fn(),
     })
     expect(api.post).toHaveBeenCalledWith('/api/tasks/t1/messages', {
-      content: CONTINUE_MESSAGE,
+      content: continueMessage(),
       profile_id: 'p1',
     })
     expect(api.post).not.toHaveBeenCalledWith(

--- a/frontend/src/__tests__/continueTask.test.tsx
+++ b/frontend/src/__tests__/continueTask.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * continueTask handler: the 继续 (Continue) button.
+ *
+ * Contract (contrasts with retryTask, which wipes context):
+ *  - POSTs /api/tasks/{id}/messages with the canned CONTINUE_MESSAGE
+ *    (the same resume path the chat send-box uses) — NOT /retry.
+ *  - The optimistic patch advances status only; it must NOT clear
+ *    error / plan / plan_history, so the task keeps its context while
+ *    the resumed run streams in.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { continueTask, CONTINUE_MESSAGE } from '../handlers/continueTask'
+import type { Task } from '../types'
+
+function makeTask(extra: Partial<Task> = {}): Task {
+  return {
+    id: 't1',
+    store_id: null,
+    title: 'T-1',
+    description: null,
+    status: 'failed',
+    plan: 'PRIOR PLAN',
+    result: null,
+    todos: null,
+    wait_condition: null,
+    error: 'boom',
+    plan_mode: false,
+    ai_profile_id: 'profile-old',
+    schedule_id: null,
+    batch_id: null,
+    created_at: '',
+    started_at: null,
+    completed_at: null,
+    ...extra,
+  } as Task
+}
+
+describe('continueTask (继续 — non-destructive resume)', () => {
+  it('posts the canned message to /messages, not /retry', async () => {
+    const api = {
+      post: vi.fn().mockResolvedValue({}),
+      get: vi.fn().mockRejectedValue(new Error('skip merge')),
+    }
+    await continueTask('t1', {
+      api,
+      profileId: 'p1',
+      setTasks: vi.fn(),
+      setSelectedTask: vi.fn(),
+      setScheduleTasks: vi.fn(),
+    })
+    expect(api.post).toHaveBeenCalledWith('/api/tasks/t1/messages', {
+      content: CONTINUE_MESSAGE,
+      profile_id: 'p1',
+    })
+    expect(api.post).not.toHaveBeenCalledWith(
+      '/api/tasks/t1/retry',
+      expect.anything(),
+    )
+  })
+
+  it('optimistic patch bumps status but PRESERVES error/plan/history', async () => {
+    const setSelectedTask = vi.fn()
+    const api = {
+      post: vi.fn().mockResolvedValue({}),
+      get: vi.fn().mockRejectedValue(new Error('skip merge')),
+    }
+    await continueTask('t1', {
+      api,
+      profileId: 'p1',
+      setTasks: vi.fn(),
+      setSelectedTask,
+      setScheduleTasks: vi.fn(),
+    })
+    // First call is the pre-await optimistic patch. Apply its updater
+    // to a populated failed task and assert context survives.
+    const updater = setSelectedTask.mock.calls[0][0] as (t: Task) => Task
+    const patched = updater(makeTask())
+    expect(patched.status).toBe('running')
+    expect(patched.error).toBe('boom') // NOT cleared
+    expect(patched.plan).toBe('PRIOR PLAN') // NOT cleared
+    // ai_profile_id is untouched too (retry swaps it; continue must not)
+    expect(patched.ai_profile_id).toBe('profile-old')
+  })
+})

--- a/frontend/src/__tests__/retryConfirmButtons.test.tsx
+++ b/frontend/src/__tests__/retryConfirmButtons.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * The failed-task action row shows THREE buttons: 继续 · 重试 · 删除.
+ *  - 继续 (Continue) fires immediately, NO confirm dialog.
+ *  - 重试 (Retry) is destructive → must confirm; only fires on OK.
+ *  - 删除 (Delete) unchanged (its own confirm lives in App.tsx).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { TasksView } from '../views/TasksView'
+import type { Task } from '../types'
+
+function failedTask(): Task {
+  return {
+    id: 'task-fail-1',
+    store_id: null,
+    title: 'Failed task',
+    description: null,
+    status: 'failed',
+    plan: null,
+    result: null,
+    todos: null,
+    wait_condition: null,
+    error: 'boom',
+    plan_mode: false,
+    ai_profile_id: 'default',
+    schedule_id: null,
+    batch_id: null,
+    created_at: '',
+    started_at: null,
+    completed_at: null,
+    is_plan_only: false,
+  } as Task
+}
+
+function makeProps(over: Record<string, unknown> = {}) {
+  const noop = vi.fn()
+  return {
+    taskPanelActive: true,
+    taskPanelTitle: 'Tasks',
+    tasks: [],
+    selectedTask: failedTask(),
+    steps: [],
+    screenshots: [],
+    logs: [],
+    agentMessages: [],
+    todoItems: [],
+    pendingQuestions: null,
+    conversationItems: [],
+    selectedAnswers: {},
+    otherInputs: {},
+    showOtherInput: {},
+    chatInput: '',
+    setChatInput: noop,
+    debugMode: false,
+    setDebugMode: noop,
+    profiles: [],
+    selectedProfileId: 'default',
+    setSelectedProfileId: noop,
+    currentUser: null,
+    showAllTasks: false,
+    openCreateModal: noop,
+    selectTask: noop,
+    stopAgent: noop,
+    retryTask: vi.fn(),
+    continueTask: vi.fn(),
+    deleteTask: vi.fn(),
+    selectAnswer: noop,
+    toggleOtherInput: noop,
+    setOtherAnswer: noop,
+    submitAllAnswers: noop,
+    sendChatMessage: noop,
+    setSelectedTask: noop,
+    setTasks: noop,
+    setCurrentUser: noop,
+    setEditingProfile: noop,
+    setShowProfileModal: noop,
+    questionBannerRef: { current: null },
+    taskSubTab: 'tasks',
+    setTaskSubTab: noop,
+    schedules: [],
+    selectedSchedule: null,
+    scheduleTasks: [],
+    showCreateSchedule: false,
+    setShowCreateSchedule: noop,
+    selectSchedule: noop,
+    deleteSchedule: noop,
+    toggleSchedulePause: noop,
+    triggerSchedule: noop,
+    replanSchedule: noop,
+    setSelectedSchedule: noop,
+    onScheduleUpdated: noop,
+    selectedStore: null,
+    stores: [],
+    ...over,
+  }
+}
+
+describe('failed-task action buttons: 继续 · 重试 · 删除', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('继续 resumes immediately with no confirm', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const props = makeProps()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    render(<TasksView {...(props as any)} />)
+    fireEvent.click(screen.getByRole('button', { name: /Continue|继续/ }))
+    expect(props.continueTask).toHaveBeenCalledWith('task-fail-1')
+    expect(confirmSpy).not.toHaveBeenCalled()
+  })
+
+  it('重试 does NOT fire when confirm is cancelled', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const props = makeProps()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    render(<TasksView {...(props as any)} />)
+    fireEvent.click(screen.getByRole('button', { name: /^Retry$|^重试$/ }))
+    expect(props.retryTask).not.toHaveBeenCalled()
+  })
+
+  it('重试 fires only after the confirm is accepted', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const props = makeProps()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    render(<TasksView {...(props as any)} />)
+    fireEvent.click(screen.getByRole('button', { name: /^Retry$|^重试$/ }))
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+    expect(props.retryTask).toHaveBeenCalledWith('task-fail-1')
+  })
+})

--- a/frontend/src/__tests__/retryConfirmButtons.test.tsx
+++ b/frontend/src/__tests__/retryConfirmButtons.test.tsx
@@ -1,13 +1,14 @@
 /**
- * The failed-task action row shows THREE buttons: 继续 · 重试 · 删除.
- *  - 继续 (Continue) fires immediately, NO confirm dialog.
- *  - 重试 (Retry) is destructive → must confirm; only fires on OK.
- *  - 删除 (Delete) unchanged (its own confirm lives in App.tsx).
+ * The failed-task action row shows THREE buttons: Continue / Retry / Delete.
+ *  - Continue fires immediately, NO confirm dialog.
+ *  - Retry is destructive → must confirm; only fires on OK.
+ *  - Delete unchanged (its own confirm lives in App.tsx).
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { TasksView } from '../views/TasksView'
 import type { Task } from '../types'
+import i18n from '../i18n'
 
 function failedTask(): Task {
   return {
@@ -95,34 +96,34 @@ function makeProps(over: Record<string, unknown> = {}) {
   }
 }
 
-describe('failed-task action buttons: 继续 · 重试 · 删除', () => {
+describe('failed-task action buttons: Continue / Retry / Delete', () => {
   afterEach(() => vi.restoreAllMocks())
 
-  it('继续 resumes immediately with no confirm', () => {
+  it('Continue resumes immediately with no confirm', () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     const props = makeProps()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     render(<TasksView {...(props as any)} />)
-    fireEvent.click(screen.getByRole('button', { name: /Continue|继续/ }))
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('tasks.continue') }))
     expect(props.continueTask).toHaveBeenCalledWith('task-fail-1')
     expect(confirmSpy).not.toHaveBeenCalled()
   })
 
-  it('重试 does NOT fire when confirm is cancelled', () => {
+  it('Retry does NOT fire when confirm is cancelled', () => {
     vi.spyOn(window, 'confirm').mockReturnValue(false)
     const props = makeProps()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     render(<TasksView {...(props as any)} />)
-    fireEvent.click(screen.getByRole('button', { name: /^Retry$|^重试$/ }))
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('tasks.retry') }))
     expect(props.retryTask).not.toHaveBeenCalled()
   })
 
-  it('重试 fires only after the confirm is accepted', () => {
+  it('Retry fires only after the confirm is accepted', () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     const props = makeProps()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     render(<TasksView {...(props as any)} />)
-    fireEvent.click(screen.getByRole('button', { name: /^Retry$|^重试$/ }))
+    fireEvent.click(screen.getByRole('button', { name: i18n.t('tasks.retry') }))
     expect(confirmSpy).toHaveBeenCalledTimes(1)
     expect(props.retryTask).toHaveBeenCalledWith('task-fail-1')
   })

--- a/frontend/src/handlers/continueTask.ts
+++ b/frontend/src/handlers/continueTask.ts
@@ -1,5 +1,5 @@
 /**
- * Handler for the "Continue" (继续) button on a failed / completed task.
+ * Handler for the Continue button on a failed / completed task.
  *
  * NON-destructive resume, in contrast to `retryTask` (which wipes the
  * plan / error / history and restarts from scratch). Continue behaves
@@ -16,11 +16,12 @@
  * resumed run streams in. The backend clears the stale error itself and
  * the post-POST refetch/merge reconciles the rest.
  */
+import i18n from '../i18n'
 import type { Task } from '../types'
 
-/** Canned message the Continue button sends — resume, don't restart. */
-export const CONTINUE_MESSAGE =
-  '继续之前的任务，现在重试；复用磁盘上已有的进度和数据，不要从头重写。'
+/** Canned message the Continue button sends — resume, don't restart.
+ *  Text lives in the i18n layer (`tasks.continueMessage`), never inline. */
+export const continueMessage = () => i18n.t('tasks.continueMessage')
 
 export interface ContinueTaskApi {
   post(url: string, body: unknown): Promise<unknown>
@@ -56,7 +57,7 @@ export async function continueTask(
 
   try {
     await deps.api.post(`/api/tasks/${taskId}/messages`, {
-      content: CONTINUE_MESSAGE,
+      content: continueMessage(),
       profile_id: deps.profileId,
     })
   } catch {

--- a/frontend/src/handlers/continueTask.ts
+++ b/frontend/src/handlers/continueTask.ts
@@ -1,0 +1,97 @@
+/**
+ * Handler for the "Continue" (继续) button on a failed / completed task.
+ *
+ * NON-destructive resume, in contrast to `retryTask` (which wipes the
+ * plan / error / history and restarts from scratch). Continue behaves
+ * exactly like the user typing "try again now" into the task's chat box:
+ * it POSTs `/api/tasks/{id}/messages`, which the backend handles by
+ * RESUMING the same task with its full context (reusing the CLI session
+ * when present, else rebuilding from the saved conversation + plan) and
+ * clearing only stale run-scoped error state. Work already on disk
+ * (e.g. an audit's cached TSVs) is reused rather than redone.
+ *
+ * The contract mirrors `retryTask`'s SSE race-guard, but the optimistic
+ * patch **only** advances `status` — it must NOT clear `error` / `plan`
+ * / `plan_history`, so the conversation and plan stay visible while the
+ * resumed run streams in. The backend clears the stale error itself and
+ * the post-POST refetch/merge reconciles the rest.
+ */
+import type { Task } from '../types'
+
+/** Canned message the Continue button sends — resume, don't restart. */
+export const CONTINUE_MESSAGE =
+  '继续之前的任务，现在重试；复用磁盘上已有的进度和数据，不要从头重写。'
+
+export interface ContinueTaskApi {
+  post(url: string, body: unknown): Promise<unknown>
+  get(url: string): Promise<Task>
+}
+
+export interface ContinueTaskDeps {
+  api: ContinueTaskApi
+  profileId: string
+  setTasks: React.Dispatch<React.SetStateAction<Task[]>>
+  setSelectedTask: React.Dispatch<React.SetStateAction<Task | null>>
+  setScheduleTasks: React.Dispatch<React.SetStateAction<Task[]>>
+}
+
+export async function continueTask(
+  taskId: string,
+  deps: ContinueTaskDeps,
+): Promise<void> {
+  // Optimistic status bump ONLY — no context clearing. Fires before the
+  // await so SSE `task_update` events (running → …) that arrive during
+  // the POST round-trip can validly progress the row without being
+  // clobbered by a post-await write.
+  const patch = { status: 'running' as const }
+  deps.setTasks(prev =>
+    prev.map(t => (t.id === taskId ? { ...t, ...patch } : t)),
+  )
+  deps.setSelectedTask(prev =>
+    prev && prev.id === taskId ? { ...prev, ...patch } : prev,
+  )
+  deps.setScheduleTasks(prev =>
+    prev.map(t => (t.id === taskId ? { ...t, ...patch } : t)),
+  )
+
+  try {
+    await deps.api.post(`/api/tasks/${taskId}/messages`, {
+      content: CONTINUE_MESSAGE,
+      profile_id: deps.profileId,
+    })
+  } catch {
+    // POST failed — refetch so the row reflects the server's real
+    // state (typically still failed / completed) instead of being
+    // stuck optimistically at running.
+    deps.api
+      .get(`/api/tasks/${taskId}`)
+      .then(mergeTask(deps))
+      .catch(() => {
+        /* both POST and GET failed; next refresh fixes it */
+      })
+    return
+  }
+
+  // Race-guard refetch: pick up whatever status the server has now
+  // without overwriting progress the SSE handler already applied.
+  deps.api
+    .get(`/api/tasks/${taskId}`)
+    .then(mergeTask(deps))
+    .catch(() => {
+      /* non-fatal — SSE continues to drive state */
+    })
+}
+
+function mergeTask(deps: ContinueTaskDeps) {
+  return (t: Task) => {
+    deps.setTasks(prev =>
+      prev.map(pt => (pt.id === t.id ? { ...pt, ...t } : pt)),
+    )
+    deps.setSelectedTask(prev =>
+      prev && prev.id === t.id ? { ...prev, ...t } : prev,
+    )
+    deps.setScheduleTasks(prev =>
+      prev.map(pt => (pt.id === t.id ? { ...pt, ...t } : pt)),
+    )
+  }
+}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -98,6 +98,7 @@
     "retry": "Retry",
     "continue": "Continue",
     "retryConfirm": "This clears the task’s history and restarts it from scratch. Are you sure?",
+    "continueMessage": "Continue the previous task — resume now, reuse the progress and data already on disk, and do not restart from scratch.",
     "rerun": "Re-run",
     "error_agent_loop": "The AI agent got stuck in a repeated loop and was automatically stopped. Please retry the task.",
     "copyAll": "Copy All",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -96,6 +96,8 @@
     "running": "Running...",
     "designing": "Planning...",
     "retry": "Retry",
+    "continue": "Continue",
+    "retryConfirm": "This clears the task’s history and restarts it from scratch. Are you sure?",
     "rerun": "Re-run",
     "error_agent_loop": "The AI agent got stuck in a repeated loop and was automatically stopped. Please retry the task.",
     "copyAll": "Copy All",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -96,6 +96,8 @@
     "running": "运行中...",
     "designing": "规划中...",
     "retry": "重试",
+    "continue": "继续",
+    "retryConfirm": "这将清空该任务的历史记录并从头重新开始，确定吗？",
     "rerun": "重新运行",
     "error_agent_loop": "AI 代理陷入重复循环，已自动停止。请重试该任务。",
     "copyAll": "全部复制",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -98,6 +98,7 @@
     "retry": "重试",
     "continue": "继续",
     "retryConfirm": "这将清空该任务的历史记录并从头重新开始，确定吗？",
+    "continueMessage": "继续之前的任务，现在重试；复用磁盘上已有的进度和数据，不要从头重写。",
     "rerun": "重新运行",
     "error_agent_loop": "AI 代理陷入重复循环，已自动停止。请重试该任务。",
     "copyAll": "全部复制",

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -49,6 +49,7 @@ interface TasksViewProps {
   selectTask: (task: Task) => void
   stopAgent: () => void
   retryTask: (taskId: string) => void
+  continueTask: (taskId: string) => void
   deleteTask: (taskId: string) => void
   selectAnswer: (questionText: string, answer: string) => void
   toggleOtherInput: (questionText: string) => void
@@ -156,6 +157,7 @@ export function TasksView({
   selectTask,
   stopAgent,
   retryTask,
+  continueTask,
   deleteTask,
   selectAnswer,
   toggleOtherInput,
@@ -470,9 +472,28 @@ export function TasksView({
                     </button>
                   )}
                   {getUI(selectedTask.status).canRetry && (
-                    <button onClick={() => retryTask(selectedTask.id)} className="px-3 py-1 text-xs text-gray-600 border border-gray-300 rounded hover:bg-gray-100">
-                      {selectedTask.status === 'completed' ? t('tasks.rerun') : t('tasks.retry')}
-                    </button>
+                    <>
+                      {/* 继续: non-destructive resume — keeps context. */}
+                      <button
+                        onClick={() => continueTask(selectedTask.id)}
+                        className="px-3 py-1 text-xs text-gray-600 border border-gray-300 rounded hover:bg-gray-100"
+                      >
+                        {t('tasks.continue')}
+                      </button>
+                      {/* 重试: destructive fresh restart — confirm first. */}
+                      <button
+                        onClick={() => {
+                          if (confirm(t('tasks.retryConfirm'))) {
+                            retryTask(selectedTask.id)
+                          }
+                        }}
+                        className="px-3 py-1 text-xs text-gray-600 border border-gray-300 rounded hover:bg-gray-100"
+                      >
+                        {selectedTask.status === 'completed'
+                          ? t('tasks.rerun')
+                          : t('tasks.retry')}
+                      </button>
+                    </>
                   )}
                   {!getUI(selectedTask.status).isActive && !selectedTask.is_plan_only && (
                     <button

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -473,14 +473,14 @@ export function TasksView({
                   )}
                   {getUI(selectedTask.status).canRetry && (
                     <>
-                      {/* 继续: non-destructive resume — keeps context. */}
+                      {/* Continue: non-destructive resume — keeps context. */}
                       <button
                         onClick={() => continueTask(selectedTask.id)}
                         className="px-3 py-1 text-xs text-gray-600 border border-gray-300 rounded hover:bg-gray-100"
                       >
                         {t('tasks.continue')}
                       </button>
-                      {/* 重试: destructive fresh restart — confirm first. */}
+                      {/* Retry: destructive fresh restart — confirm first. */}
                       <button
                         onClick={() => {
                           if (confirm(t('tasks.retryConfirm'))) {

--- a/tests/workflow/test_wf_continue_vs_retry.py
+++ b/tests/workflow/test_wf_continue_vs_retry.py
@@ -1,9 +1,9 @@
-"""继续 (Continue) vs 重试 (Retry) contract.
+"""Continue vs Retry contract.
 
 The task-detail panel shows both on a failed task:
-  - 继续 posts /messages → RESUME the same task, preserving context
+  - Continue posts /messages → RESUME the same task, preserving context
     (plan / plan_history stay; only stale run-error is cleared).
-  - 重试 posts /retry → DESTRUCTIVE fresh restart (plan / plan_history /
+  - Retry posts /retry → DESTRUCTIVE fresh restart (plan / plan_history /
     error wiped, prior messages deleted, back to PENDING).
 
 These tests pin that split so a future change can't silently make
@@ -79,14 +79,14 @@ class TestContinueVsRetry:
     async def test_continue_resumes_and_preserves_context(
         self, admin_client, install_fake_agent
     ):
-        """继续: /messages on a FAILED task resumes (mode=auto), keeps the
-        plan + plan_history, clears only the stale error."""
+        """Continue: /messages on a FAILED task resumes (mode=auto), keeps
+        the plan + plan_history, clears only the stale error."""
         install_fake_agent.default_scenario = FakeAgentScenario()
         task_id = await _seed_failed_task()
 
         r = await admin_client.post(
             f'/api/tasks/{task_id}/messages',
-            json={'content': '继续之前的任务，现在重试；复用已有进度。'},
+            json={'content': 'continue the previous task, reuse progress'},
         )
         assert r.status_code == 200
 
@@ -106,7 +106,7 @@ class TestContinueVsRetry:
         assert await _msg_count(task_id) >= 2
 
     async def test_retry_clears_context(self, admin_client):
-        """重试: /retry wipes plan/plan_history/error, deletes prior
+        """Retry: /retry wipes plan/plan_history/error, deletes prior
         messages, and resets to PENDING (fresh restart)."""
         task_id = await _seed_failed_task()
 

--- a/tests/workflow/test_wf_continue_vs_retry.py
+++ b/tests/workflow/test_wf_continue_vs_retry.py
@@ -1,0 +1,123 @@
+"""继续 (Continue) vs 重试 (Retry) contract.
+
+The task-detail panel shows both on a failed task:
+  - 继续 posts /messages → RESUME the same task, preserving context
+    (plan / plan_history stay; only stale run-error is cleared).
+  - 重试 posts /retry → DESTRUCTIVE fresh restart (plan / plan_history /
+    error wiped, prior messages deleted, back to PENDING).
+
+These tests pin that split so a future change can't silently make
+Continue destructive or Retry non-destructive.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+import app.database as _db
+from app.models.task import Task
+from app.models.task_message import TaskMessage
+from app.models.user import User
+from tests.workflow.fake_agent import FakeAgentScenario
+
+pytestmark = pytest.mark.workflow
+
+
+async def _seed_failed_task():
+    """A FAILED, non-plan task carrying plan + plan_history + error +
+    a prior conversation message."""
+    task_id = str(uuid.uuid4())
+    async with _db.async_session() as db:
+        u = (await db.execute(select(User).limit(1))).scalars().first()
+        db.add(
+            Task(
+                id=task_id,
+                title='audit',
+                description='drill all campaigns',
+                status='failed',
+                plan_mode=False,
+                plan='## prior plan\ndrill everything',
+                plan_history='["## prior plan"]',
+                error='browser infra failure',
+                error_category='browser',
+                created_by=u.id,
+            )
+        )
+        db.add(
+            TaskMessage(
+                task_id=task_id,
+                role='assistant',
+                content='partial progress: 15/34 drilled',
+                seq=0,
+            )
+        )
+        await db.commit()
+    return task_id
+
+
+async def _get_task(task_id: str) -> Task:
+    async with _db.async_session() as db:
+        return await db.get(Task, task_id)
+
+
+async def _msg_count(task_id: str) -> int:
+    async with _db.async_session() as db:
+        rows = (
+            (
+                await db.execute(
+                    select(TaskMessage).where(TaskMessage.task_id == task_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return len(rows)
+
+
+class TestContinueVsRetry:
+    async def test_continue_resumes_and_preserves_context(
+        self, admin_client, install_fake_agent
+    ):
+        """继续: /messages on a FAILED task resumes (mode=auto), keeps the
+        plan + plan_history, clears only the stale error."""
+        install_fake_agent.default_scenario = FakeAgentScenario()
+        task_id = await _seed_failed_task()
+
+        r = await admin_client.post(
+            f'/api/tasks/{task_id}/messages',
+            json={'content': '继续之前的任务，现在重试；复用已有进度。'},
+        )
+        assert r.status_code == 200
+
+        # Resumed via the follow-up path, not a fresh re-plan.
+        run_calls = install_fake_agent.get_calls(task_id=task_id, action='run')
+        assert run_calls, 'agent was not resumed'
+        assert run_calls[-1].mode == 'auto'
+
+        task = await _get_task(task_id)
+        # Context preserved — the whole point of Continue.
+        assert task.plan == '## prior plan\ndrill everything'
+        assert task.plan_history == '["## prior plan"]'
+        # Stale run-error cleared; task is no longer failed.
+        assert task.error is None
+        assert task.status in ('running', 'completed')
+        # Prior conversation kept (plus the new user message).
+        assert await _msg_count(task_id) >= 2
+
+    async def test_retry_clears_context(self, admin_client):
+        """重试: /retry wipes plan/plan_history/error, deletes prior
+        messages, and resets to PENDING (fresh restart)."""
+        task_id = await _seed_failed_task()
+
+        r = await admin_client.post(f'/api/tasks/{task_id}/retry', json={})
+        assert r.status_code == 200
+
+        task = await _get_task(task_id)
+        assert task.plan is None
+        assert task.plan_history is None
+        assert task.error is None
+        assert task.error_category is None
+        assert task.status == 'pending'
+        # Prior conversation wiped by the destructive retry.
+        assert await _msg_count(task_id) == 0


### PR DESCRIPTION
The failed/completed task action row gains a third button, so it's now **继续 (Continue) · 重试 (Retry) · 删除 (Delete)**.

## Semantics
| Button | Behavior |
|---|---|
| **继续 (Continue)** — NEW | **Non-destructive resume.** Reuses the existing `POST /api/tasks/{id}/messages` path (the same one the chat send-box uses): the backend resumes the **same** task with full context — CLI `session_id` when present, else rebuilt from saved conversation + plan — and clears only the stale run-error. Work already on disk (e.g. an audit's cached TSVs) is reused, not redone. No confirmation. |
| **重试 (Retry)** — changed | **Destructive fresh restart** (unchanged action: `POST /api/tasks/{id}/retry` wipes plan/plan_history/error, deletes prior messages, resets to PENDING). **Now gated behind a confirm dialog**: "这将清空该任务的历史记录并从头重新开始，确定吗？" — only fires on OK. |
| **删除 (Delete)** — unchanged | Same cascade-aware confirm + behavior as before. |

## Implementation
- **No new backend endpoint.** 继续 = the frontend posts a canned "continue, reuse prior progress" message to `/messages`, whose FAILED/COMPLETED follow-up branch (`app/routers/tasks_conversation.py`) already resumes with context and clears only stale run-scoped state. This is literally "send a try-again message in the send box," per the request.
- **`frontend/src/handlers/continueTask.ts`** (new): mirrors `retryTask`'s SSE race-guard (optimistic patch before the await, merge-only refetch after) but the optimistic patch **advances `status` only** — it does NOT clear `error`/`plan`/`plan_history`, so context stays visible while the resumed run streams in.
- `App.tsx` wires `continueTask`; `TasksView.tsx` renders the button and wraps 重试's onClick in `confirm(t('tasks.retryConfirm'))`. New i18n keys `tasks.continue` + `tasks.retryConfirm` (en + zh).

## Tests
- `continueTask.test.tsx` — posts to `/messages` (not `/retry`); optimistic patch preserves error/plan/history.
- `retryConfirmButtons.test.tsx` — renders the real TasksView failed-task row: 继续 fires with no dialog; 重试 fires only when confirm returns OK.
- `test_wf_continue_vs_retry.py` — backend contract: `/messages` on a FAILED task resumes (mode=auto) and keeps plan/plan_history; `/retry` clears them and deletes prior messages.
- Frontend suite: 336 pass. Backend workflow tests: pass.

## Assumptions (please correct if wrong)
1. **继续 shows on the same states as 重试** (`canRetry` → failed **and** completed). On a completed task it acts as "continue/extend"; the `/messages` path handles completed too. If 继续 should be failed-only, that's a one-line gate change.
2. **Resume mechanism** = the existing `/messages` follow-up path (reuses CLI session if alive, else rebuilds context from DB) rather than a dedicated new endpoint — chosen because the request described it as "send a try-again message in the send box," and it avoids duplicating that logic.

No real store/SKU/brand/campaign data anywhere — placeholders only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)