### PR TITLE
fix(scheduler): resume PLANNED scheduled tasks across a restart (don't orphan)

### DIFF
--- a/app/scheduler/task_queue.py
+++ b/app/scheduler/task_queue.py
@@ -388,10 +388,11 @@ class TaskQueueScheduler:
                 .order_by(Task.created_at)
             )
             for task in planned.scalars().all():
-                if task.store_id:
-                    self._queues.setdefault(task.store_id, []).append(
-                        task.id
-                    )
+                # store_id may be None (no-store / phase_mode='single'
+                # schedule); the queue uses None as a valid lane key, so
+                # append unconditionally — else a no-store scheduled task
+                # is left orphaned at PLANNED across a restart.
+                self._queues.setdefault(task.store_id, []).append(task.id)
 
             # Reset all browser sessions to idle
             result = await db.execute(select(BrowserSession))

--- a/app/scheduler/task_queue.py
+++ b/app/scheduler/task_queue.py
@@ -369,6 +369,30 @@ class TaskQueueScheduler:
                         self._queues[task.store_id] = []
                     self._queues[task.store_id].append(task.id)
 
+            # Scheduled plan-mode tasks left in PLANNED (frozen plan
+            # copied by the fanout/cron fire, awaiting a concurrency
+            # slot) must ALSO resume — the dispatcher routes
+            # PLANNED → execute_planned_task. Without this they were
+            # ORPHANED across a restart: the in-memory queue is gone and
+            # PLANNED wasn't otherwise recovered, so a scheduled task sat
+            # at PLANNED forever. Only auto-executing SCHEDULED tasks
+            # (schedule_id set) qualify; an interactive plan-mode task
+            # (schedule_id NULL) is waiting for the user to press Run and
+            # MUST stay PLANNED.
+            planned = await db.execute(
+                select(Task)
+                .where(
+                    Task.status == TaskStatus.PLANNED,
+                    Task.schedule_id.is_not(None),
+                )
+                .order_by(Task.created_at)
+            )
+            for task in planned.scalars().all():
+                if task.store_id:
+                    self._queues.setdefault(task.store_id, []).append(
+                        task.id
+                    )
+
             # Reset all browser sessions to idle
             result = await db.execute(select(BrowserSession))
             for session in result.scalars().all():

--- a/tests/unit/test_task_queue.py
+++ b/tests/unit/test_task_queue.py
@@ -55,6 +55,7 @@ async def store_and_task(db_session):
         platform=None,
         country=None,
         schedule_id=None,
+        store_id='store-1',
     ):
         async with db_session() as db:
             # Only create store if it doesn't exist yet
@@ -78,7 +79,7 @@ async def store_and_task(db_session):
                 platform=platform,
                 country=country,
                 schedule_id=schedule_id,
-                store_id='store-1',
+                store_id=store_id,
                 created_by='test-user',
                 created_at=datetime.now(UTC).isoformat(),
                 updated_at=datetime.now(UTC).isoformat(),
@@ -249,6 +250,26 @@ class TestRecovery:
         async with db_session() as db:
             task = await db.get(Task, 'task-1')
             assert task.status == TaskStatus.PLANNED  # untouched
+
+    async def test_planned_scheduled_no_store_re_enqueued(
+        self, db_session, store_and_task
+    ):
+        # A no-store scheduled task (store_id=None, e.g. phase_mode
+        # 'single') left PLANNED must also resume — the queue uses None
+        # as a valid lane key, so it must not be skipped by a store guard.
+        await store_and_task(
+            status=TaskStatus.PLANNED,
+            plan_mode=True,
+            plan='## frozen plan',
+            schedule_id='sched-1',
+            store_id=None,
+        )
+        scheduler = TaskQueueScheduler()
+
+        with patch('app.scheduler.task_queue.async_session', db_session):
+            await scheduler._recover_from_db()
+
+        assert 'task-1' in scheduler._queues.get(None, [])
 
 
 class TestCanSchedule:

--- a/tests/unit/test_task_queue.py
+++ b/tests/unit/test_task_queue.py
@@ -54,6 +54,7 @@ async def store_and_task(db_session):
         plan=None,
         platform=None,
         country=None,
+        schedule_id=None,
     ):
         async with db_session() as db:
             # Only create store if it doesn't exist yet
@@ -76,6 +77,7 @@ async def store_and_task(db_session):
                 plan=plan,
                 platform=platform,
                 country=country,
+                schedule_id=schedule_id,
                 store_id='store-1',
                 created_by='test-user',
                 created_at=datetime.now(UTC).isoformat(),
@@ -208,6 +210,45 @@ class TestRecovery:
             await scheduler._recover_from_db()
 
         assert 'task-1' in scheduler._queues.get('store-1', [])
+
+    async def test_planned_scheduled_re_enqueued(
+        self, db_session, store_and_task
+    ):
+        # A scheduled plan-mode task left PLANNED (frozen plan, awaiting a
+        # slot) must resume across a restart — else it's orphaned forever.
+        await store_and_task(
+            status=TaskStatus.PLANNED,
+            plan_mode=True,
+            plan='## frozen plan',
+            schedule_id='sched-1',
+        )
+        scheduler = TaskQueueScheduler()
+
+        with patch('app.scheduler.task_queue.async_session', db_session):
+            await scheduler._recover_from_db()
+
+        assert 'task-1' in scheduler._queues.get('store-1', [])
+
+    async def test_planned_interactive_not_re_enqueued(
+        self, db_session, store_and_task
+    ):
+        # An interactive (non-scheduled) plan-mode task waits for the user
+        # to press Run — it must NOT auto-resume on restart.
+        await store_and_task(
+            status=TaskStatus.PLANNED,
+            plan_mode=True,
+            plan='## user plan',
+            schedule_id=None,
+        )
+        scheduler = TaskQueueScheduler()
+
+        with patch('app.scheduler.task_queue.async_session', db_session):
+            await scheduler._recover_from_db()
+
+        assert 'task-1' not in scheduler._queues.get('store-1', [])
+        async with db_session() as db:
+            task = await db.get(Task, 'task-1')
+            assert task.status == TaskStatus.PLANNED  # untouched
 
 
 class TestCanSchedule:


### PR DESCRIPTION
## Symptom
A monthly report-download **fanout schedule** fired, but 4 of its per-store tasks got **stuck at `PLANNED`** and never executed — retry didn't help either.

## Root cause
Plan-mode schedules plan ahead: the fire copies the schedule's **frozen plan** into each per-store task, sets it `PLANNED`, and submits it to the queue. The dispatcher routes `PLANNED → execute_planned_task` (run the frozen plan directly). Under normal operation the tick loop drains these fine.

But **`_recover_from_db` (crash/restart recovery) only re-queued `QUEUED` and `PENDING`** tasks. A scheduled task sitting `PLANNED` in the in-memory queue (awaiting a concurrency slot) when the server restarts is **orphaned**: the in-memory queue is gone and `PLANNED` isn't recovered → it stays `PLANNED` forever. (Reproduced by a `restart` mid-fire.)

## Fix
Recovery now **also re-queues `PLANNED` tasks that belong to a schedule** (`schedule_id` set) so they resume executing the frozen plan. Interactive plan-mode tasks (`schedule_id` NULL) are **left untouched** — those are waiting for the user to press *Run* and must stay `PLANNED`.

This completes the "scheduled task plans ahead → executes directly" contract across all three entry points:
- **fire** → PLANNED → execute (already worked)
- **retry** → re-seeds the frozen plan → PLANNED → execute (already handled in `retry_task`)
- **restart recovery** → now resumes PLANNED scheduled tasks (this fix)

## Tests
`test_task_queue.py`: PLANNED+`schedule_id` is re-enqueued on recovery; PLANNED without `schedule_id` is **not** (stays PLANNED for the user). 14/14 queue tests pass; ruff + line-limit clean.

Placeholders only — no store/schedule data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)