### PR TITLE
fix(cdp-proxy): self-heal Ziniao upstream instead of serving 502 forever

### DIFF
--- a/app/browser/cdp_mux_proxy.py
+++ b/app/browser/cdp_mux_proxy.py
@@ -42,6 +42,7 @@ Download path override (``download_dir``):
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 import json
 import logging
 import time
@@ -90,10 +91,20 @@ class CDPMuxProxy(_UpstreamMixin, _RoutingMixin):
         cleanup_grace: float = DEFAULT_CLEANUP_GRACE,
         download_dir: str | None = None,
         keep_last_page: bool = False,
+        relaunch_upstream: Callable[[], Awaitable[tuple[int, str] | int | None]]
+        | None = None,
     ):
         self.listen_port = listen_port
         self.target_port = target_port
         self.target_host = target_host
+        # Self-heal hook: when reconnecting to the current upstream fails
+        # for good (the browser died / its debugging port rotated — e.g.
+        # after a Ziniao restart), this relaunches the upstream browser
+        # and returns its fresh (port, host) (or just a port). Without it
+        # an exhausted reconnect stops the proxy and every /json/version
+        # then 502s until a task re-triggers browser/start. Injected by
+        # the backend so this stays decoupled + unit-testable.
+        self._relaunch_upstream = relaunch_upstream
         self.max_clients = max_clients
         self.cleanup_grace = cleanup_grace
         self.download_dir = download_dir

--- a/app/browser/cdp_mux_upstream.py
+++ b/app/browser/cdp_mux_upstream.py
@@ -130,6 +130,13 @@ class _UpstreamMixin:
                 except Exception as e:
                     logger.warning('CDPMuxProxy reconnect failed: %s', e)
                     delay = min(delay * 2, max_delay)
+            # Reconnecting to the CURRENT upstream is hopeless: the browser
+            # is gone or its debugging port rotated (classic after a Ziniao
+            # restart — the old port serves nothing). Before giving up (and
+            # 502-ing every /json/version forever), self-heal by relaunching
+            # the upstream browser and reconnecting to its FRESH port.
+            if self._running and await self._relaunch_and_reconnect_upstream():
+                return
             logger.error(
                 'CDPMuxProxy gave up reconnecting after %d attempts',
                 max_attempts,
@@ -137,6 +144,53 @@ class _UpstreamMixin:
             asyncio.create_task(self.stop())
         finally:
             self._reconnecting = False
+
+    async def _relaunch_and_reconnect_upstream(self) -> bool:
+        """Self-heal: relaunch the upstream browser, reconnect to its
+        fresh port. Returns True iff the proxy is healthy again.
+
+        The injected ``relaunch_upstream`` hook re-launches the backing
+        browser (e.g. a fresh Ziniao ``startBrowser`` after a client
+        restart) and returns its new ``(port, host)`` — or just a port,
+        or None if it cannot recover. On success we repoint the proxy at
+        the new target and re-establish the upstream WebSocket, so
+        re-dispatched tasks get a live browser instead of a 502.
+        """
+        relaunch = getattr(self, '_relaunch_upstream', None)
+        if relaunch is None:
+            return False
+        try:
+            fresh = await relaunch()
+        except Exception as e:
+            logger.warning('CDPMuxProxy upstream relaunch failed: %s', e)
+            return False
+        if not fresh:
+            return False
+        if isinstance(fresh, tuple):
+            new_port, new_host = int(fresh[0]), fresh[1]
+        else:
+            new_port, new_host = int(fresh), self.target_host
+        logger.info(
+            'CDPMuxProxy self-heal: relaunched upstream, repointing '
+            '%s:%d -> %s:%d',
+            self.target_host,
+            self.target_port,
+            new_host,
+            new_port,
+        )
+        self.target_host = new_host
+        self.target_port = new_port
+        try:
+            await self._connect_upstream()
+        except Exception as e:
+            logger.warning('CDPMuxProxy reconnect after relaunch failed: %s', e)
+            return False
+        logger.info(
+            'CDPMuxProxy upstream self-healed on %s:%d',
+            self.target_host,
+            self.target_port,
+        )
+        return True
 
     # ------------------------------------------------------------------
     # Startup cleanup

--- a/app/browser/cdp_mux_upstream.py
+++ b/app/browser/cdp_mux_upstream.py
@@ -172,7 +172,7 @@ class _UpstreamMixin:
         # treat it as unhealed rather than raising out of the reconnect
         # coroutine and leaving the proxy half-repointed.
         try:
-            if isinstance(fresh, (tuple, list)):
+            if isinstance(fresh, tuple | list):
                 if len(fresh) != 2:
                     raise ValueError(f'expected (port, host), got {fresh!r}')
                 new_port, new_host = int(fresh[0]), fresh[1]

--- a/app/browser/cdp_mux_upstream.py
+++ b/app/browser/cdp_mux_upstream.py
@@ -166,10 +166,25 @@ class _UpstreamMixin:
             return False
         if not fresh:
             return False
-        if isinstance(fresh, tuple):
-            new_port, new_host = int(fresh[0]), fresh[1]
-        else:
-            new_port, new_host = int(fresh), self.target_host
+        # Validate the hook's return shape. A backend may hand back a
+        # (port, host) tuple or a bare port; anything else (wrong-arity
+        # tuple, non-int port) is a buggy hook, not a live upstream —
+        # treat it as unhealed rather than raising out of the reconnect
+        # coroutine and leaving the proxy half-repointed.
+        try:
+            if isinstance(fresh, (tuple, list)):
+                if len(fresh) != 2:
+                    raise ValueError(f'expected (port, host), got {fresh!r}')
+                new_port, new_host = int(fresh[0]), fresh[1]
+            else:
+                new_port, new_host = int(fresh), self.target_host
+        except (TypeError, ValueError, IndexError) as e:
+            logger.warning(
+                'CDPMuxProxy relaunch hook returned an invalid target %r: %s',
+                fresh,
+                e,
+            )
+            return False
         logger.info(
             'CDPMuxProxy self-heal: relaunched upstream, repointing '
             '%s:%d -> %s:%d',

--- a/app/browser/cdp_mux_upstream.py
+++ b/app/browser/cdp_mux_upstream.py
@@ -180,17 +180,34 @@ class _UpstreamMixin:
         )
         self.target_host = new_host
         self.target_port = new_port
-        try:
-            await self._connect_upstream()
-        except Exception as e:
-            logger.warning('CDPMuxProxy reconnect after relaunch failed: %s', e)
-            return False
-        logger.info(
-            'CDPMuxProxy upstream self-healed on %s:%d',
+        # A freshly-relaunched browser's debugging port is not accepting
+        # connections the instant startBrowser returns — connecting once
+        # races the port coming up ("fresh port not up yet") and would
+        # 502 forever. Retry with backoff so the fresh port has time.
+        last_err: Exception | None = None
+        for attempt in range(1, 7):
+            if not self._running:
+                return False
+            try:
+                await self._connect_upstream()
+                logger.info(
+                    'CDPMuxProxy upstream self-healed on %s:%d (attempt %d)',
+                    self.target_host,
+                    self.target_port,
+                    attempt,
+                )
+                return True
+            except Exception as e:
+                last_err = e
+                await asyncio.sleep(min(attempt * 1.5, 6.0))
+        logger.warning(
+            'CDPMuxProxy reconnect after relaunch failed (fresh port %s:%d '
+            'never came up): %s',
             self.target_host,
             self.target_port,
+            last_err,
         )
-        return True
+        return False
 
     # ------------------------------------------------------------------
     # Startup cleanup

--- a/app/browser/ziniao.py
+++ b/app/browser/ziniao.py
@@ -212,12 +212,54 @@ class ZiniaoBackend(BrowserBackend):
         # 'ContainerId is missing', CDP dies ~15s later). Verified:
         # closing the env's last page kills it even 25s after it is fully
         # established; keeping any one page open keeps the env alive.
+        async def _relaunch_upstream() -> tuple[int, str] | None:
+            """Self-heal hook for the mux proxy.
+
+            Ziniao's ``debuggingPort`` rotates on every relaunch and dies
+            on a client restart, so a proxy that only ever retries the
+            original port serves 502 forever after the browser goes away
+            (e.g. a server restart tore down the in-process proxy and the
+            upstream port is now stale). This kill+relaunches the Ziniao
+            client and returns the FRESH reachable ``(port, host)`` so the
+            proxy can repoint itself. Returns None when it cannot recover
+            (WSL can't auto-relaunch the client; anything unreachable).
+            """
+            if is_wsl():
+                return None
+            try:
+                await kill_and_relaunch_ziniao(
+                    socket_port, client_path, user_info
+                )
+                result, host_used = await try_connect_ziniao(
+                    socket_port, start_data, timeout=60
+                )
+                if not result or str(result.get('statusCode')) != '0':
+                    return None
+                new_port = result.get('debuggingPort')
+                if not new_port:
+                    return None
+                new_host = (
+                    LOCALHOST if host_used == LOCALHOST else ziniao_host()
+                )
+                if not await self._cdp_port_reachable(new_host, int(new_port)):
+                    return None
+                logger.info(
+                    'Ziniao upstream self-healed: fresh CDP %s:%s',
+                    new_host,
+                    new_port,
+                )
+                return int(new_port), new_host
+            except Exception as e:
+                logger.warning('Ziniao upstream self-heal failed: %s', e)
+                return None
+
         self._proxy = CDPMuxProxy(
             listen_port=proxy_port,
             target_port=int(cdp_port),
             target_host=target_host,
             download_dir=str(dl_dir),
             keep_last_page=True,
+            relaunch_upstream=_relaunch_upstream,
         )
         await self._proxy.start()
 

--- a/tests/unit/test_browser/test_cdp_self_heal.py
+++ b/tests/unit/test_browser/test_cdp_self_heal.py
@@ -1,0 +1,171 @@
+"""Unit test for CDPMuxProxy upstream self-heal.
+
+The mux proxy runs *inside* the server process and connects upstream to
+a backend browser's CDP debugging port. That port is not stable: after a
+server restart the in-process proxy is torn down, and when tasks
+re-dispatch the backend browser may have gone away or (for Ziniao)
+relaunched on a DIFFERENT, rotated debugging port. A proxy that only ever
+retries its ORIGINAL ``target_port`` reconnects forever against a dead
+port and serves HTTP 502 on ``/json/version`` indefinitely — every
+re-dispatched task then 502s, its daemon never creates a ``.sock``, and
+the task thrashes and fails.
+
+These tests pin the self-heal contract: when ordinary reconnection to the
+current upstream is exhausted, the proxy invokes its injected
+``relaunch_upstream`` hook to obtain a FRESH ``(port, host)``, repoints
+itself, and reconnects — rather than giving up (which stops the proxy and
+502s). They exercise the recovery path with a fully mocked upstream: no
+real browser, no Ziniao client, no network, no backoff sleeps.
+"""
+
+import asyncio
+from unittest import mock
+
+import pytest
+
+from app.browser.cdp_mux_proxy import CDPMuxProxy
+
+OLD_PORT = 9222
+NEW_PORT = 9337  # rotated debugging port after a backend relaunch
+
+
+def _make_proxy(relaunch=None):
+    """A proxy wired to a target, never actually listening."""
+    proxy = CDPMuxProxy(
+        listen_port=0,
+        target_port=OLD_PORT,
+        relaunch_upstream=relaunch,
+    )
+    proxy._running = True
+    return proxy
+
+
+@pytest.mark.unit
+class TestRelaunchAndReconnect:
+    """The self-heal primitive: relaunch upstream, repoint, reconnect."""
+
+    async def test_repoints_to_fresh_port_and_reconnects(self):
+        relaunch = mock.AsyncMock(return_value=(NEW_PORT, '127.0.0.1'))
+        proxy = _make_proxy(relaunch)
+        proxy._connect_upstream = mock.AsyncMock()
+
+        healed = await proxy._relaunch_and_reconnect_upstream()
+
+        assert healed is True
+        relaunch.assert_awaited_once()
+        # Proxy now points at the fresh port the relaunch reported.
+        assert proxy.target_port == NEW_PORT
+        assert proxy.target_host == '127.0.0.1'
+        proxy._connect_upstream.assert_awaited_once()
+
+    async def test_bare_port_return_keeps_host(self):
+        # Hook may return just a port (host unchanged).
+        relaunch = mock.AsyncMock(return_value=NEW_PORT)
+        proxy = _make_proxy(relaunch)
+        original_host = proxy.target_host
+        proxy._connect_upstream = mock.AsyncMock()
+
+        healed = await proxy._relaunch_and_reconnect_upstream()
+
+        assert healed is True
+        assert proxy.target_port == NEW_PORT
+        assert proxy.target_host == original_host
+
+    async def test_no_hook_cannot_self_heal(self):
+        proxy = _make_proxy(relaunch=None)
+        proxy._connect_upstream = mock.AsyncMock()
+
+        healed = await proxy._relaunch_and_reconnect_upstream()
+
+        assert healed is False
+        # No hook → must not touch the target or attempt a reconnect.
+        assert proxy.target_port == OLD_PORT
+        proxy._connect_upstream.assert_not_awaited()
+
+    async def test_hook_returns_none_gives_up(self):
+        # Backend cannot recover (e.g. WSL can't auto-relaunch Ziniao).
+        relaunch = mock.AsyncMock(return_value=None)
+        proxy = _make_proxy(relaunch)
+        proxy._connect_upstream = mock.AsyncMock()
+
+        healed = await proxy._relaunch_and_reconnect_upstream()
+
+        assert healed is False
+        assert proxy.target_port == OLD_PORT
+        proxy._connect_upstream.assert_not_awaited()
+
+    async def test_reconnect_failure_after_relaunch_reports_unhealed(self):
+        relaunch = mock.AsyncMock(return_value=(NEW_PORT, '127.0.0.1'))
+        proxy = _make_proxy(relaunch)
+        proxy._connect_upstream = mock.AsyncMock(
+            side_effect=ConnectionError('fresh port not up yet')
+        )
+
+        healed = await proxy._relaunch_and_reconnect_upstream()
+
+        assert healed is False
+
+    async def test_hook_exception_is_swallowed(self):
+        relaunch = mock.AsyncMock(side_effect=RuntimeError('client wedged'))
+        proxy = _make_proxy(relaunch)
+        proxy._connect_upstream = mock.AsyncMock()
+
+        healed = await proxy._relaunch_and_reconnect_upstream()
+
+        assert healed is False
+        proxy._connect_upstream.assert_not_awaited()
+
+
+@pytest.mark.unit
+class TestReconnectEscalatesToSelfHeal:
+    """End-to-end: exhausted reconnect escalates instead of 502-ing."""
+
+    async def test_stale_port_triggers_relaunch_not_permanent_stop(self):
+        # Upstream reconnect succeeds only once the proxy points at the
+        # FRESH port — i.e. retrying the stale port is hopeless, exactly
+        # the post-restart / rotated-debuggingPort scenario.
+        relaunch = mock.AsyncMock(return_value=(NEW_PORT, '127.0.0.1'))
+        proxy = _make_proxy(relaunch)
+
+        async def fake_connect():
+            if proxy.target_port == OLD_PORT:
+                raise ConnectionError('stale debugging port serves nothing')
+            # Fresh port: connection succeeds.
+
+        proxy._connect_upstream = mock.AsyncMock(side_effect=fake_connect)
+        proxy.stop = mock.AsyncMock()
+
+        # No real backoff waits.
+        with mock.patch(
+            'app.browser.cdp_mux_upstream.asyncio.sleep',
+            new=mock.AsyncMock(),
+        ):
+            await proxy._reconnect_upstream()
+
+        # Self-healed: repointed at the fresh port, never gave up (502).
+        relaunch.assert_awaited_once()
+        assert proxy.target_port == NEW_PORT
+        proxy.stop.assert_not_called()
+        assert proxy._reconnecting is False
+
+    async def test_gives_up_when_self_heal_also_fails(self):
+        # Relaunch can't recover → proxy stops (the honest terminal state,
+        # not a silent forever-502).
+        relaunch = mock.AsyncMock(return_value=None)
+        proxy = _make_proxy(relaunch)
+        proxy._connect_upstream = mock.AsyncMock(
+            side_effect=ConnectionError('dead')
+        )
+        proxy.stop = mock.AsyncMock()
+
+        with mock.patch(
+            'app.browser.cdp_mux_upstream.asyncio.sleep',
+            new=mock.AsyncMock(),
+        ):
+            await proxy._reconnect_upstream()
+            # Let the create_task(self.stop()) give-up task run.
+            await asyncio.sleep(0)
+
+        relaunch.assert_awaited_once()
+        proxy.stop.assert_called_once()
+        assert proxy._reconnecting is False

--- a/tests/unit/test_browser/test_cdp_self_heal.py
+++ b/tests/unit/test_browser/test_cdp_self_heal.py
@@ -97,13 +97,22 @@ class TestRelaunchAndReconnect:
     async def test_reconnect_failure_after_relaunch_reports_unhealed(self):
         relaunch = mock.AsyncMock(return_value=(NEW_PORT, '127.0.0.1'))
         proxy = _make_proxy(relaunch)
+        # Reconnect keeps failing (fresh port never comes up): the proxy
+        # retries with backoff, then reports unhealed. Patch sleep so the
+        # bounded retry loop doesn't wait for real.
         proxy._connect_upstream = mock.AsyncMock(
             side_effect=ConnectionError('fresh port not up yet')
         )
 
-        healed = await proxy._relaunch_and_reconnect_upstream()
+        with mock.patch(
+            'app.browser.cdp_mux_upstream.asyncio.sleep',
+            new=mock.AsyncMock(),
+        ):
+            healed = await proxy._relaunch_and_reconnect_upstream()
 
         assert healed is False
+        # Retried more than once before giving up.
+        assert proxy._connect_upstream.await_count > 1
 
     async def test_hook_exception_is_swallowed(self):
         relaunch = mock.AsyncMock(side_effect=RuntimeError('client wedged'))

--- a/tests/unit/test_browser/test_cdp_self_heal.py
+++ b/tests/unit/test_browser/test_cdp_self_heal.py
@@ -71,6 +71,26 @@ class TestRelaunchAndReconnect:
         assert proxy.target_port == NEW_PORT
         assert proxy.target_host == original_host
 
+    async def test_invalid_hook_return_shape_gives_up(self):
+        # A buggy hook (wrong-arity tuple, non-int port) must be treated
+        # as unhealed — not raise out of the reconnect coroutine and
+        # leave the proxy half-repointed.
+        for bad in [
+            (NEW_PORT,),
+            (NEW_PORT, '127.0.0.1', 'extra'),
+            'not-a-port',
+        ]:
+            relaunch = mock.AsyncMock(return_value=bad)
+            proxy = _make_proxy(relaunch)
+            proxy._connect_upstream = mock.AsyncMock()
+
+            healed = await proxy._relaunch_and_reconnect_upstream()
+
+            assert healed is False, f'{bad!r} should not self-heal'
+            # Target untouched, no reconnect attempted.
+            assert proxy.target_port == OLD_PORT
+            proxy._connect_upstream.assert_not_awaited()
+
     async def test_no_hook_cannot_self_heal(self):
         proxy = _make_proxy(relaunch=None)
         proxy._connect_upstream = mock.AsyncMock()


### PR DESCRIPTION
## Problem

The CDP mux proxy runs **inside** the server process (uvicorn owns ports 9222-9225, one per store). A server restart tears down every per-store proxy. On restart — or whenever the backend browser dies mid-run — the proxy relistens but can only ever retry its **original** `target_port`.

For Ziniao that port is stale: `startBrowser` hands back a **rotated** `debuggingPort` on every relaunch, and a client restart kills the old one entirely. So the proxy's reconnect loop retries a dead port, exhausts its 10 attempts, calls `stop()`, and then every `GET /json/version` returns **HTTP 502 indefinitely**. Re-dispatched tasks hit that 502, their browser-use daemons never create a `.sock`, and the tasks thrash and fail — exactly what a monthly report-download fanout schedule kept doing after a restart during an active run.

## Fix — self-heal, don't 502

When ordinary reconnection to the current upstream is exhausted, escalate instead of giving up:

- `CDPMuxProxy.__init__` takes an optional `relaunch_upstream` hook.
- `_reconnect_upstream`, after its backoff attempts fail, calls `_relaunch_and_reconnect_upstream()`: the hook relaunches the backing browser and returns a **fresh `(port, host)`** (or a bare port, or `None`). The proxy repoints `target_host`/`target_port` and reconnects, so re-dispatched tasks get a live browser.
- Only if the hook **also** can't recover does the proxy `stop()` — the honest terminal state, not a silent forever-502.
- The Ziniao backend supplies the hook: it kill+relaunches the client via `kill_and_relaunch_ziniao`, reads the new `debuggingPort`, and reachability-probes it before handing it back. WSL (which can't auto-relaunch Ziniao) returns `None` and falls through to the existing clear-error guidance.

**Concurrency is untouched** — the per-store proxy + per-client mux (`ws://…/client-<task_id>`) design is intentional and preserved; nothing here serializes or caps stores.

### Why not "make the proxy survive restarts" (out-of-process)?
A server restart already marks RUNNING/DESIGNING tasks FAILED and kills their agent processes — there's no live session worth preserving. What matters is that **re-runs get a healthy browser**. Self-heal-on-demand delivers that by hardening the existing reconnect path, with no new daemon, IPC, or state migration.

## Test gap — why existing tests missed this

- CDP-proxy ↔ Ziniao **recovery is integration/e2e-only** territory; no unit test simulated "server restart → proxy loses its upstream → upstream port has rotated → proxy must self-heal." The proxy tests that exist (`test_cdp_reset_tabs`, `test_cdp_startup_cleanup`, `test_cdp_download_rewrite`) exercise routing/cleanup with a mocked-but-**present** upstream — none drive the reconnect-exhaustion path.
- Queue/scheduler tests mock the agent **and** the browser entirely, so a dead CDP upstream never enters their world.
- The old `_reconnect_upstream` had no seam to assert against — it always retried the same port and then `stop()`ed, so the 502-forever outcome was invisible to unit tests.

This PR adds `tests/unit/test_browser/test_cdp_self_heal.py` (8 cases, fully mocked — no real browser, Ziniao client, network, or backoff sleeps) pinning the contract:

- exhausted reconnect on a stale port **escalates to relaunch**, repoints to the fresh port, reconnects, and does **not** `stop()` (no permanent 502);
- bare-port vs `(port, host)` return shapes;
- no hook / hook returns `None` / hook raises / reconnect-after-relaunch fails → reports unhealed and preserves the give-up path.

## Validation

- `ruff check` + `ruff format` clean
- `scripts/check_line_limit.sh` passes (800-line limit)
- `pytest tests/unit/test_browser/` → **162 passed** (8 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
