### PR TITLE
fix(amazon-reports): SP ad export is per-marketplace, not account-level

### DIFF
--- a/app/skills_v2/amazon-reports/SKILL.md
+++ b/app/skills_v2/amazon-reports/SKILL.md
@@ -769,15 +769,27 @@ of the session.
 > registration flow AFTER** you enter through the menu (see the
 > report-applicability rule near the top).
 
-### The ad account is often UNIFIED across marketplaces
+### The ad *console* spans marketplaces, but each *export* is PER-MARKETPLACE
 
-Many accounts run **one advertising account spanning several
-marketplaces** (verified on a MENA account 2026-07: the console banner
-reads "ads across **multiple countries/regions**", a single `entityId`,
-a Country column). Its Sponsored Products Advertised Product report is
-**account-level** — a single export already contains every marketplace
-in that account. Knowing this avoids re-generating "a separate report
-per marketplace" when one account report already holds them all.
+The ad console may show several countries under one `entityId` ("ads
+across multiple countries/regions"), but the **exported** Sponsored
+Products Advertised Product report is **scoped to the marketplace the
+console is currently on** — each country has its OWN campaigns **and its
+own currency** (e.g. `sa` rows are SAR, `ae` rows are AED). A single
+export does **NOT** contain every marketplace.
+
+So **export each marketplace separately** (switch the console's
+marketplace, export again) into that country's folder — and **never copy
+one marketplace's report into another's folder.** Verified 2026-07: a
+store's SA and AE ad reports are distinct files with different countries
+(`沙特阿拉伯` vs `阿联酋`) and currencies; reusing the SA file for AE
+misattributes SA's spend to AE.
+
+**Verify content, not just that a file exists:** open the report and
+confirm its `国家/地区` (Country/Region) column matches the marketplace
+you meant to export (`sa`→`沙特阿拉伯`, `ae`→`阿联酋`). If an "AE" file
+contains only `沙特阿拉伯` rows, it's the wrong (SA) export — redo it for
+AE; do not save it as the AE report.
 
 ### Page Structure
 


### PR DESCRIPTION
## Why

Re-lands a correction that was lost from the #45 merge (it was pushed to the branch after the merge captured its state). Main currently carries a **wrong** claim in the amazon-reports skill §6: that the ad account is "unified" and "a single export already contains every marketplace." 

That is false, and it caused a real data-integrity bug: an agent, believing one report covers all marketplaces, exported one marketplace's Sponsored Products report and **reused/copied it for the other marketplace's folder**. Downstream reporting then attributed the wrong marketplace's spend (and wrong currency) to the other store.

Verified against real exports: a store's two-marketplace ad reports are **distinct files** — different `国家/地区` (Country/Region) values and **different currencies** (e.g. SAR vs AED). A single export does not contain both.

No real store/brand/SKU/account data in this PR — generic placeholders and marketplace/currency names only.

## Change

Rewrites §6 to state:
- the ad **console** may span several countries under one `entityId`, but each **export is scoped to the currently-selected marketplace** (its own country + currency);
- **export each marketplace separately** into its own folder, and **never copy one marketplace's report into another's folder**;
- **verify content, not just file existence** — confirm the report's `国家/地区` column matches the marketplace you meant to export; if an "AE" file contains only SA rows, it's the wrong export — redo it.

## Related

The downstream aggregator (`reports.py` in the reporting repo) is being hardened separately to attribute ad spend only to rows matching the store's own marketplace, as defence-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Xthn4cVTJmpHGWSvWptTa