### PR TITLE
fix(email-watermark): make get_new_emails the cursor authority

### DIFF
--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -335,10 +335,14 @@ TOOLS = [
                         'the key; see the canonical-keys table in the '
                         'task system prompt (Scheduled task — cross-run '
                         'state). For example, `email_watermark` must be '
-                        'a unix epoch seconds integer string (not ISO). '
-                        'NEVER pass null or an empty string — if you '
-                        'have nothing to persist, do not call this '
-                        'tool.'
+                        'a unix epoch seconds integer string (not ISO), '
+                        'and for a store with linked email accounts it '
+                        'must be the `next_watermark` from '
+                        'vibe_seller_get_new_emails, written verbatim — '
+                        'the server rejects a hand-derived value or one '
+                        'below the floor that tool established. NEVER '
+                        'pass null or an empty string — if you have '
+                        'nothing to persist, do not call this tool.'
                     ),
                     'minLength': 1,
                 },

--- a/app/prompts/scheduled_watermark.md
+++ b/app/prompts/scheduled_watermark.md
@@ -12,7 +12,7 @@ you used with `vibe_seller_get_schedule_state`):
 
 | Workflow | key | value to write |
 |---|---|---|
-| Daily email sweep | `email_watermark` | The **`next_watermark`** returned by `vibe_seller_get_new_emails`, written **verbatim**. That is the only accepted source: the server records it as a floor and **rejects** any `email_watermark` you set by hand, from an email `Date` header, or below that floor (a store with linked email accounts also rejects the write entirely until you have called `get_new_emails`). Unix epoch seconds as an integer string, e.g. `"1776441057"` — never an ISO timestamp, and never an epoch you computed yourself from a date. |
+| Daily email sweep | `email_watermark` | The **`next_watermark`** returned by `vibe_seller_get_new_emails`, written **verbatim**. That is the only accepted source: the server records it as a floor and **rejects** any `email_watermark` you set by hand, from an email `Date` header, or below that floor (a store with linked email accounts also rejects the write entirely until you have called `vibe_seller_get_new_emails`). Unix epoch seconds as an integer string, e.g. `"1776441057"` — never an ISO timestamp, and never an epoch you computed yourself from a date. |
 | Order audit | `last_order_id` | highest order id you processed |
 | Messaging / chat | `last_message_id` | newest message id handled |
 | Product sync | `last_sku_batch_id` | newest batch id fully applied |

--- a/app/prompts/scheduled_watermark.md
+++ b/app/prompts/scheduled_watermark.md
@@ -12,7 +12,7 @@ you used with `vibe_seller_get_schedule_state`):
 
 | Workflow | key | value to write |
 |---|---|---|
-| Daily email sweep | `email_watermark` | The integer in the `epoch` column of the newest row your SELECT returned (you should have projected `CAST(strftime('%s', date) AS INTEGER) AS epoch` on purpose — do NOT compute epoch mentally from the ISO date, that loses the year). Unix epoch seconds as an integer string, e.g. `"1776441057"`. NOT an ISO timestamp; the server rejects ISO for this key because lex comparison under tz/microseconds is unsafe. |
+| Daily email sweep | `email_watermark` | The **`next_watermark`** returned by `vibe_seller_get_new_emails`, written **verbatim**. That is the only accepted source: the server records it as a floor and **rejects** any `email_watermark` you set by hand, from an email `Date` header, or below that floor (a store with linked email accounts also rejects the write entirely until you have called `get_new_emails`). Unix epoch seconds as an integer string, e.g. `"1776441057"` — never an ISO timestamp, and never an epoch you computed yourself from a date. |
 | Order audit | `last_order_id` | highest order id you processed |
 | Messaging / chat | `last_message_id` | newest message id handled |
 | Product sync | `last_sku_batch_id` | newest batch id fully applied |

--- a/app/routers/tasks_schedule_state.py
+++ b/app/routers/tasks_schedule_state.py
@@ -35,6 +35,24 @@ _EMAIL_WATERMARK_KEY = 'email_watermark'
 # Default first-run lookback when no cursor exists yet.
 _DEFAULT_LOOKBACK_HOURS = 24
 
+# Server-managed floor for the email watermark. Written ONLY by
+# ``get_new_emails`` (never by the agent) and set to the highest
+# ``next_watermark`` the server has emitted for this schedule+store.
+# ``set_schedule_state('email_watermark', v)`` refuses to persist a
+# value below it — see the incident write-up in
+# ``tests/e2e/test_email_watermark_e2e.py``: a model that hand-derived
+# the watermark from an email's ``Date`` header (a value BELOW the
+# ``fetched_at`` axis the reader filters on) passed the coarse
+# ±90-day window check, so run 2 re-swept the already-processed email
+# and leaked its body. The floor moves that contract from prose into
+# code: the cursor cannot regress below what ``get_new_emails`` showed
+# the agent, and — for a store that actually has linked email accounts
+# — cannot be set at all until ``get_new_emails`` has run.
+_EMAIL_WATERMARK_FLOOR_KEY = '_email_watermark_floor'
+# Keys beginning with this prefix are server-managed and rejected on
+# the agent-facing write path (so an agent cannot lower the floor).
+_RESERVED_KEY_PREFIX = '_'
+
 router = APIRouter(prefix='/api/tasks', tags=['tasks'])
 
 
@@ -157,6 +175,45 @@ async def _load_scheduled_task(db: AsyncSession, task_id: str) -> Task:
     return task
 
 
+async def _store_has_email_accounts(
+    db: AsyncSession, store_id: str | None
+) -> bool:
+    """True if ``store_id`` has at least one linked email account.
+
+    Gates the watermark-floor enforcement: only a store that actually
+    runs email sweeps must go through ``get_new_emails`` before writing
+    ``email_watermark``. Stores with no linked account (and the many
+    tests that use ``email_watermark`` as a generic KV sample) keep the
+    plain typed-value semantics.
+    """
+    if not store_id:
+        return False
+    row = await db.execute(
+        select(StoreEmailLink.id)
+        .where(StoreEmailLink.store_id == store_id)
+        .limit(1)
+    )
+    return row.first() is not None
+
+
+async def _get_watermark_floor(
+    db: AsyncSession, schedule_id: str, store_scope: str
+) -> int | None:
+    """Return the server-managed email-watermark floor, or None.
+
+    None means ``get_new_emails`` has not run yet for this
+    schedule+store, so no cursor has been shown to the agent.
+    """
+    state = await db.get(
+        ScheduleState,
+        (schedule_id, store_scope, _EMAIL_WATERMARK_FLOOR_KEY),
+    )
+    if state is None or not state.value:
+        return None
+    # Written only by the server as ``str(int)`` — int() is safe.
+    return int(state.value)
+
+
 class RegisterFinalizeRequest(BaseModel):
     # Non-empty NL instruction for the gather/reduce step. Same
     # strip+min_length contract as schedule-state so the MCP boundary
@@ -250,7 +307,13 @@ async def get_schedule_state(
                 ScheduleState.store_id == store_scope,
             )
         )
-        known_keys = sorted(row[0] for row in existing.all())
+        # Hide server-managed cursors (e.g. the email-watermark floor)
+        # so the agent never tries to read or mimic them.
+        known_keys = sorted(
+            row[0]
+            for row in existing.all()
+            if not row[0].startswith(_RESERVED_KEY_PREFIX)
+        )
         return {
             'key': key,
             'value': None,
@@ -289,12 +352,57 @@ async def set_schedule_state(
     MCP tool result never leaks it to the agent.
     """
     _validate_schedule_state_key(key)
+    if key.startswith(_RESERVED_KEY_PREFIX):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"keys starting with '{_RESERVED_KEY_PREFIX}' are reserved "
+                'for server-managed cursors and cannot be written via '
+                'set_schedule_state.'
+            ),
+        )
     # `body.value` is already stripped + non-empty — enforced by
     # SetScheduleStateRequest's StringConstraints (pydantic 422s on
     # null / missing / empty / whitespace-only at the boundary).
     _validate_typed_value(key, body.value)
     task = await _load_scheduled_task(db, task_id)
     store_scope = task.store_id or NO_STORE_SCOPE
+
+    # Email-watermark cursor authority: for a store that actually runs
+    # email sweeps, the watermark may only advance through what
+    # get_new_emails showed the agent. This makes the run-1→run-2 leak
+    # (persisting a Date-header epoch below the fetched_at axis)
+    # impossible from this surface — see _EMAIL_WATERMARK_FLOOR_KEY.
+    if key == _EMAIL_WATERMARK_KEY and await _store_has_email_accounts(
+        db, task.store_id
+    ):
+        floor = await _get_watermark_floor(db, task.schedule_id, store_scope)
+        if floor is None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    'This store has linked email account(s): call '
+                    'vibe_seller_get_new_emails first and persist its '
+                    '`next_watermark` verbatim. The watermark must come '
+                    'from that tool (it keys off the fetched_at axis the '
+                    'reader filters on) — do not set email_watermark by '
+                    'hand or from an email Date header.'
+                ),
+            )
+        if int(body.value) < floor:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f'value {body.value} is below the email-watermark '
+                    f'floor {floor} — the newest email '
+                    'vibe_seller_get_new_emails has shown you. Persisting '
+                    'it would re-sweep already-processed emails next run. '
+                    'Persist the `next_watermark` from get_new_emails '
+                    'verbatim; never derive the watermark from an email '
+                    'Date header.'
+                ),
+            )
+
     now = datetime.now(UTC).isoformat()
     stmt = sqlite_insert(ScheduleState).values(
         schedule_id=task.schedule_id,
@@ -414,6 +522,39 @@ async def get_new_emails(
             'email': acct.email,
             'new_emails': emails,
         })
+
+    # Record the cursor floor server-side (monotonic, never decreases):
+    # this is the highest next_watermark we have shown the agent, and
+    # set_schedule_state('email_watermark', …) refuses any value below
+    # it. Written here, on the sanctioned read path, so the agent can
+    # never persist a watermark that would re-sweep what it just saw.
+    prior_floor = await _get_watermark_floor(db, task.schedule_id, store_scope)
+    floor_val = next_watermark
+    if prior_floor is not None:
+        floor_val = max(floor_val, prior_floor)
+    floor_now = datetime.now(UTC).isoformat()
+    floor_stmt = sqlite_insert(ScheduleState).values(
+        schedule_id=task.schedule_id,
+        store_id=store_scope,
+        key=_EMAIL_WATERMARK_FLOOR_KEY,
+        value=str(floor_val),
+        updated_at=floor_now,
+        updated_by_task_id=task_id,
+    )
+    floor_stmt = floor_stmt.on_conflict_do_update(
+        index_elements=[
+            ScheduleState.schedule_id,
+            ScheduleState.store_id,
+            ScheduleState.key,
+        ],
+        set_={
+            'value': floor_stmt.excluded.value,
+            'updated_at': floor_stmt.excluded.updated_at,
+            'updated_by_task_id': floor_stmt.excluded.updated_by_task_id,
+        },
+    )
+    await db.execute(floor_stmt)
+    await db.commit()
 
     return {
         'key': _EMAIL_WATERMARK_KEY,

--- a/app/routers/tasks_schedule_state.py
+++ b/app/routers/tasks_schedule_state.py
@@ -14,7 +14,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, StringConstraints
-from sqlalchemy import select
+from sqlalchemy import Integer, cast, func, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -120,6 +120,25 @@ def _validate_schedule_state_key(key: str) -> None:
             status_code=400,
             detail=(
                 'Invalid key: must match [A-Za-z0-9_.-] and be 1-64 chars.'
+            ),
+        )
+
+
+def _reject_reserved_key(key: str) -> None:
+    """Reject agent access to server-managed (``_``-prefixed) keys.
+
+    Applied on BOTH the read and write paths so an agent can neither
+    read the email-watermark floor nor lower it. The server's own
+    floor read/write goes through ``db`` directly, not these
+    endpoints, so it is unaffected.
+    """
+    if key.startswith(_RESERVED_KEY_PREFIX):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"keys starting with '{_RESERVED_KEY_PREFIX}' are reserved "
+                'for server-managed cursors and cannot be read or written '
+                'via the schedule-state tools.'
             ),
         )
 
@@ -280,6 +299,7 @@ async def get_schedule_state(
     the MCP tool output cannot expose it to the agent.
     """
     _validate_schedule_state_key(key)
+    _reject_reserved_key(key)
     task = await _load_scheduled_task(db, task_id)
     # Scope by the calling task's store_id so fanout siblings each
     # see their own cursor. NO_STORE_SCOPE ('') is the sentinel for
@@ -307,8 +327,10 @@ async def get_schedule_state(
                 ScheduleState.store_id == store_scope,
             )
         )
-        # Hide server-managed cursors (e.g. the email-watermark floor)
-        # so the agent never tries to read or mimic them.
+        # Omit server-managed cursors (e.g. the email-watermark floor)
+        # from the hint list. Direct reads of them are also rejected
+        # (see _reject_reserved_key), so the agent never sees or mimics
+        # them by either path.
         known_keys = sorted(
             row[0]
             for row in existing.all()
@@ -352,15 +374,7 @@ async def set_schedule_state(
     MCP tool result never leaks it to the agent.
     """
     _validate_schedule_state_key(key)
-    if key.startswith(_RESERVED_KEY_PREFIX):
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"keys starting with '{_RESERVED_KEY_PREFIX}' are reserved "
-                'for server-managed cursors and cannot be written via '
-                'set_schedule_state.'
-            ),
-        )
+    _reject_reserved_key(key)
     # `body.value` is already stripped + non-empty — enforced by
     # SetScheduleStateRequest's StringConstraints (pydantic 422s on
     # null / missing / empty / whitespace-only at the boundary).
@@ -523,21 +537,22 @@ async def get_new_emails(
             'new_emails': emails,
         })
 
-    # Record the cursor floor server-side (monotonic, never decreases):
-    # this is the highest next_watermark we have shown the agent, and
-    # set_schedule_state('email_watermark', …) refuses any value below
-    # it. Written here, on the sanctioned read path, so the agent can
-    # never persist a watermark that would re-sweep what it just saw.
-    prior_floor = await _get_watermark_floor(db, task.schedule_id, store_scope)
-    floor_val = next_watermark
-    if prior_floor is not None:
-        floor_val = max(floor_val, prior_floor)
+    # Record the cursor floor server-side. The floor is the highest
+    # next_watermark we have shown the agent;
+    # set_schedule_state('email_watermark', …) refuses any lower value,
+    # so the agent can never persist a watermark that re-sweeps what it
+    # just saw. The update is ATOMIC and monotonic: the ON CONFLICT
+    # clause takes MAX(existing, new) in SQL rather than a
+    # read-then-write in Python, so two overlapping GET /new-emails
+    # calls (or a retry) can never clobber a higher floor with a lower
+    # one. CAST to INTEGER so the comparison is numeric, not the unsafe
+    # lexicographic ordering the epoch-string format otherwise invites.
     floor_now = datetime.now(UTC).isoformat()
     floor_stmt = sqlite_insert(ScheduleState).values(
         schedule_id=task.schedule_id,
         store_id=store_scope,
         key=_EMAIL_WATERMARK_FLOOR_KEY,
-        value=str(floor_val),
+        value=str(next_watermark),
         updated_at=floor_now,
         updated_by_task_id=task_id,
     )
@@ -548,7 +563,10 @@ async def get_new_emails(
             ScheduleState.key,
         ],
         set_={
-            'value': floor_stmt.excluded.value,
+            'value': func.max(
+                cast(floor_stmt.excluded.value, Integer),
+                cast(ScheduleState.value, Integer),
+            ),
             'updated_at': floor_stmt.excluded.updated_at,
             'updated_by_task_id': floor_stmt.excluded.updated_by_task_id,
         },

--- a/tests/workflow/test_wf_new_emails.py
+++ b/tests/workflow/test_wf_new_emails.py
@@ -350,6 +350,7 @@ class TestWatermarkFloorAuthority:
         )
         # Establish the floor via the sanctioned read path.
         r1 = await admin_client.get(f'/api/tasks/{task_id}/new-emails')
+        assert r1.status_code == 200
         floor = int(r1.json()['next_watermark'])
 
         # A Date-header-derived value below the floor (the fetched_at
@@ -368,19 +369,25 @@ class TestWatermarkFloorAuthority:
         )
         assert ok.status_code == 200
 
-    async def test_reserved_floor_key_write_rejected(
+    async def test_reserved_floor_key_rejected_read_and_write(
         self, admin_client, override_async_session, admin_user, email_env
     ):
-        """Agents cannot write the server-managed floor key directly."""
+        """Agents can neither write nor read the server-managed floor."""
         task_id = await _make_running_task(
             override_async_session,
             admin_user,
             email_env['schedule_id'],
             email_env['store_id'],
         )
-        r = await admin_client.put(
+        w = await admin_client.put(
             f'/api/tasks/{task_id}/schedule-state/_email_watermark_floor',
             json={'value': '0'},
+        )
+        assert w.status_code == 400
+        assert 'reserved' in w.json()['detail']
+
+        r = await admin_client.get(
+            f'/api/tasks/{task_id}/schedule-state/_email_watermark_floor'
         )
         assert r.status_code == 400
         assert 'reserved' in r.json()['detail']
@@ -397,10 +404,12 @@ class TestWatermarkFloorAuthority:
         )
         # get_new_emails writes the floor; then persist the watermark.
         r1 = await admin_client.get(f'/api/tasks/{task_id}/new-emails')
-        await admin_client.put(
+        assert r1.status_code == 200
+        put = await admin_client.put(
             f'/api/tasks/{task_id}/schedule-state/email_watermark',
             json={'value': r1.json()['next_watermark']},
         )
+        assert put.status_code == 200
         # A miss on an unrelated key lists other keys — the floor
         # (a `_`-prefixed reserved key) must not appear.
         miss = await admin_client.get(

--- a/tests/workflow/test_wf_new_emails.py
+++ b/tests/workflow/test_wf_new_emails.py
@@ -19,6 +19,7 @@ import pytest_asyncio
 from app.email.db import db_path_for_account, init_email_db, store_emails
 from app.models.email_account import EmailAccount
 from app.models.schedule import Schedule
+from app.models.schedule_state import ScheduleState
 from app.models.store import Store
 from app.models.store_email_link import StoreEmailLink
 from app.models.task import Task
@@ -245,13 +246,26 @@ class TestNewEmailsSweep:
             email_env['store_id'],
         )
 
-        # Watermark parked at "now" — as a fumbled sweep would leave it.
+        # Watermark parked at "now". Seed it directly in the DB rather
+        # than via the PUT endpoint: for an email-linked store that
+        # endpoint now refuses a watermark that didn't come from
+        # get_new_emails (the cursor-authority guard tested separately
+        # in TestWatermarkFloorAuthority). This test is about the READ
+        # axis (fetched_at, not the Date header), so we bypass the write
+        # guard and pin the cursor directly.
         now_epoch = int(datetime.now(UTC).timestamp())
-        put = await admin_client.put(
-            f'/api/tasks/{task_id}/schedule-state/email_watermark',
-            json={'value': str(now_epoch)},
-        )
-        assert put.status_code == 200
+        async with override_async_session() as db:
+            db.add(
+                ScheduleState(
+                    schedule_id=email_env['schedule_id'],
+                    store_id=email_env['store_id'],
+                    key='email_watermark',
+                    value=str(now_epoch),
+                    updated_at=datetime.now(UTC).isoformat(),
+                    updated_by_task_id=task_id,
+                )
+            )
+            await db.commit()
 
         # A new email arrives AFTER the cursor (fetched_at ahead of it)
         # but with a Date header from an hour BEFORE it.
@@ -293,3 +307,105 @@ class TestNewEmailsSweep:
         )
         r = await admin_client.get(f'/api/tasks/{task_id}/new-emails')
         assert r.status_code == 400
+
+
+class TestWatermarkFloorAuthority:
+    """get_new_emails is the sole authority for the email watermark.
+
+    Pins the design fix for the run-1→run-2 leak: a store with linked
+    email accounts can only advance ``email_watermark`` through the
+    ``next_watermark`` get_new_emails emitted. A hand-derived value —
+    the Date-header epoch a fumbled sweep persisted in the incident —
+    is below that floor and is rejected at the write boundary, so the
+    already-processed email can never be re-swept.
+    """
+
+    async def test_write_rejected_before_get_new_emails(
+        self, admin_client, override_async_session, admin_user, email_env
+    ):
+        """No floor yet + store has email accounts → write is refused."""
+        task_id = await _make_running_task(
+            override_async_session,
+            admin_user,
+            email_env['schedule_id'],
+            email_env['store_id'],
+        )
+        r = await admin_client.put(
+            f'/api/tasks/{task_id}/schedule-state/email_watermark',
+            json={'value': str(int(datetime.now(UTC).timestamp()) - 60)},
+        )
+        assert r.status_code == 400
+        assert 'get_new_emails' in r.json()['detail']
+
+    async def test_write_below_floor_rejected(
+        self, admin_client, override_async_session, admin_user, email_env
+    ):
+        """The incident: a value below what get_new_emails showed is
+        rejected, so run 2 cannot re-sweep the processed email."""
+        task_id = await _make_running_task(
+            override_async_session,
+            admin_user,
+            email_env['schedule_id'],
+            email_env['store_id'],
+        )
+        # Establish the floor via the sanctioned read path.
+        r1 = await admin_client.get(f'/api/tasks/{task_id}/new-emails')
+        floor = int(r1.json()['next_watermark'])
+
+        # A Date-header-derived value below the floor (the fetched_at
+        # axis) — exactly what leaked in the e2e — is refused.
+        r = await admin_client.put(
+            f'/api/tasks/{task_id}/schedule-state/email_watermark',
+            json={'value': str(floor - 1)},
+        )
+        assert r.status_code == 400
+        assert 'floor' in r.json()['detail']
+
+        # Persisting the next_watermark verbatim (== floor) is accepted.
+        ok = await admin_client.put(
+            f'/api/tasks/{task_id}/schedule-state/email_watermark',
+            json={'value': str(floor)},
+        )
+        assert ok.status_code == 200
+
+    async def test_reserved_floor_key_write_rejected(
+        self, admin_client, override_async_session, admin_user, email_env
+    ):
+        """Agents cannot write the server-managed floor key directly."""
+        task_id = await _make_running_task(
+            override_async_session,
+            admin_user,
+            email_env['schedule_id'],
+            email_env['store_id'],
+        )
+        r = await admin_client.put(
+            f'/api/tasks/{task_id}/schedule-state/_email_watermark_floor',
+            json={'value': '0'},
+        )
+        assert r.status_code == 400
+        assert 'reserved' in r.json()['detail']
+
+    async def test_floor_hidden_from_other_known_keys(
+        self, admin_client, override_async_session, admin_user, email_env
+    ):
+        """The internal floor never surfaces to the agent's key list."""
+        task_id = await _make_running_task(
+            override_async_session,
+            admin_user,
+            email_env['schedule_id'],
+            email_env['store_id'],
+        )
+        # get_new_emails writes the floor; then persist the watermark.
+        r1 = await admin_client.get(f'/api/tasks/{task_id}/new-emails')
+        await admin_client.put(
+            f'/api/tasks/{task_id}/schedule-state/email_watermark',
+            json={'value': r1.json()['next_watermark']},
+        )
+        # A miss on an unrelated key lists other keys — the floor
+        # (a `_`-prefixed reserved key) must not appear.
+        miss = await admin_client.get(
+            f'/api/tasks/{task_id}/schedule-state/nope'
+        )
+        known = miss.json()['other_known_keys']
+        assert '_email_watermark_floor' not in known
+        assert 'email_watermark' in known


### PR DESCRIPTION
## Why

While triaging PR #48's CI, `tests/e2e/test_email_watermark_e2e.py` failed **flakily** — and the root cause was a real latent design flaw, not the test. The `email_watermark` cursor was a **prose-only contract**:

- The **reader** (`get_new_emails`) filters on the **`fetched_at`** axis (when *we* stored the row).
- The **writer** (`set_schedule_state('email_watermark', v)`) accepted **any** epoch within a coarse ±90-day window.

In the failing run a weak model (MiniMax-M2.5) called `get_new_emails` with the wrong (unprefixed) tool name, gave up on the tool, read the DB by hand, and persisted the watermark from the email's **`Date` header** — a value *below* the `fetched_at` of an email it had just processed. It passed the 90-day window check, so **run 2 re-swept that email and leaked its body** (exactly the assertion the e2e pins). The e2e result flipped ✅→❌ across markdown-only commits on #48, confirming the trigger is model/timing-driven — but the reason a model *could* poison the cursor is this missing server-side contract.

## What (move the contract into code)

Make `get_new_emails` the **sole authority** for the email watermark:

- `get_new_emails` records a **server-managed floor** (`_email_watermark_floor`) = the highest `next_watermark` it has emitted for this schedule+store (monotonic).
- `set_schedule_state('email_watermark', …)` — **only for a store that actually has linked email accounts** — refuses the write until `get_new_emails` has run (no floor yet), and refuses any value **below** the floor.
- Reserved `_`-prefixed keys are rejected on the agent write path and hidden from `other_known_keys`, so an agent can't lower the floor.
- **Generic KV** use (stores with no email link, non-email cursors like `last_order_id`) is **unchanged**.

Result: the cursor can only advance through what the tool showed the agent — a hand-derived or `Date`-header value is **impossible from this surface**, so the leak bug class can't recur.

Prose aligned so it can't re-teach the bypass: `scheduled_watermark.md` and the `set_schedule_state` MCP description now say the email watermark must be the `next_watermark` from `get_new_emails`, written verbatim (the old text described a manual `SELECT` + hand-computed epoch — the path the model took).

## Tests

- New `TestWatermarkFloorAuthority` (in `test_wf_new_emails.py`): write-before-`get_new_emails` rejected; below-floor rejected; verbatim accepted; reserved-key rejected; floor hidden from `other_known_keys`.
- Updated the `fetched_at`-axis read test to seed the cursor directly (its old direct PUT is now correctly guarded).
- `test_wf_new_emails` + `test_wf_schedule_state` + `test_wf_email` + `test_prompt_assembly` all green; ruff clean; files under the 800-line cap.

Note: this doesn't try to force a weak model to call tools correctly (inherent to a live-LLM e2e) — it makes a *wrong* cursor value **unpersistable**, which is the durable fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
