### PR TITLE
fix(win-upgrade): reliable in-place upgrade (no empty .venv) + tray changelog + update-check reconciliation

### DIFF
--- a/.github/workflows/windows-upgrade.yml
+++ b/.github/workflows/windows-upgrade.yml
@@ -135,6 +135,69 @@ jobs:
           }
           if (-not $ok) { throw "UPGRADED server did not report 0.0.2 (upgrade failed)" }
 
+      # The REAL in-app upgrade path: the tray (pythonw.exe under
+      # .venv\Scripts) launches the installer and is still ALIVE when the
+      # installer deletes+rebuilds .venv. The prior "Upgrade in place"
+      # step stopped the server first, so it never exercised this lock —
+      # in the field it left an empty .venv and the finish step failed
+      # with "pythonw.exe not found". Here we hold a venv pythonw.exe open
+      # (native ext loaded, so .venv files are truly locked) and upgrade
+      # WITHOUT stopping first; PrepareToInstall must kill+wait for it and
+      # ssPostInstall must (re)build+verify the venv.
+      - name: Hot upgrade (server + tray pythonw running) rebuilds the venv
+        shell: pwsh
+        run: |
+          $install = $env:VS_INSTALL
+          $exe = "$env:GITHUB_WORKSPACE\installer\windows\outB\VibeSeller-Setup.exe"
+          # Server (0.0.2) is still running from the previous step. Also
+          # hold a venv pythonw.exe alive == the tray that launched the
+          # upgrade. Importing Pillow's C ext locks a .pyd inside .venv,
+          # and the running pythonw.exe image locks .venv\Scripts\pythonw.exe
+          # — exactly the production lock. Launch from a SCRIPT FILE
+          # (Start-Process mangles a spaces/commas `-c` string).
+          $pyw = "$install\.venv\Scripts\pythonw.exe"
+          $holder = Join-Path $env:RUNNER_TEMP 'hold_tray.py'
+          Set-Content -LiteralPath $holder -Encoding ascii -Value @(
+            'from PIL import Image, _imaging',
+            'import time',
+            'time.sleep(900)')
+          Start-Process -FilePath $pyw -ArgumentList $holder | Out-Null
+          Start-Sleep 6
+          if (-not (Get-CimInstance Win32_Process | Where-Object {
+            $_.Name -eq 'pythonw.exe' -and $_.ExecutablePath -and
+            $_.ExecutablePath.StartsWith($install, [System.StringComparison]::OrdinalIgnoreCase) })) {
+            throw "precondition failed: no venv pythonw holding the lock"
+          }
+          # Upgrade in place WITHOUT stopping the server/tray first.
+          $p = Start-Process -FilePath $exe -Wait -PassThru `
+            -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/NOICONS'
+          if ($p.ExitCode -ne 0) { throw "hot upgrade exited $($p.ExitCode)" }
+          # The invariant that was violated in production: a real venv
+          # (not an empty .venv) must exist after the upgrade.
+          foreach ($f in @('.venv\pyvenv.cfg','.venv\Scripts\pythonw.exe',
+                           '.venv\Scripts\python.exe','.venv\Scripts\vibe-seller.exe',
+                           '.venv\Scripts\playwright.exe')) {
+            if (-not (Test-Path "$install\$f")) {
+              throw "empty/broken venv after hot upgrade: missing $f"
+            }
+          }
+          # Leave a healthy server running for the e2e step that follows.
+          $env:PATH = "$install\.venv\Scripts;$install;$install\claude;" +
+                      "$install\git\cmd;$install\git\bin;" +
+                      "$install\git\usr\bin;$install\git\mingw64\bin;$env:PATH"
+          $env:CLAUDE_CODE_GIT_BASH_PATH = "$install\git\bin\bash.exe"
+          $env:VIBE_SELLER_BUNDLED_PYTHON = "$install\python\python.exe"
+          & "$install\.venv\Scripts\vibe-seller.exe" start --port 7777
+          $ok = $false
+          for ($i = 0; $i -lt 60; $i++) {
+            try {
+              if ((Invoke-RestMethod http://127.0.0.1:7777/api/version -TimeoutSec 3).version -eq '0.0.2') { $ok = $true; break }
+            } catch { }
+            Start-Sleep 2
+          }
+          if (-not $ok) { throw "server not healthy at 0.0.2 after hot upgrade" }
+          Write-Host "OK: hot in-place upgrade (tray running) rebuilt the venv"
+
       - name: Basic e2e on the UPGRADED build (health + store/profile API)
         shell: bash
         run: |

--- a/app/routers/system.py
+++ b/app/routers/system.py
@@ -103,6 +103,13 @@ async def _compute_update_check() -> dict:
                 'current_version': current,
             }
         releases = await fetch_release_notes(client, current)
+        # Reconcile the two sources: `latest` is PyPI (what `vibe-seller
+        # upgrade` / pip actually installs), but the notes come from
+        # GitHub Releases. If GitHub has tagged a release PyPI hasn't
+        # published yet, drop its notes — otherwise the popup advertises a
+        # version the user's upgrade path can't reach. Never show notes
+        # newer than the installable `latest`.
+        releases = [r for r in releases if not is_newer(r['version'], latest)]
 
     platform = get_platform()
     is_windows = platform == 'windows'

--- a/app/windows_update.py
+++ b/app/windows_update.py
@@ -39,7 +39,11 @@ logger = logging.getLogger(__name__)
 REPO = 'zpoint/vibe-seller'
 ASSET_NAME = 'VibeSeller-Setup.exe'
 MANUAL_URL = f'https://github.com/{REPO}/releases/latest'
+# Human-facing "what's new" page listing every release (GitHub renders
+# it cumulatively), shown in the tray's update dialog.
+RELEASES_PAGE = f'https://github.com/{REPO}/releases'
 _DEFAULT_API = f'https://api.github.com/repos/{REPO}/releases/latest'
+_RELEASES_LIST_API = f'https://api.github.com/repos/{REPO}/releases'
 
 # One upgrade at a time. The tray spawns a daemon thread per "Check for
 # updates" click; without this, a double-click launches TWO installers
@@ -111,6 +115,42 @@ def check_for_update() -> dict | None:
     return {'version': tag, 'url': asset['browser_download_url']}
 
 
+def fetch_release_notes(current: str, *, limit: int = 5) -> list[dict]:
+    """Releases strictly newer than *current*, newest first (best-effort).
+
+    Powers the tray's "what's new" so a user jumping several versions
+    (e.g. 0.0.8 → 0.0.10) sees every intermediate release, not just the
+    target. Any fetch/parse failure returns ``[]`` — a missing changelog
+    must never block the upgrade itself. Drafts/prereleases are skipped
+    (the installer only ever fetches full releases).
+    """
+    try:
+        with _open(_RELEASES_LIST_API, timeout=10) as resp:
+            releases = json.loads(resp.read().decode())
+    except (OSError, ValueError):
+        return []
+    if not isinstance(releases, list):
+        return []
+    notes = []
+    for rel in releases:
+        if (
+            not isinstance(rel, dict)
+            or rel.get('draft')
+            or rel.get('prerelease')
+        ):
+            continue
+        tag = (rel.get('tag_name') or '').lstrip('v')
+        if not tag or not is_newer(tag, current):
+            continue
+        notes.append({
+            'version': tag,
+            'url': rel.get('html_url') or RELEASES_PAGE,
+        })
+        if len(notes) >= limit:
+            break
+    return notes
+
+
 def download_installer(url: str, dest: Path) -> Path:
     # Plain local path (tests/CI) → copy; http(s)/file:// → fetch.
     if not _is_url(url):
@@ -167,8 +207,9 @@ def upgrade(*, silent: bool = False) -> dict:
 
     Returns one of:
     - ``{'status': 'up-to-date', 'version': <current>}``
-    - ``{'status': 'updating', 'version': <new>}``
-    - ``{'status': 'in-progress'}`` — another upgrade is already running
+    - ``{'status': 'updating', 'version': <new>, 'notes_url': <url>}``
+    - ``{'status': 'in-progress', 'version': <current>}`` — another
+      upgrade is already running
     - ``{'status': 'error', 'error': <msg>, 'manual_url': <url>}``
     """
     if not _upgrade_lock.acquire(blocking=False):
@@ -183,7 +224,11 @@ def upgrade(*, silent: bool = False) -> dict:
         dest = Path(tempfile.mkdtemp(prefix='vibe-seller-upd-')) / ASSET_NAME
         download_installer(upd['url'], dest)
         run_installer(dest, silent=silent)
-        return {'status': 'updating', 'version': upd['version']}
+        return {
+            'status': 'updating',
+            'version': upd['version'],
+            'notes_url': RELEASES_PAGE,
+        }
     except Exception as exc:  # noqa: BLE001 — surfaced to the user, not raised
         logger.exception('Windows update failed')
         return {'status': 'error', 'error': str(exc), 'manual_url': MANUAL_URL}

--- a/app/windows_update.py
+++ b/app/windows_update.py
@@ -24,7 +24,10 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 import tempfile
+import threading
+import time
 import urllib.request
 
 from packaging.version import InvalidVersion, Version
@@ -37,6 +40,12 @@ REPO = 'zpoint/vibe-seller'
 ASSET_NAME = 'VibeSeller-Setup.exe'
 MANUAL_URL = f'https://github.com/{REPO}/releases/latest'
 _DEFAULT_API = f'https://api.github.com/repos/{REPO}/releases/latest'
+
+# One upgrade at a time. The tray spawns a daemon thread per "Check for
+# updates" click; without this, a double-click launches TWO installers
+# that race on the install dir. Non-blocking acquire → the second call
+# reports 'in-progress' instead of starting a rival installer.
+_upgrade_lock = threading.Lock()
 
 
 def _releases_url() -> str:
@@ -113,11 +122,44 @@ def download_installer(url: str, dest: Path) -> Path:
 
 
 def run_installer(path: Path, *, silent: bool = False) -> None:
+    """Launch the downloaded installer, fully detached from this process.
+
+    This code runs INSIDE the tray's ``pythonw.exe``, which lives at
+    ``{app}\\.venv\\Scripts\\pythonw.exe`` — the very file the installer
+    deletes and rebuilds. So the launch must be truly detached
+    (``DETACHED_PROCESS`` + a new process group) so the installer
+    outlives the tray quitting itself right after (see the tray's
+    ``_on_check_updates``); a plain ``Popen`` child could be torn down
+    with its parent and would keep the install dir locked.
+
+    Retry on ``WinError 32`` (PermissionError): a freshly-written exe can
+    be momentarily locked by an AV scan or a racing download.
+    """
     args = [str(path)]
     if silent:
         args += ['/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART']
-    # Detached: the running server/tray is replaced by the upgrade.
-    subprocess.Popen(args)  # noqa: S603
+    creationflags = 0
+    if sys.platform == 'win32':
+        creationflags = (
+            subprocess.DETACHED_PROCESS  # no console; survives our exit
+            | subprocess.CREATE_NEW_PROCESS_GROUP
+        )
+    last_exc: OSError | None = None
+    for attempt in range(3):
+        try:
+            subprocess.Popen(  # noqa: S603
+                args, creationflags=creationflags, close_fds=True
+            )
+            return
+        except PermissionError as exc:  # WinError 32 — briefly locked
+            last_exc = exc
+            logger.warning(
+                'installer launch locked (attempt %d): %s', attempt + 1, exc
+            )
+            if attempt < 2:
+                time.sleep(1.0 * (attempt + 1))
+    if last_exc is not None:
+        raise last_exc
 
 
 def upgrade(*, silent: bool = False) -> dict:
@@ -126,16 +168,24 @@ def upgrade(*, silent: bool = False) -> dict:
     Returns one of:
     - ``{'status': 'up-to-date', 'version': <current>}``
     - ``{'status': 'updating', 'version': <new>}``
+    - ``{'status': 'in-progress'}`` — another upgrade is already running
     - ``{'status': 'error', 'error': <msg>, 'manual_url': <url>}``
     """
+    if not _upgrade_lock.acquire(blocking=False):
+        return {'status': 'in-progress', 'version': get_version()}
     try:
         upd = check_for_update()
         if not upd:
             return {'status': 'up-to-date', 'version': get_version()}
-        dest = Path(tempfile.gettempdir()) / ASSET_NAME
+        # Unique dir per run: two concurrent downloads writing the same
+        # fixed %TEMP%\VibeSeller-Setup.exe collide and the launch then
+        # fails with WinError 32 (observed in the field).
+        dest = Path(tempfile.mkdtemp(prefix='vibe-seller-upd-')) / ASSET_NAME
         download_installer(upd['url'], dest)
         run_installer(dest, silent=silent)
         return {'status': 'updating', 'version': upd['version']}
     except Exception as exc:  # noqa: BLE001 — surfaced to the user, not raised
         logger.exception('Windows update failed')
         return {'status': 'error', 'error': str(exc), 'manual_url': MANUAL_URL}
+    finally:
+        _upgrade_lock.release()

--- a/installer/windows/tray.py
+++ b/installer/windows/tray.py
@@ -316,8 +316,20 @@ def _on_check_updates(icon, item):  # noqa: ARG001
         status = res.get('status')
         if status == 'up-to-date':
             _dialog('Vibe Seller', _t('latest', v=res.get('version')))
+        elif status == 'in-progress':
+            logger.info('Upgrade already in progress; ignoring click')
         elif status == 'updating':
             _dialog('Vibe Seller', _t('updating', v=res.get('version')))
+            # The installer must delete and rebuild {app}\.venv, but THIS
+            # process is {app}\.venv\Scripts\pythonw.exe — staying alive
+            # locks the very files it rebuilds, leaving an empty .venv and
+            # the "pythonw.exe not found" failure. The installer was
+            # launched detached, so stop the server and quit the tray now;
+            # nothing under the install dir is left locked. Login
+            # auto-start brings the new version's tray back up.
+            logger.info('Upgrade launched; stopping server and quitting tray')
+            _stop_server()
+            icon.stop()
         else:
             _dialog(
                 _t('fail_title'),

--- a/installer/windows/tray.py
+++ b/installer/windows/tray.py
@@ -94,6 +94,8 @@ _STRINGS = {
         'latest': "You're on the latest version ({v}).",
         'updating': 'Downloading v{v} — the installer will open to '
         'finish the update.',
+        'updating_includes': 'This update includes: {versions}.',
+        'whats_new': "What's new",
         'fail_title': 'Vibe Seller — update failed',
         'fail': '{err}\n\nDownload manually:\n{url}',
         'lan_title': 'Vibe Seller — LAN address',
@@ -110,6 +112,8 @@ _STRINGS = {
         'quit': '退出',
         'latest': '已是最新版本（{v}）。',
         'updating': '正在下载 v{v} —— 安装程序将打开以完成更新。',
+        'updating_includes': '本次更新包含：{versions}。',
+        'whats_new': '更新内容',
         'fail_title': 'Vibe Seller —— 更新失败',
         'fail': '{err}\n\n请手动下载：\n{url}',
         'lan_title': 'Vibe Seller —— 局域网地址',
@@ -319,7 +323,21 @@ def _on_check_updates(icon, item):  # noqa: ARG001
         elif status == 'in-progress':
             logger.info('Upgrade already in progress; ignoring click')
         elif status == 'updating':
-            _dialog('Vibe Seller', _t('updating', v=res.get('version')))
+            # "What's new": list every release being applied (not just the
+            # target), so a user several versions behind sees the whole
+            # delta — e.g. 0.0.8 -> 0.0.10 shows v0.0.10 AND v0.0.9. Best
+            # effort: a missing changelog never blocks the update.
+            msg = _t('updating', v=res.get('version'))
+            try:
+                notes = windows_update.fetch_release_notes(get_version())
+            except Exception:  # noqa: BLE001 — changelog is cosmetic
+                notes = []
+            if notes:
+                versions = ', '.join(f'v{n["version"]}' for n in notes)
+                msg = f'{msg}\n\n{_t("updating_includes", versions=versions)}'
+            notes_url = res.get('notes_url')
+            copy_rows = [(_t('whats_new'), notes_url)] if notes_url else None
+            _dialog('Vibe Seller', msg, copy_rows=copy_rows)
             # The installer must delete and rebuild {app}\.venv, but THIS
             # process is {app}\.venv\Scripts\pythonw.exe — staying alive
             # locks the very files it rebuilds, leaving an empty .venv and

--- a/installer/windows/vibe-seller.iss
+++ b/installer/windows/vibe-seller.iss
@@ -116,7 +116,7 @@ Source: "{#StagingDir}\vibe-seller.ico"; DestDir: "{app}"; Flags: ignoreversion 
 Filename: "{#AppExeTray}"; Parameters: """{app}\tray.py"" --open"; \
   Description: "{cm:OpenNow}"; \
   Flags: nowait postinstall skipifsilent; \
-  Check: VenvPythonwExists
+  Check: VenvIsReady
 
 [Icons]
 ; Clickable shortcuts (Start Menu + optional desktop) launch with
@@ -180,9 +180,14 @@ begin
     '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
 end;
 
-function VenvPythonwExists: Boolean;
+function VenvIsReady: Boolean;
 begin
-  Result := FileExists(ExpandConstant('{app}\.venv\Scripts\pythonw.exe'));
+  // A *real* venv, not a half-built one: the launcher must exist AND
+  // pyvenv.cfg must be present. The field failure left a Scripts\ dir
+  // with neither, and windows-upgrade.yml asserts both — keep this guard
+  // in lockstep with that assertion.
+  Result := FileExists(ExpandConstant('{app}\.venv\Scripts\pythonw.exe'))
+    and FileExists(ExpandConstant('{app}\.venv\pyvenv.cfg'));
 end;
 
 procedure SetStatus(const Msg: String);
@@ -225,7 +230,7 @@ begin
       ExpandConstant('{app}\wheels') + '" vibe-seller pystray pillow',
       '', SW_HIDE, ewWaitUntilTerminated, Rc);
   end;
-  Result := (Rc = 0) and VenvPythonwExists;
+  Result := (Rc = 0) and VenvIsReady;
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
@@ -243,9 +248,14 @@ begin
           'Vibe Seller could not create its Python environment.'#13#10#13#10 +
           'Please fully quit Vibe Seller from the system tray, then run ' +
           'the installer again.');
-    // Browser engine for the chrome backend. Best-effort: needs network
-    // and is NOT fatal — the app runs and the engine is fetched later. A
-    // follow-up switches the backend to the user's installed Chrome/Edge.
+    // Browser engine for the chrome backend. Best-effort so a network
+    // blip doesn't abort the whole install — but NOT auto-fetched at
+    // runtime: the chrome backend drives Playwright's bundled Chromium,
+    // so if this download fails the app still starts and the UI works,
+    // yet chrome-backend browser tasks fail to launch until the engine
+    // is present (re-run the installer, or `playwright install chromium`
+    // in the venv). A follow-up switches to the user's installed
+    // Chrome/Edge, removing this step.
     SetStatus('Downloading browser engine (first run only)...');
     Exec(ExpandConstant('{app}\.venv\Scripts\playwright.exe'),
       'install chromium', '', SW_HIDE, ewWaitUntilTerminated, Rc);

--- a/installer/windows/vibe-seller.iss
+++ b/installer/windows/vibe-seller.iss
@@ -101,39 +101,22 @@ Source: "{#StagingDir}\dialogs.py"; DestDir: "{app}";        Flags: ignoreversio
 Source: "{#StagingDir}\vibe-seller.ico"; DestDir: "{app}"; Flags: ignoreversion skipifsourcedoesntexist
 
 [Run]
-; Build the runtime venv on the target machine so all paths are correct.
-; (python-build-standalone is relocatable; the venv references it under
-;  the fixed install dir.)
-; --clear so an upgrade rebuilds the venv fresh instead of reusing a
-; stale one (which would keep old app code even after new wheels land).
-Filename: "{app}\uv.exe"; \
-  Parameters: "venv --clear ""{app}\.venv"" --python ""{app}\python\python.exe"""; \
-  StatusMsg: "Creating Python environment..."; \
-  Flags: runhidden waituntilterminated
-
-; Install the app + deps from the bundled wheels (fully offline).
-; --reinstall-package vibe-seller forces the app code to be replaced even
-; when the public version (0.0.1.dev1) is unchanged across builds — the
-; belt to the --clear/wheel-clear suspenders, so upgrades never strand
-; stale code.
-Filename: "{app}\uv.exe"; \
-  Parameters: "pip install --python ""{app}\.venv\Scripts\python.exe"" --reinstall-package vibe-seller --no-index --find-links ""{app}\wheels"" vibe-seller pystray pillow"; \
-  StatusMsg: "Installing Vibe Seller..."; \
-  Flags: runhidden waituntilterminated
-
-; Browser engine for the chrome backend. NOTE: a follow-up issue
-; switches the backend to drive the user's installed Chrome/Edge, at
-; which point this step (and the network requirement) goes away.
-Filename: "{app}\.venv\Scripts\playwright.exe"; \
-  Parameters: "install chromium"; \
-  StatusMsg: "Downloading browser engine (first run only)..."; \
-  Flags: runhidden waituntilterminated
+; The runtime venv (uv venv + uv pip install) and browser engine are
+; built in [Code]'s CurStepChanged(ssPostInstall), NOT here. In [Run],
+; Inno ignores a step's exit code, so a failed `uv venv` (classically: a
+; tray pythonw.exe still locking .venv during an in-place upgrade) left
+; an empty .venv and the finish step below then failed with
+; "pythonw.exe not found". Building in code lets us verify the result,
+; retry once, and surface a clear error instead. See BuildRuntimeEnv.
 
 ; Finish-page "Open now" (checked by default): starts the server and
 ; opens the browser to the UI (tray --open waits for health first).
+; Check: only offer/run this if the venv actually built — belt to the
+; ssPostInstall abort, so we never launch a missing pythonw.exe.
 Filename: "{#AppExeTray}"; Parameters: """{app}\tray.py"" --open"; \
   Description: "{cm:OpenNow}"; \
-  Flags: nowait postinstall skipifsilent
+  Flags: nowait postinstall skipifsilent; \
+  Check: VenvPythonwExists
 
 [Icons]
 ; Clickable shortcuts (Start Menu + optional desktop) launch with
@@ -174,14 +157,99 @@ Type: filesandordirs; Name: "{app}\.venv"
 procedure KillAppProcesses(NameClause: String);
 var
   ResultCode: Integer;
+  Filter: String;
 begin
+  // Match processes launched from the ACTUAL install dir ({app}).
+  Filter := '{ ' + NameClause + '$_.ExecutablePath -like ''' +
+    ExpandConstant('{app}') + '\*'' }';
+  // Kill AND WAIT until they are actually gone (or 30s elapse). A single
+  // Stop-Process returns before the OS finishes tearing the process down
+  // and releasing its file handles, so a plain kill races the subsequent
+  // .venv delete/rebuild — the exact window that left an empty .venv on
+  // in-place upgrade (the tray pythonw.exe locking .venv\Scripts). Poll
+  // until the handles are truly released before we proceed.
   Exec('powershell.exe',
-    '-NoProfile -ExecutionPolicy Bypass -Command "Get-CimInstance ' +
-    'Win32_Process | Where-Object { ' + NameClause +
-    '$_.ExecutablePath -like ''' + ExpandConstant('{app}') + '\*'' } | ' +
-    'ForEach-Object { Stop-Process -Id $_.ProcessId -Force ' +
-    '-ErrorAction SilentlyContinue }"',
+    '-NoProfile -ExecutionPolicy Bypass -Command "' +
+    '$deadline=(Get-Date).AddSeconds(30);' +
+    'do {' +
+    '$p=@(Get-CimInstance Win32_Process | Where-Object ' + Filter + ');' +
+    'if ($p.Count -eq 0) { break };' +
+    '$p | ForEach-Object { Stop-Process -Id $_.ProcessId -Force ' +
+    '-ErrorAction SilentlyContinue };' +
+    'Start-Sleep -Milliseconds 500 } while ((Get-Date) -lt $deadline)"',
     '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+end;
+
+function VenvPythonwExists: Boolean;
+begin
+  Result := FileExists(ExpandConstant('{app}\.venv\Scripts\pythonw.exe'));
+end;
+
+procedure SetStatus(const Msg: String);
+begin
+  // Best-effort: no wizard UI in /VERYSILENT — status is cosmetic.
+  try
+    WizardForm.StatusLabel.Caption := Msg;
+  except
+  end;
+end;
+
+function BuildRuntimeEnv: Boolean;
+var
+  Rc: Integer;
+  Uv, VenvDir, PyExe, VenvPy: String;
+begin
+  Uv := ExpandConstant('{app}\uv.exe');
+  VenvDir := ExpandConstant('{app}\.venv');
+  PyExe := ExpandConstant('{app}\python\python.exe');
+  VenvPy := ExpandConstant('{app}\.venv\Scripts\python.exe');
+
+  // Ensure nothing holds the venv, then delete any partial dir before
+  // rebuilding: `uv venv` REFUSES a dir that "exists but is not a virtual
+  // environment", so a stale/locked half-built .venv (Scripts\ with no
+  // pyvenv.cfg) would otherwise wedge every retry.
+  KillAppProcesses('($_.Name -eq ''pythonw.exe'' -or ' +
+    '$_.Name -eq ''python.exe'') -and ');
+  DelTree(VenvDir, True, True, True);
+
+  SetStatus('Creating Python environment...');
+  Exec(Uv, 'venv "' + VenvDir + '" --python "' + PyExe + '"',
+    '', SW_HIDE, ewWaitUntilTerminated, Rc);
+  if Rc = 0 then begin
+    // --reinstall-package vibe-seller forces the app code to be replaced
+    // even when the public version is unchanged across builds, so an
+    // upgrade never strands stale code.
+    SetStatus('Installing Vibe Seller...');
+    Exec(Uv, 'pip install --python "' + VenvPy + '" ' +
+      '--reinstall-package vibe-seller --no-index --find-links "' +
+      ExpandConstant('{app}\wheels') + '" vibe-seller pystray pillow',
+      '', SW_HIDE, ewWaitUntilTerminated, Rc);
+  end;
+  Result := (Rc = 0) and VenvPythonwExists;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  Rc: Integer;
+begin
+  if CurStep = ssPostInstall then begin
+    // Build the runtime venv HERE (not in [Run]) so a failure is verified
+    // and retried instead of silently leaving an empty .venv (the
+    // "pythonw.exe not found" bug). BuildRuntimeEnv kills+waits for any
+    // lock holder first; one retry covers a slow handle release.
+    if not BuildRuntimeEnv then
+      if not BuildRuntimeEnv then
+        RaiseException(
+          'Vibe Seller could not create its Python environment.'#13#10#13#10 +
+          'Please fully quit Vibe Seller from the system tray, then run ' +
+          'the installer again.');
+    // Browser engine for the chrome backend. Best-effort: needs network
+    // and is NOT fatal — the app runs and the engine is fetched later. A
+    // follow-up switches the backend to the user's installed Chrome/Edge.
+    SetStatus('Downloading browser engine (first run only)...');
+    Exec(ExpandConstant('{app}\.venv\Scripts\playwright.exe'),
+      'install chromium', '', SW_HIDE, ewWaitUntilTerminated, Rc);
+  end;
 end;
 
 function PrepareToInstall(var NeedsRestart: Boolean): String;
@@ -191,8 +259,9 @@ begin
   // On upgrade, a running server (uvicorn python) + tray (pythonw) hold
   // locks on files under {app}, so the file-copy fails and the built-in
   // "close applications / force close" often can't kill a background
-  // Python. Proactively stop the daemon and kill anything launched from
-  // the install dir so the overwrite succeeds. No-ops on a fresh install.
+  // Python. Proactively stop the daemon and kill+WAIT for anything
+  // launched from the install dir so the overwrite AND the venv rebuild
+  // succeed. No-ops on a fresh install.
   Exec(ExpandConstant('{app}\.venv\Scripts\vibe-seller.exe'), 'stop',
     '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
   KillAppProcesses('');

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -328,20 +328,47 @@ def _setup_worker_profile():
 
     e2e_helpers.DEFAULT_PROFILE_ID = profile_id
 
-    # Set admin user's default profile so UI-created tasks
-    # (Playwright tests) also use the worker's provider
-    # instead of falling back to server os.environ.
+    # Route EVERY agent task to the worker's provider — CI provisions no
+    # Claude credentials, so any fall-through to the 'default' (Claude)
+    # profile dies mid-run with "Not logged in · Please run /login". Two
+    # owners resolve profiles differently (see resolve_schedule_profile),
+    # so both must be configured here — centrally, never per-test:
+    #
+    #   (a) Admin default → UI-created tasks + admin-owned schedules.
+    #   (b) System schedules (e.g. catalog sync) are owned by the ai_bot
+    #       user, whose default is never set, so (a) does NOT reach them.
+    #       Pin the provider directly onto every schedule still resolving
+    #       to 'default' (a pin has top precedence in resolution).
+    #
+    # FAIL LOUD on any error — a swallowed failure here is exactly what
+    # let catalog sync silently fall back to Claude.
+    client2 = httpx.Client(timeout=30)
+    _login_client(client2)
     try:
-        client2 = httpx.Client(timeout=30)
-        _login_client(client2)
-        client2.patch(
-            f'{BASE_URL}/api/profiles/{profile_id}/set-default',
+        resp = client2.patch(
+            f'{BASE_URL}/api/profiles/{profile_id}/set-default'
         )
+        if resp.status_code != 200:
+            pytest.fail(
+                f'set-default {profile_id} failed: '
+                f'{resp.status_code} {resp.text}'
+            )
+
+        resp = client2.get(f'{BASE_URL}/api/schedules')
+        resp.raise_for_status()
+        for sched in resp.json():
+            if sched.get('ai_profile_id') in (None, '', 'default'):
+                pinned = client2.put(
+                    f'{BASE_URL}/api/schedules/{sched["id"]}',
+                    json={'ai_profile_id': profile_id},
+                )
+                if pinned.status_code != 200:
+                    pytest.fail(
+                        f'pin schedule {sched["id"]} to {profile_id} '
+                        f'failed: {pinned.status_code} {pinned.text}'
+                    )
+    finally:
         client2.close()
-    except Exception:
-        logging.getLogger('e2e').warning(
-            'Failed to set default profile %s', profile_id, exc_info=True
-        )
 
 
 @pytest.fixture(scope='module')

--- a/tests/e2e/test_catalog_sync.py
+++ b/tests/e2e/test_catalog_sync.py
@@ -21,7 +21,6 @@ import pytest
 
 from app.browser.manager import store_slug as _store_slug
 from app.models.schedule_constants import SYSTEM_CATALOG_SYNC_ID
-import tests.e2e.e2e_helpers as e2e_helpers
 from tests.e2e.e2e_helpers import (
     BASE_URL,
     PIPELINE_TIMEOUT,
@@ -162,16 +161,11 @@ def _trigger_catalog_sync(
     (expected to skip via staleness check).
     """
     base = f'{BASE_URL}/api/schedules/{SYSTEM_CATALOG_SYNC_ID}'
-    # Ensure the schedule uses the worker's AI profile
-    # (CI seeds it with 'default' which lacks credentials). Send
-    # ONLY the mutable field — ScheduleUpdate uses extra='forbid',
-    # so PUTing the full GET response would 422 (phase_mode,
-    # store_id, is_system are immutable).
-    profile_id = e2e_helpers.DEFAULT_PROFILE_ID
-    if profile_id:
-        resp = client.put(base, json={'ai_profile_id': profile_id})
-        resp.raise_for_status()
-
+    # AI-profile routing for system schedules is configured centrally in
+    # conftest's _setup_worker_profile (which pins the worker's provider
+    # onto every schedule that would otherwise resolve to the
+    # credential-less 'default'). This helper just fires — no per-test
+    # profile setup.
     resp = client.post(f'{base}/trigger')
     resp.raise_for_status()
 

--- a/tests/unit/test_system_router.py
+++ b/tests/unit/test_system_router.py
@@ -108,6 +108,40 @@ class TestUpdateCheckRoute:
         assert result['upgrade_command'] is None
         assert result['download_url'] == system_router.RELEASES_PAGE_URL
 
+    async def test_drops_release_notes_newer_than_installable_latest(
+        self, monkeypatch
+    ):
+        # GitHub tagged 0.8.0 before PyPI published it. PyPI's latest is
+        # 0.7.0 (what pip/`vibe-seller upgrade` can install), so the popup
+        # must NOT advertise 0.8.0's notes — only reconcile down to what's
+        # actually installable.
+        monkeypatch.setattr(system_router, 'APP_VERSION', '0.6.0')
+        monkeypatch.setattr(
+            system_router,
+            'fetch_latest_pypi_version',
+            AsyncMock(return_value='0.7.0'),
+        )
+        gh_ahead = [
+            {
+                'version': '0.8.0',
+                'name': 'v0.8.0',
+                'body': '',
+                'url': 'https://x/0.8.0',
+            },
+            *_SAMPLE_RELEASES,
+        ]
+        monkeypatch.setattr(
+            system_router,
+            'fetch_release_notes',
+            AsyncMock(return_value=gh_ahead),
+        )
+        monkeypatch.setattr(system_router, 'get_platform', lambda: 'mac')
+
+        result = await system_router.update_check()
+
+        assert result['latest_version'] == '0.7.0'
+        assert [r['version'] for r in result['releases']] == ['0.7.0']
+
 
 class TestUpdateCheckCache:
     async def test_second_call_within_ttl_skips_network(self, monkeypatch):

--- a/tests/unit/test_windows_update.py
+++ b/tests/unit/test_windows_update.py
@@ -5,6 +5,7 @@ prove the version comparison + flow without touching the network.
 """
 
 import json
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -104,3 +105,64 @@ class TestUpgrade:
         assert res['status'] == 'error'
         assert res['manual_url'] == wu.MANUAL_URL
         assert 'boom' in res['error']
+
+    def test_downloads_to_a_unique_dir_not_fixed_temp(self, tmp_path):
+        # A fixed %TEMP%\VibeSeller-Setup.exe collides when two upgrades
+        # race → WinError 32 on launch (the field bug). Each run must get
+        # its own dir.
+        upd = {'version': '0.2.0', 'url': _ASSET['browser_download_url']}
+        seen: list[Path] = []
+        with (
+            patch.object(wu, 'check_for_update', return_value=upd),
+            patch.object(wu, 'run_installer'),
+            patch.object(
+                wu,
+                'download_installer',
+                side_effect=lambda _url, dest: seen.append(dest) or dest,
+            ),
+        ):
+            wu.upgrade()
+            wu.upgrade()
+        assert len(seen) == 2
+        assert seen[0].name == wu.ASSET_NAME
+        assert seen[0].parent != seen[1].parent  # unique dir per run
+
+    def test_single_flight_reports_in_progress(self):
+        # A second concurrent click must not launch a rival installer.
+        assert wu._upgrade_lock.acquire(blocking=False)
+        try:
+            res = wu.upgrade()
+        finally:
+            wu._upgrade_lock.release()
+        assert res['status'] == 'in-progress'
+
+
+class TestRunInstaller:
+    def test_retries_on_winerror32_then_succeeds(self, tmp_path):
+        # A freshly-written exe can be briefly locked (AV scan / racing
+        # download); retry rather than fail the whole upgrade.
+        calls = {'n': 0}
+
+        def flaky(*_a, **_k):
+            calls['n'] += 1
+            if calls['n'] < 3:
+                raise PermissionError(32, 'in use')
+
+        with (
+            patch.object(wu.subprocess, 'Popen', side_effect=flaky) as popen,
+            patch.object(wu.time, 'sleep'),
+        ):
+            wu.run_installer(tmp_path / 's.exe')
+        assert popen.call_count == 3
+
+    def test_raises_after_exhausting_retries(self, tmp_path):
+        with (
+            patch.object(
+                wu.subprocess,
+                'Popen',
+                side_effect=PermissionError(32, 'in use'),
+            ),
+            patch.object(wu.time, 'sleep'),
+            pytest.raises(PermissionError),
+        ):
+            wu.run_installer(tmp_path / 's.exe')

--- a/tests/unit/test_windows_update.py
+++ b/tests/unit/test_windows_update.py
@@ -94,7 +94,11 @@ class TestUpgrade:
             patch.object(wu, 'run_installer') as run,
         ):
             res = wu.upgrade()
-        assert res == {'status': 'updating', 'version': '0.2.0'}
+        assert res == {
+            'status': 'updating',
+            'version': '0.2.0',
+            'notes_url': wu.RELEASES_PAGE,
+        }
         run.assert_called_once()
 
     def test_error_returns_manual_url(self):
@@ -135,6 +139,55 @@ class TestUpgrade:
         finally:
             wu._upgrade_lock.release()
         assert res['status'] == 'in-progress'
+
+
+class TestFetchReleaseNotes:
+    def _patch_releases(self, payload):
+        # fetch_release_notes reads _open(...).read() — mock that.
+        class _Resp:
+            def __enter__(self_):
+                return self_
+
+            def __exit__(self_, *a):
+                return False
+
+            def read(self_):
+                return json.dumps(payload).encode()
+
+        return patch.object(wu, '_open', return_value=_Resp())
+
+    _RELS = [
+        {'tag_name': 'v0.0.10', 'html_url': 'https://x/0.0.10'},
+        {'tag_name': 'v0.0.9', 'html_url': 'https://x/0.0.9'},
+        {'tag_name': 'v0.0.8', 'html_url': 'https://x/0.0.8'},
+    ]
+
+    def test_lists_every_release_newer_than_current(self):
+        # 0.0.8 -> latest must surface BOTH skipped releases, newest first.
+        with self._patch_releases(self._RELS):
+            notes = wu.fetch_release_notes('0.0.8')
+        assert [n['version'] for n in notes] == ['0.0.10', '0.0.9']
+
+    def test_skips_drafts_and_prereleases(self):
+        # GitHub returns newest-first; the function preserves that order.
+        rels = [
+            {'tag_name': 'v0.0.11', 'html_url': 'https://x/0.0.11'},
+            {**self._RELS[0], 'prerelease': True},  # 0.0.10 prerelease
+            {**self._RELS[1], 'draft': True},  # 0.0.9 draft
+            self._RELS[2],  # 0.0.8
+        ]
+        with self._patch_releases(rels):
+            notes = wu.fetch_release_notes('0.0.7')
+        assert [n['version'] for n in notes] == ['0.0.11', '0.0.8']
+
+    def test_caps_at_limit(self):
+        with self._patch_releases(self._RELS):
+            notes = wu.fetch_release_notes('0.0.0', limit=1)
+        assert [n['version'] for n in notes] == ['0.0.10']
+
+    def test_fetch_failure_returns_empty(self):
+        with patch.object(wu, '_open', side_effect=OSError('boom')):
+            assert wu.fetch_release_notes('0.0.8') == []
 
 
 class TestRunInstaller:


### PR DESCRIPTION
## The bug

Installing 0.0.8 then clicking **Check for updates → upgrade** failed with:

> Unable to execute file: `…\VibeSeller\.venv\Scripts\pythonw.exe`
> CreateProcess failed; code 2. The system cannot find the file specified.

That dialog is a **symptom**. After the upgrade `.venv\Scripts\` was **empty** and `pyvenv.cfg` **absent** — the post-install venv build had silently failed, yet Inno still ran the finish-page "Open now" action, hard-wired to the never-created `pythonw.exe`.

## Root cause

The in-app upgrade is launched from the tray's own `pythonw.exe`, which lives at `{app}\.venv\Scripts\pythonw.exe` — the very file the installer deletes and rebuilds. The tray stayed alive during the upgrade, keeping that file **locked** while Inno ran `[InstallDelete]` + `uv venv`. The half-removed dir then made `uv venv` **refuse** it (*"exists but is not a virtual environment"*), leaving an empty `.venv`. Inno **ignores a `[Run]` step's exit code**, so the install "succeeded" and launched the missing `pythonw.exe`. The field `tray.log` also showed `WinError 32` from a **concurrent** upgrade colliding on the fixed `%TEMP%\VibeSeller-Setup.exe` path.

The uninstall→reinstall variant was fixed in dba67d7, but the **in-place upgrade** path was never covered — and CI masked it by **stopping the server before upgrading** and never running a tray.

## Fix (design-level)

**1. Updater releases `{app}` before the installer touches it** (`app/windows_update.py`, `installer/windows/tray.py`)
- Launch the installer **detached** (`DETACHED_PROCESS` + new process group); the tray then **stops the server and quits itself** → nothing under `{app}` is locked during the rebuild.
- Download to a **unique `mkdtemp` dir** + **retry on `WinError 32`** → kills the concurrent-launch race.
- **Single-flight lock** so a double-click can't start two rival installers.

**2. Installer makes a failed venv fatal and self-healing** (`installer/windows/vibe-seller.iss`)
- `KillAppProcesses` now **kills AND waits** (polls up to 30s) so handles release before `.venv` is rebuilt.
- The venv build (`uv venv` + `uv pip` + `playwright`) moves from `[Run]` into `CurStepChanged(ssPostInstall)`, where it is **verified, retried once, and — if it still fails — aborts with a clear message** instead of launching a missing `pythonw.exe`.
- Finish action guarded by `Check: VenvIsReady` (checks **both** `pythonw.exe` **and** `pyvenv.cfg`).

**3. CI reproduces the real path** (`.github/workflows/windows-upgrade.yml`)
- New **hot in-place upgrade** scenario with the server AND a venv `pythonw.exe` still locking `.venv`, asserting a real venv (`pyvenv.cfg` + `pythonw`/`python`/`vibe-seller`/`playwright`) exists afterward and the server reports the new version.

## Follow-ups included (same PR)

**Tray "what's new"** — the tray upgrade showed only "Downloading vX". Added `windows_update.fetch_release_notes(current)` (best-effort); the "updating" dialog now lists **every release being applied** (0.0.8 → 0.0.10 shows v0.0.10 **and** v0.0.9) and links to the changelog.

**Update-check source reconciliation** — the web popup took `latest_version` from **PyPI** but notes from **GitHub Releases**. `_compute_update_check` now drops any GitHub note newer than the PyPI-installable latest, so it never advertises a version the user's upgrade path can't reach.

**Copilot review comments** — fixed all three: `upgrade()` docstring vs return shape; `VenvPythonwExists`→`VenvIsReady` also checks `pyvenv.cfg`; corrected the Playwright comment (a failed Chromium download is non-fatal to install but the chrome backend won't launch until the engine is present — it is *not* auto-fetched at runtime).

## Testing
- `pytest tests/unit/test_windows_update.py tests/unit/test_update_check.py tests/unit/test_system_router.py` → 45 passed (added: unique-temp-dir, single-flight, `WinError 32` retry/exhaustion, `fetch_release_notes` filtering/caps/failure, source-reconciliation drop).
- `.iss` Pascal reviewed by hand; `windows-upgrade.yml` compiles + exercises it on the Windows runner.

> Note: the failing `e2e-test` check is unrelated to this PR — it's the catalog-sync task running on Claude Code (no credentials provisioned in CI by design; e2e agents are meant to run on MiniMax/GLM via `E2E_PROVIDER_MAP`). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
