### PR TITLE
feat(release): gate mac/linux `vibe-seller upgrade` before PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,14 @@ name: Release
 #                         `vibe-seller --version` matches, /api/health is
 #                         200, and POST/GET round-trips on /api/stores +
 #                         /api/profiles. Gates the production publish.
+#   4b. verify-upgrade-testpypi  Fresh runner: install the PREV dev build,
+#                         verify it, then `vibe-seller upgrade --test-pypi
+#                         --version <new>` (the real CLI command, running on
+#                         the PREV install) and re-verify — proving the
+#                         in-place upgrade path works BEFORE we publish to
+#                         PyPI. Also gates the production publish. Both dev
+#                         builds come from THIS checkout (build stage) so
+#                         PREV already carries the `--test-pypi` flag.
 #   5. publish-pypi       Publish the canonical wheel.
 #   6. verify-pypi        Re-run the same smoke against PyPI (post-publish
 #                         audit; same script, different version + source).
@@ -56,6 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       dev_version: ${{ steps.build_testpypi.outputs.dev_version }}
+      dev_version_prev: ${{ steps.build_testpypi.outputs.dev_version_prev }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -100,18 +109,30 @@ jobs:
         # Tag-derived version, e.g. v0.0.1 → 0.0.1.
         run: python -m build --outdir dist-pypi
 
-      - name: Build dev-versioned wheel (for TestPyPI)
+      - name: Build dev-versioned wheels (for TestPyPI)
         id: build_testpypi
         # `SETUPTOOLS_SCM_PRETEND_VERSION` overrides the tag-derived
         # version. We stamp it with UTC seconds so every workflow run
         # gets a unique, immutable upload, e.g.
         # `0.0.1.dev20260514120555`.
+        #
+        # Build TWO dev wheels — PREV (older) and NEW — from THIS SAME
+        # checkout so the verify-upgrade job can exercise `vibe-seller
+        # upgrade --test-pypi` prev→new. Both must be same-code: the
+        # upgrade command runs on the PREV install, so PREV must already
+        # carry the `--test-pypi` flag (a previously-RELEASED version
+        # wouldn't). `dev$((TS-1))` < `dev$TS`, so NEW is a real upgrade.
         run: |
-          DEV_VERSION="${GITHUB_REF_NAME#v}.dev$(date -u +%Y%m%d%H%M%S)"
-          echo "==> dev version: $DEV_VERSION"
+          TS=$(date -u +%Y%m%d%H%M%S)
+          DEV_VERSION="${GITHUB_REF_NAME#v}.dev${TS}"
+          DEV_VERSION_PREV="${GITHUB_REF_NAME#v}.dev$((TS - 1))"
+          echo "==> prev dev: $DEV_VERSION_PREV ; new dev: $DEV_VERSION"
+          SETUPTOOLS_SCM_PRETEND_VERSION="$DEV_VERSION_PREV" \
+            python -m build --outdir dist-testpypi
           SETUPTOOLS_SCM_PRETEND_VERSION="$DEV_VERSION" \
             python -m build --outdir dist-testpypi
           echo "dev_version=$DEV_VERSION" >> "$GITHUB_OUTPUT"
+          echo "dev_version_prev=$DEV_VERSION_PREV" >> "$GITHUB_OUTPUT"
 
       - name: Verify both wheels bundle frontend assets
         run: |
@@ -249,9 +270,71 @@ jobs:
           echo "--- last 30 lines of server log ---"
           tail -30 ~/.vibe-seller/logs/backend_7777.log 2>/dev/null || true
 
+  verify-upgrade-testpypi:
+    name: Verify in-place upgrade (prev → new, gates release)
+    needs: [build, publish-testpypi]
+    runs-on: ubuntu-latest
+    env:
+      PREV: ${{ needs.build.outputs.dev_version_prev }}
+      NEW: ${{ needs.build.outputs.dev_version }}
+      SIMPLE_INDEX: https://test.pypi.org/simple/vibe-seller/
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait for both dev versions on the TestPyPI simple index
+        run: |
+          for want in "$PREV" "$NEW"; do
+            echo "waiting for vibe-seller==$want ..."
+            ok=0
+            for _ in $(seq 1 60); do
+              if curl -fsS "$SIMPLE_INDEX" 2>/dev/null | grep -qF "$want"; then
+                ok=1; break
+              fi
+              sleep 2
+            done
+            [ "$ok" = 1 ] || { echo "ERROR: $want not on simple index"; exit 1; }
+          done
+
+      - name: Install the PREVIOUS build from TestPyPI
+        run: ./install.sh --test-pypi --version "$PREV"
+
+      - name: Old version stands up (server + API round-trips)
+        run: |
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          vibe-seller start --port 7777
+          bash tests/releases/verify_install.sh "$PREV"
+          vibe-seller stop --port 7777
+
+      - name: In-place upgrade via the real CLI command
+        # The whole point: exercise `vibe-seller upgrade` itself (running
+        # on the PREV install, as a real user would) pointed at the new
+        # build. GATES the PyPI publish — a broken upgrade path never
+        # reaches real users. Both builds are same-code, so PREV already
+        # carries the `--test-pypi` flag this step relies on.
+        run: |
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          vibe-seller upgrade --test-pypi --version "$NEW"
+
+      - name: New version stands up + --version bumped
+        # verify_install.sh asserts `vibe-seller --version == NEW` plus
+        # /api/health + store/profile round-trips — the same smoke reused
+        # from the fresh-install verify stages.
+        run: |
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          vibe-seller start --port 7777
+          bash tests/releases/verify_install.sh "$NEW"
+          vibe-seller stop --port 7777
+
+      - name: Stop server + dump logs
+        if: always()
+        run: |
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          vibe-seller stop --port 7777 || true
+          tail -30 ~/.vibe-seller/logs/backend_7777.log 2>/dev/null || true
+
   publish-pypi:
     name: Publish to PyPI (canonical)
-    needs: verify-testpypi
+    needs: [verify-testpypi, verify-upgrade-testpypi]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/app/cli.py
+++ b/app/cli.py
@@ -17,12 +17,15 @@ import argparse
 import asyncio
 from contextlib import suppress
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
+import json
 import os
 from pathlib import Path
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
+import urllib.request
 
 from app.platform import (
     collect_agent_descendants,
@@ -164,13 +167,28 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     # upgrade --------------------------------------------------------
-    subs.add_parser(
+    up = subs.add_parser(
         'upgrade',
         help=(
             'Upgrade vibe-seller in place. Uses `uv tool upgrade` when '
             'uv is on PATH (the install.sh path), falls back to '
             '`pip install --upgrade` otherwise.'
         ),
+    )
+    up.add_argument(
+        '--test-pypi',
+        action='store_true',
+        help=(
+            'Upgrade to a release candidate on TestPyPI instead of the '
+            'latest PyPI release. Requires --version. Mirrors '
+            '`install.sh --test-pypi`.'
+        ),
+    )
+    up.add_argument(
+        '--version',
+        dest='target_version',
+        default=None,
+        help='Exact version to install (required with --test-pypi).',
     )
 
     return parser
@@ -333,7 +351,9 @@ def _cmd_stop(args: argparse.Namespace) -> int:
     return 0
 
 
-def _cmd_upgrade() -> int:
+def _cmd_upgrade(args: argparse.Namespace) -> int:
+    if getattr(args, 'test_pypi', False):
+        return _upgrade_from_test_pypi(args.target_version)
     # `uv tool upgrade vibe-seller` is the canonical path since
     # install.sh uses `uv tool install`. Falling back to pip keeps the
     # subcommand useful for the manual `pip install vibe-seller` user.
@@ -352,6 +372,58 @@ def _cmd_upgrade() -> int:
     return subprocess.run(cmd).returncode
 
 
+def _upgrade_from_test_pypi(version: str | None) -> int:
+    """Replace the current install with a specific TestPyPI wheel.
+
+    Release-candidate testing path — mirrors ``install.sh --test-pypi
+    --version``. TestPyPI hosts only this project and its wheels are
+    dev-versioned, so (like install.sh) we download the wheel by exact
+    version and ``uv tool install --force`` it, letting dependencies
+    resolve from real PyPI. Requires ``uv`` and an explicit version.
+    """
+    if not version:
+        print(
+            'vibe-seller upgrade --test-pypi requires --version <ver>',
+            file=sys.stderr,
+        )
+        return 2
+    if not shutil.which('uv'):
+        print(
+            'vibe-seller upgrade --test-pypi requires uv on PATH',
+            file=sys.stderr,
+        )
+        return 2
+    meta_url = f'https://test.pypi.org/pypi/vibe-seller/{version}/json'
+    try:
+        with urllib.request.urlopen(meta_url, timeout=30) as resp:  # noqa: S310
+            meta = json.loads(resp.read().decode())
+        wheel_url = next(
+            u['url'] for u in meta['urls'] if u['packagetype'] == 'bdist_wheel'
+        )
+    except (OSError, ValueError, KeyError, StopIteration) as exc:
+        print(
+            f'no TestPyPI wheel for vibe-seller=={version}: {exc}',
+            file=sys.stderr,
+        )
+        return 1
+    # Keep the wheel's real filename — uv reads name/version/tags from it.
+    tmp_dir = tempfile.mkdtemp(prefix='vibe-seller-wheel-')
+    wheel_path = os.path.join(tmp_dir, os.path.basename(wheel_url))
+    try:
+        with (
+            urllib.request.urlopen(  # noqa: S310
+                wheel_url, timeout=300
+            ) as resp,
+            open(wheel_path, 'wb') as f,
+        ):
+            shutil.copyfileobj(resp, f)
+        cmd = ['uv', 'tool', 'install', '--force', wheel_path]
+        print(f'==> {" ".join(cmd)}')
+        return subprocess.run(cmd).returncode
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     if args.command == 'start':
@@ -359,7 +431,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == 'stop':
         return _cmd_stop(args)
     if args.command == 'upgrade':
-        return _cmd_upgrade()
+        return _cmd_upgrade(args)
     return 1  # unreachable: subparsers.required = True
 
 

--- a/tests/unit/test_cli_upgrade.py
+++ b/tests/unit/test_cli_upgrade.py
@@ -1,0 +1,109 @@
+"""Tests for `vibe-seller upgrade` — the in-place CLI updater.
+
+Covers the default (PyPI) path and the `--test-pypi --version` release-
+candidate path. Network + subprocess are mocked, so these run offline.
+"""
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app.cli as cli
+
+pytestmark = pytest.mark.unit
+
+
+def _args(argv):
+    return cli._build_parser().parse_args(argv)
+
+
+class TestUpgradeArgParsing:
+    def test_plain_upgrade_has_no_test_pypi(self):
+        args = _args(['upgrade'])
+        assert args.command == 'upgrade'
+        assert args.test_pypi is False
+        assert args.target_version is None
+
+    def test_test_pypi_with_version(self):
+        args = _args(['upgrade', '--test-pypi', '--version', '0.0.1.dev1'])
+        assert args.test_pypi is True
+        assert args.target_version == '0.0.1.dev1'
+
+
+class TestCmdUpgradeDefault:
+    def test_uses_uv_tool_upgrade_when_uv_present(self):
+        with (
+            patch.object(cli.shutil, 'which', return_value='/usr/bin/uv'),
+            patch.object(cli.subprocess, 'run') as run,
+        ):
+            run.return_value = MagicMock(returncode=0)
+            rc = cli._cmd_upgrade(_args(['upgrade']))
+        assert rc == 0
+        assert run.call_args[0][0] == ['uv', 'tool', 'upgrade', 'vibe-seller']
+
+    def test_falls_back_to_pip_without_uv(self):
+        with (
+            patch.object(cli.shutil, 'which', return_value=None),
+            patch.object(cli.subprocess, 'run') as run,
+        ):
+            run.return_value = MagicMock(returncode=0)
+            cli._cmd_upgrade(_args(['upgrade']))
+        cmd = run.call_args[0][0]
+        assert cmd[1:] == ['-m', 'pip', 'install', '--upgrade', 'vibe-seller']
+
+
+class TestCmdUpgradeTestPypi:
+    def test_requires_version(self):
+        with patch.object(cli.subprocess, 'run') as run:
+            rc = cli._cmd_upgrade(_args(['upgrade', '--test-pypi']))
+        assert rc == 2
+        run.assert_not_called()
+
+    def test_requires_uv(self):
+        args = _args(['upgrade', '--test-pypi', '--version', '0.0.1.dev1'])
+        with patch.object(cli.shutil, 'which', return_value=None):
+            rc = cli._cmd_upgrade(args)
+        assert rc == 2
+
+    def test_downloads_wheel_and_force_installs(self):
+        wheel = 'vibe_seller-0.0.1.dev2-py3-none-any.whl'
+        meta = {
+            'urls': [
+                {'packagetype': 'sdist', 'url': 'https://x/pkg.tar.gz'},
+                {'packagetype': 'bdist_wheel', 'url': f'https://x/{wheel}'},
+            ]
+        }
+        responses = [
+            io.BytesIO(json.dumps(meta).encode()),  # metadata fetch
+            io.BytesIO(b'PK-fake-wheel-bytes'),  # wheel download
+        ]
+        with (
+            patch.object(cli.shutil, 'which', return_value='/usr/bin/uv'),
+            patch.object(cli.urllib.request, 'urlopen', side_effect=responses),
+            patch.object(cli.subprocess, 'run') as run,
+        ):
+            run.return_value = MagicMock(returncode=0)
+            args = _args(['upgrade', '--test-pypi', '--version', '0.0.1.dev2'])
+            rc = cli._cmd_upgrade(args)
+        assert rc == 0
+        cmd = run.call_args[0][0]
+        assert cmd[:4] == ['uv', 'tool', 'install', '--force']
+        assert cmd[4].endswith(wheel)  # real wheel filename preserved
+
+    def test_missing_wheel_returns_error(self):
+        meta = {'urls': [{'packagetype': 'sdist', 'url': 'https://x/s.tgz'}]}
+        with (
+            patch.object(cli.shutil, 'which', return_value='/usr/bin/uv'),
+            patch.object(
+                cli.urllib.request,
+                'urlopen',
+                return_value=io.BytesIO(json.dumps(meta).encode()),
+            ),
+            patch.object(cli.subprocess, 'run') as run,
+        ):
+            args = _args(['upgrade', '--test-pypi', '--version', '0.0.1.dev9'])
+            rc = cli._cmd_upgrade(args)
+        assert rc == 1  # no bdist_wheel in urls
+        run.assert_not_called()


### PR DESCRIPTION
## What & why

The release pipeline verified a **fresh install** of each new version end-to-end (`verify-testpypi` → `verify-pypi`), but never exercised the in-place **`vibe-seller upgrade`** path (old → new) — the mac/linux analogue of what `windows-upgrade.yml` already gates for Windows. A broken upgrade could ship to PyPI (immutable) unnoticed.

This adds a **gated** upgrade test that runs **before** the real PyPI publish, and reuses the existing `tests/releases/verify_install.sh` smoke verbatim.

## Changes

**`app/cli.py` — `vibe-seller upgrade --test-pypi --version <X>`**
Mirrors `install.sh --test-pypi`: downloads the exact TestPyPI wheel and `uv tool install --force`s it (TestPyPI hosts only this project; deps resolve from real PyPI). The default `vibe-seller upgrade` (`uv tool upgrade` / `pip install --upgrade`) is unchanged.

**`.github/workflows/release.yml` — new `verify-upgrade-testpypi` job (gates `publish-pypi`)**
```
install.sh --test-pypi --version <PREV>   →  verify_install.sh <PREV>
vibe-seller upgrade --test-pypi --version <NEW>   ← the real CLI command
                                          →  verify_install.sh <NEW>   (--version == NEW + endpoints)
```

## The design catch (why two dev builds)

The upgrade command runs on the **PREV** install, so PREV must already carry the `--test-pypi` flag — a *previously-released* version wouldn't (chicken-and-egg). So, exactly like `windows-upgrade.yml`, the `build` stage now produces **two same-code dev wheels** from this checkout — `…dev$((TS-1))` and `…dev$TS` — both have the flag, and `dev$TS` is a genuine upgrade over `dev$((TS-1))`. Both publish to TestPyPI; nothing extra reaches real PyPI.

This is also why Option A (test `vibe-seller upgrade` in `verify-pypi`, post-publish) was rejected — it can't gate: the bad version would already be immutable on PyPI.

## Testing
- `pytest tests/unit/test_cli_upgrade.py` → 8 passed (arg parsing; default uv/pip paths; `--test-pypi` wheel-download + `--force` install; missing-wheel + missing-version/uv error paths; network + subprocess mocked).
- `release.yml` is tag-triggered, so it can't run on this PR; authored to mirror the existing verify stages. YAML validated.

> Separate from the Windows in-place-upgrade fix in #50 — this is the mac/linux `vibe-seller upgrade` release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
