### PR TITLE
docs(amazon-shared): New Seller Central navigation + Ziniao passkey login (old + new)

### DIFF
--- a/app/skills_v2/amazon-ads/SKILL.md
+++ b/app/skills_v2/amazon-ads/SKILL.md
@@ -9,7 +9,9 @@ gates: [ad_completeness_review, ad_negation_allowlist, ad_execution_fidelity]
 # Amazon Ads — Catalog
 
 > **PREREQUISITE:** Read `../amazon-shared/SKILL.md` for marketplace
-> TLD map, hamburger-menu navigation, sign-in / Ziniao / OTP handling,
+> TLD map, version-aware navigation (New Seller Central vs classic;
+> navigate by direct URL), the Ziniao login challenge-loop (password /
+> OTP / hosted-passkey),
 > and the ad-console vs seller-central account caveat.
 
 This skill is a **catalog**. The actual content lives in topical

--- a/app/skills_v2/amazon-ads/references/mechanics.md
+++ b/app/skills_v2/amazon-ads/references/mechanics.md
@@ -42,10 +42,13 @@ guess seller-central paths.
 | Coupon create | `https://sellercentral.amazon.<tld>/coupons/create-coupon` | |
 
 The ad console **redirects through Amazon sign-in on first hit per
-session** even though the seller-central session is good. Ziniao
-auto-fills the password (and OTP/2FA via 紫鸟验证码服务). Click
-`signInSubmit` (or the `mfaSubmit` after OTP) and wait ~5s for the
-redirect to settle.
+session** even though the seller-central session is good. Follow the
+full login flow in **`amazon-shared` §2** — it's a challenge LOOP
+(password / OTP / hosted-passkey, in whatever combination Amazon's risk
+control picks), with Ziniao auto-filling each step it has stored (its
+`紫鸟验证码服务` OTP panel and `已托管账号Passkey` overlay are **native,
+not page DOM** — coordinate-click, don't querySelector). Rule:
+Ziniao-stored → use Ziniao; else ask a human.
 
 Each store's ad console may be on a *different* underlying Amazon
 account from its seller-central account (different email and entity
@@ -2152,15 +2155,15 @@ under `advertising.amazon.<tld>`. The ads-tuning audit primarily
 drives `advertising.amazon.<tld>`; switching to seller-central
 may require a session change. **Cookies for the two subdomains
 share the same Amazon account credential**, so once
-`amazon-shared § 1` login has happened in this Chromium profile,
+`amazon-shared § 2` login has happened in this Chromium profile,
 both subdomains see the same logged-in user.
 
 If the first navigation to `sellercentral.amazon.<tld>` after a
 fresh start lands on `/ap/signin`, run the standard login flow
-from `amazon-shared § 1` (Ziniao auto-fills password on
-`Sign in` click; OTP comes from the store's bound email account
-— the workspace handles OTP retrieval). The flow is verified to
-take ~10-20 s end-to-end.
+from **`amazon-shared § 2`** — the challenge LOOP (password / OTP /
+hosted-passkey, whatever Amazon's risk control presents), with Ziniao
+auto-filling each step it has stored. The flow is verified to take
+~10-20 s end-to-end.
 
 ### URL & navigation path
 

--- a/app/skills_v2/amazon-invoice/SKILL.md
+++ b/app/skills_v2/amazon-invoice/SKILL.md
@@ -7,9 +7,10 @@ requires: [amazon-shared]
 # Amazon Invoice Generator
 
 > **PREREQUISITE:** Read `../amazon-shared/SKILL.md` for marketplace
-> TLD map, sign-in / Ziniao / OTP handling, and the hamburger-menu
-> navigation pattern (used to reach Tax Document Library before
-> running this generator).
+> TLD map, the Ziniao login challenge-loop (password / OTP /
+> hosted-passkey), and version-aware navigation (New Seller Central vs
+> classic; prefer the direct Tax Document Library URL over the menu)
+> before running this generator.
 
 Generate professional tax invoices for Amazon orders by extracting data from Seller Central and producing PDF invoices via ReportLab.
 

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -7,9 +7,11 @@ requires: [amazon-shared]
 
 # Amazon — Listing CRUD (flat-file upload)
 
-> **PREREQUISITE:** read `../amazon-shared/SKILL.md` for login, Ziniao
-> auto-fill / OTP, marketplace TLDs, hamburger navigation, and the
-> capture rule (live data → `/tmp/<task>/`, never `knowledge/`).
+> **PREREQUISITE:** read `../amazon-shared/SKILL.md` for the Ziniao
+> login challenge-loop (password / OTP / hosted-passkey), marketplace
+> TLDs, version-aware navigation (New Seller Central vs classic;
+> navigate by direct URL), and the capture rule (live data →
+> `/tmp/<task>/`, never `knowledge/`).
 
 Amazon's **Add Products via Upload** takes a category **flat-file
 template** — a macro-enabled `.xlsm` whose `Template` sheet is a wide

--- a/app/skills_v2/amazon-shared/SKILL.md
+++ b/app/skills_v2/amazon-shared/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amazon-shared
-description: "Common Amazon Seller Central / advertising-console mechanics — marketplace TLD map, hamburger-menu hover navigation, sign-in / Ziniao auto-fill / OTP redirect handling, ad-console vs seller-central account caveat, capture rule. Prerequisite: every other amazon-* skill (amazon-ads, amazon-reports, amazon-invoice, future amazon-listing / amazon-fbn / etc.) expects this loaded for cross-cutting auth and navigation patterns."
+description: "Common Amazon Seller Central / advertising-console mechanics — marketplace TLD map; version-aware navigation (New Seller Central 'NGS' vs classic, navigate by direct URL); sign-in as a challenge LOOP with Ziniao auto-fill of password / OTP (紫鸟验证码服务) / hosted passkey (已托管账号Passkey, native overlay → coordinate-click), Ziniao-stored-else-human rule; ad-console vs seller-central account caveat; capture rule. Prerequisite: every other amazon-* skill (amazon-ads, amazon-reports, amazon-invoice, amazon-listing / amazon-fbn / etc.) expects this loaded for cross-cutting auth and navigation patterns."
 ---
 
 # Amazon — Shared (auth, navigation, common patterns)
@@ -40,29 +40,100 @@ for store X" is ambiguous.
 ## 2. Sign-in flow (browser-side)
 
 The first hit per session typically redirects through Amazon sign-in
-even if a previous Seller Central session is still good. Ziniao
-auto-fills the password and the OTP / 2FA code (via the 紫鸟验证码
-service when configured for the store). The agent's job is to wait
-for the auto-fill to land, click the submit button, and let the
-redirect settle.
+(`/ap/signin`) even if a previous session is still good. The modern
+flow is multi-step: **email → Continue → password → (optional 2FA)**.
+Ziniao pre-fills the email and password; the agent advances each step
+and lets the redirect settle.
 
 ```bash
 browser-use <<'PY'
-new_tab("https://advertising.amazon.<tld>/campaign-manager")
-wait_for_load()                                # password + OTP usually pre-filled
-print(page_info())
-# click the sign-in submit (or the MFA submit after OTP)
-js("document.querySelector('#signInSubmit').click()")
-wait_for_load()                                # redirect settles
+new_tab("https://sellercentral.amazon.<tld>/home")
+wait_for_load()
+# Email step: field pre-filled by Ziniao. The Continue button is not
+# always #continue — if a JS click no-ops, coordinate-click it.
+js("var c=document.querySelector('#continue,input#continue'); if(c) c.click();")
+wait_for_load()
+# Password step: Ziniao pre-fills #ap_password. Submit.
+js("var b=document.querySelector('#signInSubmit'); if(b) b.click();")
+wait_for_load()
 print(page_info())
 PY
 ```
 
-`page_info()` does NOT show auto-filled input values — fields
-appear empty even when filled. Read the value directly with
-`js("return document.querySelector('#ap_password').value")`
-to confirm a password / OTP field was auto-filled before deciding
-whether to ask the user.
+`page_info()` does NOT show auto-filled input values — fields appear
+empty even when filled. Confirm with
+`js("return document.querySelector('#ap_password').value ? 'filled':'empty'")`
+before deciding whether to ask the user.
+
+### Login is a challenge LOOP, not a fixed sequence
+
+Which challenges Amazon presents — password, OTP, passkey, or a
+combination — is decided by **Amazon's risk control and varies run to
+run** (a passkey can still be followed by OTP; a trusted session skips
+both). So do **not** hard-code an order. After each submit, re-read the
+page and resolve whatever challenge is shown, repeating until the URL
+reaches `/home` or `/amazonsell/business`.
+
+**Decision rule at every challenge — Ziniao-stored → use Ziniao;
+otherwise → ask a human.** Ziniao "has it" when the field is pre-filled
+(password) or a Ziniao panel appears (`紫鸟验证码服务` for OTP,
+`已托管账号Passkey` for passkey). If the expected Ziniao affordance never
+appears for a required step, stop and ask the user — never loop forever
+on a challenge Ziniao can't satisfy.
+
+### 2a. Ziniao helper panels are NATIVE overlays — screenshot, don't querySelector
+
+When a step needs a code or a passkey, Ziniao renders its own panel:
+the OTP service (**`紫鸟验证码服务`**) and the hosted-passkey picker
+(**`已托管账号Passkey`**). **These are Ziniao-native overlays, NOT part
+of the page DOM** — `document.querySelector` can't find them and a JS
+`.click()` silently no-ops (verified: `navigator.credentials.get` hooks
+never fire). Drive them by sight: `capture_screenshot(path)` → read the
+button's pixel position → `click_at_xy(x, y)`. A human clicks these the
+same way, so the agent can too — coordinate-click reaches them because
+they render inside the browser viewport.
+
+### 2b. OTP / 2FA
+
+If the flow lands on `/ap/mfa` (Two-Step Verification), Ziniao fetches
+the code and fills the OTP field (its `紫鸟验证码服务` panel shows
+`验证码获取成功`). Submit (`#signInSubmit` is usually in the page DOM
+here; coordinate-click the "Sign in" button if not). This path is the
+long-standing default and needs no special handling beyond the submit.
+
+### 2c. Passkey (accounts Amazon has moved to passkey login)
+
+Some accounts no longer offer a usable password/OTP login and are
+**forced onto passkeys**. The store's passkey is **hosted by Ziniao**
+(not an OS/biometric credential), so login stays fully automatable —
+there is no Touch ID / Windows Hello dialog:
+
+1. At the password step, take the passkey branch: click **"Sign in with
+   a passkey"** (a real page-DOM link — JS or coordinate click both work).
+2. Ziniao pops its **`已托管账号Passkey`** overlay listing the hosted
+   Amazon credential for the account, with a blue **`使用该Passkey登录`**
+   ("sign in with this passkey") button. This overlay is native (§2a) —
+   `capture_screenshot()` then `click_at_xy()` on that blue button. Do
+   **not** try to querySelector it. **The overlay floats to a different
+   position each time** (its Y shifts run to run), so re-screenshot and
+   read the button's coordinates every attempt — never reuse hardcoded
+   x/y.
+3. The flow then continues the challenge LOOP above — for this account it
+   routes on to OTP (§2b), which Ziniao autofills; a lower-risk session
+   may go straight to `/home`. Resolve each step until you land on the
+   dashboard.
+
+> **Daemon-drop gotcha:** a successful passkey navigation sometimes tears
+> down the browser-use session (next call fails with a socket
+> `FileNotFoundError`). That's not a login failure — rotate `VIBE_TASK_ID`
+> and re-open the home URL to confirm the logged-in state.
+
+**Robustness / when to ask a human:** the only genuine blocker is the
+hosted-passkey overlay never appearing after "Sign in with a passkey"
+(passkey not provisioned in Ziniao for this store). If it *does* appear,
+coordinate-click it — do not escalate. If the URL is still on
+`/ap/signin` ~8s after the coordinate-click, re-screenshot (the button
+may have shifted) and click again before giving up.
 
 ## 3. Ad-console vs Seller-Central — different accounts
 
@@ -79,42 +150,73 @@ issue:
 
 Both indicate which account is currently signed in.
 
-## 4. Hamburger-menu hover navigation
+## 4. Navigation — two UI generations (New Seller Central vs classic)
 
-Many seller-central pages (Reports, Performance, Inventory submenus)
-are reachable only via the **hamburger menu** at top-left. The menu
-uses a **hover-to-reveal** pattern — you must dispatch a `mouseover`,
-not a `click`, on a parent category to reveal its submenu items.
+Amazon is rolling out **New Seller Central** ("NGS"). A migrated account
+looks and navigates differently from a classic one, so first know which
+you're on — then use the one navigation method that works on **both**.
+
+### 4a. Navigate by DIRECT URL — the version-agnostic path (do this first)
+
+The redesign changed the *chrome* (menus, tabs, dashboard), but the
+underlying **page paths are unchanged** — `/reportcentral/...`,
+`/payments/reports-repository`, `/orders-v3`, `/business-reports`,
+`/myinventory/inventory`, etc. all load directly on both UIs (verified).
+So for a known destination, **just `new_tab(<url>)`** — do not open the
+menu at all. Canonical per-country paths live in
+`knowledge/project/common/amazon-sites.md`; that is the source of truth.
+Only fall back to the menu (§4c/§4d) when you need to *discover* a page
+whose URL you don't have.
+
+### 4b. Detecting the version
+
+Load `/home` and check where you land / what renders:
+
+- **New Seller Central (NGS)** — `/home` redirects to
+  **`/amazonsell/business`** (`?ref=homepage_redirect_ngs`); the page has
+  a **"New Seller Central" toggle** in the top bar, a dashboard
+  **channel-tab row** (My business / Products / Supply chain / Orders /
+  Finance / Customers / Marketing) and `casino-*` web components
+  (`document.querySelector('casino-greeting-header, navigation-favorites-bar')`).
+- **Classic** — plain `/home` dashboard, no `casino-*` elements; the old
+  hamburger hover-menu (§4d).
+- **Force classic** when a page misbehaves under NGS: append
+  **`?ngs_do_not_redirect_flag=1`** to `/home` to stay on the classic home.
+
+### 4c. NGS chrome (for discovery only)
+
+- **Favorites / quick-nav bar** (`navigation-favorites-bar`, top,
+  horizontal): direct links (Manage All Inventory, Payments, Business
+  Reports, …). Read their real hrefs from the bar's (shadow) DOM and open
+  them.
+- **Hamburger** (`navigation-hamburger-menu`, top-left) opens a
+  full-height **left drawer** with categories (Catalog, Inventory,
+  Pricing, Orders, Advertising, Stores, Growth, Reports, Payments,
+  Performance, Apps and Services, Brands, Learn). Categories expand to a
+  flyout; if a stable selector isn't obvious, `capture_screenshot()` then
+  `click_at_xy(x, y)`.
+
+### 4d. Classic chrome — hamburger hover-to-reveal
+
+On a classic account the hamburger menu uses a **hover-to-reveal**
+pattern — dispatch `mouseover` (not click) on a parent category:
 
 ```bash
 browser-use <<'PY'
-# 1. Open the hamburger menu (opens the full sidebar overlay).
-#    The menu button is a role=button inside the
-#    navigation-hamburger-menu shadow DOM — reach it via its shadow host.
 js("document.querySelector('navigation-hamburger-menu').shadowRoot.querySelector('[role=button]').click()")
 wait_for_load()
-
-# 2. Reveal the submenu by dispatching mouseover on the parent
-#    category (aria-expanded flips false -> true; submenu appears).
 js("""
 var cat = [...document.querySelectorAll('[aria-expanded=false]')]
   .find(e => e.textContent.trim() === 'Reports');
-cat.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+cat.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));   # NOT click — click navigates away
 """)
-
-# 3. Click the submenu item once it renders.
-print(page_info())
-js("""
-[...document.querySelectorAll('a, [role=button]')]
-  .find(e => e.textContent.trim() === 'Business Reports').click();
-""")
+js("""[...document.querySelectorAll('a, [role=button]')]
+  .find(e => e.textContent.trim() === 'Business Reports').click();""")
 PY
 ```
 
-**Do NOT click the category name directly** — clicking navigates
-away instead of revealing the submenu. Always dispatch `mouseover`
-first. If a stable selector for the category/item isn't obvious,
-fall back to `capture_screenshot()` then `click_at_xy(x, y)`.
+If a stable selector isn't obvious, `capture_screenshot()` + `click_at_xy(x, y)`.
+But prefer §4a (direct URL) over any of this whenever you know the path.
 
 ## 5. Capture rule
 

--- a/app/skills_v2/amazon-shared/SKILL.md
+++ b/app/skills_v2/amazon-shared/SKILL.md
@@ -62,8 +62,9 @@ PY
 
 `page_info()` does NOT show auto-filled input values — fields appear
 empty even when filled. Confirm with
-`js("return document.querySelector('#ap_password').value ? 'filled':'empty'")`
-before deciding whether to ask the user.
+`js("return document.querySelector('#ap_password')?.value ? 'filled':'empty'")`
+(null-safe `?.` — the same snippet runs on steps where the field is
+absent) before deciding whether to ask the user.
 
 ### Login is a challenge LOOP, not a fixed sequence
 


### PR DESCRIPTION
## Why

Amazon is rolling out **New Seller Central** ("NGS"), and is **forcing passkey login** on some accounts. Both change how an agent navigates and signs in. I explored both live (drove two SA stores' Ziniao browsers) and made `amazon-shared` — the auth/nav hub every `amazon-*` skill loads — robust for **old and new**, so the agent detects its version and navigates without wasting turns on version-specific dead-ends.

## Navigation — `amazon-shared` §4 (rewritten, version-aware)

- **Detect the version:** NGS if `/home` redirects to `/amazonsell/business` (`ref=homepage_redirect_ngs`), or the page has the "New Seller Central" toggle / the channel-tab row (My business / Products / Supply chain / …) / `casino-*` web components. Otherwise classic.
- **Primary rule — navigate by DIRECT deep-link URL.** The redesign changed the chrome, not the paths: `/reportcentral/…`, `/payments/reports-repository`, `/orders-v3`, `/business-reports`, `/myinventory` all load on **both** UIs (verified). So for a known destination, just open the URL — no menu. Canonical paths stay in `knowledge/project/common/amazon-sites.md`.
- **NGS chrome documented for *discovery only*:** favorites/quick-nav bar (`navigation-favorites-bar`) + hamburger left-drawer (Catalog/Inventory/…/Reports). Classic hamburger **hover-to-reveal** kept as the classic path.
- **Escape hatch:** `?ngs_do_not_redirect_flag=1` forces the classic `/home`.

## Sign-in — `amazon-shared` §2 (rewritten as a challenge LOOP)

- Amazon's **risk control varies the combination** (password / OTP / passkey), so the skill **resolves whatever challenge appears, in a loop, until `/home`** — no hard-coded order. (Observed: one clean pass with no OTP; another run went passkey → OTP.)
- **Decision rule at every challenge: Ziniao-stored → use Ziniao; else → ask a human.**
- 🔑 Ziniao's **OTP panel (`紫鸟验证码服务`)** and **hosted-passkey panel (`已托管账号Passkey` → `使用该Passkey登录`)** are **native overlays, NOT page DOM** — `querySelector`/JS `.click()` silently no-op (a `navigator.credentials.get` hook never fired). Must **`capture_screenshot()` + `click_at_xy()`** — a human clicks them the same way, so the agent can too (verified the coordinate-click advances login). The passkey overlay **floats to a different Y each run** → re-screenshot, never reuse coords.
- The hosted passkey means **no OS/biometric dialog** — login stays fully automatable. Note the post-passkey **daemon-socket drop** → rotate `VIBE_TASK_ID` and re-check the logged-in state.

## Verified live

- **NGS navigation** on one SA store (confirmed the two home dashboards, favorites bar, drawer, direct-URL loads).
- **Full logout → passkey → OTP re-login** on another SA store, entirely Ziniao-assisted, landing back on the dashboard.

Cross-refs in `amazon-ads` (SKILL + `references/mechanics.md`), `amazon-listing`, `amazon-invoice` updated to point at the new shared §2/§4. **Placeholders only — no account/store/ASIN data.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Xthn4cVTJmpHGWSvWptTa