### PR TITLE
fix(win-installer): robust .venv removal before rebuild (retry past handle-release race)

### DIFF
--- a/installer/windows/vibe-seller.iss
+++ b/installer/windows/vibe-seller.iss
@@ -202,6 +202,7 @@ end;
 procedure RemoveVenvRobust(const VenvDir: String);
 var
   Rc, Attempt: Integer;
+  PsPath: String;
 begin
   // Inno's DelTree (and a single delete) can fail to remove .venv right
   // after the tray/server is killed: the OS releases the terminated
@@ -210,9 +211,14 @@ begin
   // then `uv venv` refuses ("exists but is not a virtual environment"),
   // leaving an empty .venv. This bites in-place upgrades launched from a
   // PRE-FIX tray (0.0.8/0.0.9) that doesn't quit itself. Retry — DelTree,
-  // then the more forgiving PowerShell Remove-Item -Force — with backoff
-  // until the directory is actually gone (bounded; the caller aborts with
-  // a clear message if it never clears).
+  // then the more forgiving PowerShell Remove-Item -Force — until the
+  // directory is actually gone (bounded; the caller aborts with a clear
+  // message if it never clears).
+  //
+  // Double any apostrophe so a path like C:\Users\O'Brien\... stays a
+  // valid PowerShell single-quoted literal instead of a silent no-op.
+  PsPath := VenvDir;
+  StringChangeEx(PsPath, '''', '''''', True);
   Attempt := 0;
   while DirExists(VenvDir) and (Attempt < 10) do begin
     DelTree(VenvDir, True, True, True);
@@ -220,9 +226,15 @@ begin
       Break;
     Exec('powershell.exe',
       '-NoProfile -ExecutionPolicy Bypass -Command "Remove-Item ' +
-      '-LiteralPath ''' + VenvDir + ''' -Recurse -Force ' +
-      '-ErrorAction SilentlyContinue; Start-Sleep -Milliseconds 800"',
+      '-LiteralPath ''' + PsPath + ''' -Recurse -Force ' +
+      '-ErrorAction SilentlyContinue"',
       '', SW_HIDE, ewWaitUntilTerminated, Rc);
+    if not DirExists(VenvDir) then
+      Break;
+    // Back off in Inno (NOT inside PowerShell) so the handle-release wait
+    // still happens even if powershell.exe fails to launch — that wait is
+    // the whole point of the retry.
+    Sleep(800);
     Attempt := Attempt + 1;
   end;
 end;

--- a/installer/windows/vibe-seller.iss
+++ b/installer/windows/vibe-seller.iss
@@ -199,6 +199,34 @@ begin
   end;
 end;
 
+procedure RemoveVenvRobust(const VenvDir: String);
+var
+  Rc, Attempt: Integer;
+begin
+  // Inno's DelTree (and a single delete) can fail to remove .venv right
+  // after the tray/server is killed: the OS releases the terminated
+  // process's file handles slightly AFTER it leaves the process list, so
+  // a lingering handle on .venv\Scripts\*.exe blocks the delete — and
+  // then `uv venv` refuses ("exists but is not a virtual environment"),
+  // leaving an empty .venv. This bites in-place upgrades launched from a
+  // PRE-FIX tray (0.0.8/0.0.9) that doesn't quit itself. Retry — DelTree,
+  // then the more forgiving PowerShell Remove-Item -Force — with backoff
+  // until the directory is actually gone (bounded; the caller aborts with
+  // a clear message if it never clears).
+  Attempt := 0;
+  while DirExists(VenvDir) and (Attempt < 10) do begin
+    DelTree(VenvDir, True, True, True);
+    if not DirExists(VenvDir) then
+      Break;
+    Exec('powershell.exe',
+      '-NoProfile -ExecutionPolicy Bypass -Command "Remove-Item ' +
+      '-LiteralPath ''' + VenvDir + ''' -Recurse -Force ' +
+      '-ErrorAction SilentlyContinue; Start-Sleep -Milliseconds 800"',
+      '', SW_HIDE, ewWaitUntilTerminated, Rc);
+    Attempt := Attempt + 1;
+  end;
+end;
+
 function BuildRuntimeEnv: Boolean;
 var
   Rc: Integer;
@@ -209,13 +237,15 @@ begin
   PyExe := ExpandConstant('{app}\python\python.exe');
   VenvPy := ExpandConstant('{app}\.venv\Scripts\python.exe');
 
-  // Ensure nothing holds the venv, then delete any partial dir before
-  // rebuilding: `uv venv` REFUSES a dir that "exists but is not a virtual
-  // environment", so a stale/locked half-built .venv (Scripts\ with no
-  // pyvenv.cfg) would otherwise wedge every retry.
+  // Ensure nothing holds the venv, then robustly remove any partial dir
+  // before rebuilding: `uv venv` REFUSES a dir that "exists but is not a
+  // virtual environment", so a stale/locked half-built .venv (Scripts\
+  // with no pyvenv.cfg) would otherwise wedge every retry. RemoveVenvRobust
+  // retries past the post-kill file-handle-release race that a plain
+  // DelTree loses on pre-fix in-place upgrades.
   KillAppProcesses('($_.Name -eq ''pythonw.exe'' -or ' +
     '$_.Name -eq ''python.exe'') -and ');
-  DelTree(VenvDir, True, True, True);
+  RemoveVenvRobust(VenvDir);
 
   SetStatus('Creating Python environment...');
   Exec(Uv, 'venv "' + VenvDir + '" --python "' + PyExe + '"',


### PR DESCRIPTION
## The bug (found in the field)

Upgrading **0.0.8 → 0.0.10** on Windows still failed — but with the *clear* message #50 added:

> Runtime error (at 11:412): Vibe Seller could not create its Python environment. Please fully quit Vibe Seller from the system tray, then run the installer again.

So #50's verify-and-abort worked (no more cryptic "pythonw.exe not found"), **but the venv build didn't self-heal** — `.venv\Scripts` was left empty (no `pyvenv.cfg`).

## Root cause

The **pre-fix tray (0.0.8/0.0.9) does not quit itself** during a tray-launched upgrade (that self-quit is only in 0.0.10+). `PrepareToInstall` kills it, but **the OS releases a terminated process's file handles slightly *after* it leaves the process list**. Inno's `DelTree` loses that race, fails to remove `.venv\Scripts`, and `uv venv` then **refuses** the leftover dir — *"exists, but it's not a virtual environment"* — on both `BuildRuntimeEnv` attempts → abort.

Reproduced live on the affected machine:
```
$ uv venv ...\.venv --python ...\python\python.exe
  × Failed to create virtualenv
  ╰─▶ The directory `...\.venv` exists, but it's not a virtual environment
```
(#50's CI "hot upgrade" test passed because its timing happened to win the race; the real machine lost it.)

## Fix

Replace the single `DelTree` in `BuildRuntimeEnv` with **`RemoveVenvRobust`**, which retries `DelTree` + PowerShell `Remove-Item -Recurse -Force` with 800 ms backoff (up to ~8 s) until `.venv` is *actually gone*. That outlasts the handle-release window, so `uv venv` builds fresh instead of refusing a stale dir. PowerShell `Remove-Item` is the same call that reliably cleared the dir during manual recovery when a plain delete failed. The verify/abort stays as the final safety net.

## Scope / propagation
- Installer-side → lands in the **next release**. Once the fixed build is "latest," a pre-fix user who clicks "Check for updates" downloads **this** installer and self-heals.
- On the *current* 0.0.10, the manual workaround already works: **fully quit Vibe Seller from the tray, then re-run the installer** (nothing holds `.venv`, so the rebuild succeeds).

## Testing
- Reproduced the exact `uv venv` refusal against the leftover `.venv`, and confirmed the robust removal (`Remove-Item -Recurse -Force`) clears it and `uv venv` + offline `uv pip install` then rebuild a working 0.0.10 env.
- `.iss` Pascal reviewed by hand (declaration order valid; `DelTree` now only inside the retry helper). The handle-release *race* itself can't be deterministically forced in CI; `windows-upgrade.yml`'s hot-upgrade job continues to cover the upgrade-with-locked-venv mechanism.

> Follow-up to #50. Recommend cutting **0.0.11** with this so pre-fix users get a self-healing installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)