### PR TITLE
feat(amazon-ads): clone auto campaigns + bulk negate + recovery principles

### DIFF
--- a/app/skills_v2/amazon-ads/SKILL.md
+++ b/app/skills_v2/amazon-ads/SKILL.md
@@ -17,6 +17,60 @@ gates: [ad_completeness_review, ad_negation_allowlist, ad_execution_fidelity]
 This skill is a **catalog**. The actual content lives in topical
 references in `references/`. Load whichever ones apply to the task.
 
+## When something doesn't fit the recipe — recover, don't stall
+
+The references below are worked examples, not the full space of what
+you'll hit. Amazon's UI, campaign types, and account states vary; a step
+that assumes one shape will sometimes meet another. **A gap in these
+docs is not a stop sign — it's a cue to reason from first principles.**
+You are a capable agent; the recipe is a starting point, not a cage.
+When a documented step doesn't fit, do NOT hand a half-finished task
+back to the user ("please do X manually"). Work the problem:
+
+- **The export is ground truth; the live UI is fragile.** For anything
+  data-heavy — reading campaigns, keywords, search terms, deciding what
+  to negate — use the **bulk export** (or a Search-Terms CSV), never the
+  on-screen grid. Amazon's grids are **virtualized** (only ~13 of
+  hundreds of rows exist in the DOM; `innerText` is undefined
+  mid-scroll). Scraping them is the single most common way a run wastes
+  itself. If you catch yourself scrolling a grid and re-reading, stop —
+  export instead.
+
+- **If a command/recipe doesn't cover your case, build it from the
+  export's own structure.** `ads_bulk.py` has `inspect` / `clone-campaign`
+  / `bid-update` / `negate` / `archive-campaign` — but if your case
+  isn't one of them (a campaign type, an entity, a field with no
+  helper), open the export, find a row of the kind you need (a working
+  example of exactly this on this account), and emit the same columns
+  with your values changed. The export **teaches you the exact tokens**
+  this account+locale accepts — you never have to invent them. (Worked:
+  an SB-video negative isn't in the SP script, so read an SB row and
+  build the SB negative sheet from it.)
+
+- **Poll async jobs in separate, short calls — never one long silent
+  sleep, and never block on a Monitor for browser/job state.** A bulk
+  export or upload takes minutes; check it with a short poll (a few
+  `sleep 20` + re-open), returning to the loop between checks so
+  progress stays observable. A single 15-minute `sleep` — or blocking a
+  `Monitor`/`TaskOutput` waiting for a page/job event — looks like a hang
+  and strands the run.
+
+- **Verify by re-reading ground truth, not by trusting "Success".** A
+  bulk `Success` status only means the file was accepted; re-export (or
+  re-read the campaign) and confirm the committed state — the campaign
+  is `enabled`, the Product Ad advertises the *intended* SKU (a cloned
+  campaign renamed to the new product can still point at the old SKU),
+  the negatives are present.
+
+- **Never exit-in-the-half.** If you're blocked, restate the invariant
+  ("I must end this campaign as `enabled` advertising SKU X"), find the
+  ground-truth source, and take the next concrete step toward it. Ask a
+  human only when a credential/permission is genuinely missing, not when
+  a recipe merely ran out.
+
+The references are the map; these principles are how you travel when the
+map ends.
+
 ## What this skill produces
 
 For tuning / audit tasks ("review the ads", "improve ACOS", "audit"):

--- a/app/skills_v2/amazon-ads/references/bulk-operations.md
+++ b/app/skills_v2/amazon-ads/references/bulk-operations.md
@@ -72,7 +72,45 @@ $PY "$S" bid-update "$EXPORT" \
 $PY "$S" archive-campaign "$EXPORT" \
     --campaign "acme widgets 006 manual keyword US" \
     --out /tmp/<slug>/bulk_archive.xlsx
+
+# CLONE an AUTO campaign — same command; it detects auto from the source
+# (which has product-targeting rows, not keywords) and copies those match
+# groups (close-match/loose-match/substitutes/complements) verbatim. Do
+# NOT hand-write auto-target tokens; clone from a working auto campaign.
+$PY "$S" clone-campaign "$EXPORT" \
+    --src "acme widgets 004 auto US" --new "acme widgets 006 auto US" \
+    --sku WIDGET-006-Blue-M --daily-budget 10 --out /tmp/<slug>/bulk_auto.xlsx
+
+# NEGATE zero-sales keywords on a campaign (bulk — NOT by scraping the
+# on-screen grid). Campaign-level by default; --level adgroup for ad-group.
+$PY "$S" negate "$EXPORT" \
+    --campaign "acme widgets 006 manual keyword US" \
+    --keywords "generic term a,generic term b" --match negativePhrase \
+    --out /tmp/<slug>/bulk_negate.xlsx
 ```
+
+> **Negation is a bulk op, never a grid scrape.** The on-screen keyword /
+> search-term table is a **virtualized ag-Grid** (~13 of hundreds of rows
+> render; `innerText` is often undefined mid-virtualization) — reading or
+> clicking it to negate **does not work and wastes the run**. Decide *what*
+> to negate from the **export / Search-Terms CSV**, then apply via `negate`
+> (Sponsored Products). Sponsored **Brands** / SB-video negatives aren't in
+> the SP sheet — use the SB bulk sheet or the console targeting UI's
+> add-negative control; the principle (bulk/console, never scrape) is the
+> same.
+
+> **Clone re-points the product; verify name ↔ product.** `clone-campaign`
+> sets the new Product Ad to the `--sku` you pass — always the NEW
+> product's own seller SKU (resolve it from inventory by the new ASIN
+> first). A campaign named `…006…` that still advertises the 005/004 SKU is
+> the classic clone-rename bug; after upload, verify the created campaign's
+> Product Ad SKU/ASIN, not just its name.
+
+> **Create emits `paused`; enable when the task says to go live.** New
+> campaigns are emitted paused so nothing spends on upload. If the task is
+> to launch them, follow with a `bid-update`-style Update row setting
+> `State=enabled` (or enable in the console) — do not leave them paused and
+> call the task done when it asked you to run them.
 
 The output XLSX contains **only** the rows to act on (Create / Update /
 Archive), with `Operation` set accordingly. It reuses the exact header

--- a/app/skills_v2/amazon-ads/scripts/ads_bulk.py
+++ b/app/skills_v2/amazon-ads/scripts/ads_bulk.py
@@ -369,10 +369,32 @@ def cmd_clone_campaign(args):
             f'campaign {args.src!r} (check the exact name via `inspect`)'
         )
 
-    # Infer targeting type from what the source actually has: a
-    # product-targeting child => AUTO campaign; otherwise MANUAL.
-    is_auto = any(is_entity(r, 'product_targeting') for r in src_children)
-    targeting_type = TARGETING_AUTO if is_auto else TARGETING_MANUAL
+    # Targeting type comes from the SOURCE CAMPAIGN's own Targeting Type
+    # column — that is authoritative. Do NOT infer it from child rows:
+    # SP-Manual-**Product** campaigns also carry product-targeting rows, so
+    # their presence does NOT imply AUTO. Fall back to MANUAL (the common
+    # case) with a warning only if the source Campaign row isn't in the
+    # export (e.g. a paused campaign exported without zero-impression rows).
+    _TT = {
+        'AUTO': TARGETING_AUTO,
+        'MANUAL': TARGETING_MANUAL,
+        '自动': TARGETING_AUTO,
+        '手动': TARGETING_MANUAL,
+    }
+    targeting_type = None
+    for r in data:
+        if is_entity(r, 'campaign') and r[Col.CAMPAIGN_NAME] == args.src:
+            key = str(r[Col.TARGETING_TYPE] or '').strip()
+            targeting_type = _TT.get(key.upper(), _TT.get(key))
+            break
+    if targeting_type is None:
+        print(
+            f'warning: source campaign {args.src!r} Targeting Type not found '
+            'in export; defaulting new campaign to MANUAL. Pass a source that '
+            'appears in the export (zero-impression export for paused ones).',
+            file=sys.stderr,
+        )
+        targeting_type = TARGETING_MANUAL
 
     new = args.new
     ag = args.ad_group or new
@@ -625,22 +647,31 @@ def cmd_negate(args):
         )
     agid = None
     if args.level == 'adgroup':
-        for r in data:
-            if (
-                is_entity(r, 'ad_group')
-                and campaign_name_of(r, id_to_name) == args.campaign
-                and (
-                    args.ad_group is None
-                    or r[Col.AD_GROUP_NAME] == args.ad_group
-                )
-            ):
-                agid = r[Col.AD_GROUP_ID]
-                break
-        if not agid:
+        ag_rows = [
+            r
+            for r in data
+            if is_entity(r, 'ad_group')
+            and campaign_name_of(r, id_to_name) == args.campaign
+        ]
+        if args.ad_group:
+            ag_rows = [
+                r for r in ag_rows if r[Col.AD_GROUP_NAME] == args.ad_group
+            ]
+        elif len(ag_rows) > 1:
+            names = ', '.join(
+                sorted({str(r[Col.AD_GROUP_NAME]) for r in ag_rows})
+            )
+            sys.exit(
+                f'error: campaign {args.campaign!r} has multiple ad groups '
+                f'({names}); pass --ad-group to pick one, or --level campaign '
+                'to negate at the campaign level. Refusing to guess.'
+            )
+        if not ag_rows:
             sys.exit(
                 f'error: no ad group found for {args.campaign!r} '
                 '(needed for ad-group-level negatives; try --level campaign)'
             )
+        agid = ag_rows[0][Col.AD_GROUP_ID]
     match = NEG_MATCH_API.get(str(args.match).strip().lower(), args.match)
     kws = [k.strip() for k in (args.keywords or '').split(',') if k.strip()]
     if args.keywords_file:

--- a/app/skills_v2/amazon-ads/scripts/ads_bulk.py
+++ b/app/skills_v2/amazon-ads/scripts/ads_bulk.py
@@ -369,12 +369,10 @@ def cmd_clone_campaign(args):
             f'campaign {args.src!r} (check the exact name via `inspect`)'
         )
 
-    # Targeting type comes from the SOURCE CAMPAIGN's own Targeting Type
-    # column — that is authoritative. Do NOT infer it from child rows:
-    # SP-Manual-**Product** campaigns also carry product-targeting rows, so
-    # their presence does NOT imply AUTO. Fall back to MANUAL (the common
-    # case) with a warning only if the source Campaign row isn't in the
-    # export (e.g. a paused campaign exported without zero-impression rows).
+    # Targeting type is read from the SOURCE CAMPAIGN's own column
+    # (authoritative) — NOT inferred from child rows: SP-Manual-Product
+    # campaigns also carry product-targeting rows, so their presence does
+    # not imply AUTO. Fall back to MANUAL + warn if the source row is absent.
     _TT = {
         'AUTO': TARGETING_AUTO,
         'MANUAL': TARGETING_MANUAL,
@@ -622,16 +620,12 @@ NEG_MATCH_API = {
 
 # --- negate -------------------------------------------------------------
 def cmd_negate(args):
-    """Emit Negative Keyword rows to add negatives to an existing SP
-    campaign (the SUPPORTED way to negate — never scrape the on-screen
-    virtualized keyword grid, which shows only ~13 of hundreds of rows).
+    """Emit Negative Keyword rows for an existing SP campaign (the
+    supported way to negate — never scrape the virtualized keyword grid).
 
-    Resolves the campaign id (and, for ad-group-level, its ad-group id)
-    from the export by name, then emits one Create Negative Keyword row per
-    term. NOTE: this is Sponsored **Products**. Sponsored Brands / SB-video
-    negatives live in the SB bulk sheet (or the console targeting UI) — see
-    bulk-operations.md; the principle (bulk/console, never grid-scrape) is
-    the same.
+    Resolves the campaign id (and ad-group id for ad-group level) from the
+    export by name. Sponsored **Products** only; SB / SB-video negatives
+    live in the SB bulk sheet / console (same bulk-not-scrape principle).
     """
     _wb, ws, header, data = load(args.file)
     id_to_name = build_campaign_index(data)

--- a/app/skills_v2/amazon-ads/scripts/ads_bulk.py
+++ b/app/skills_v2/amazon-ads/scripts/ads_bulk.py
@@ -350,18 +350,29 @@ def cmd_clone_campaign(args):
     _wb, ws, header, data = load(args.file)
     id_to_name = build_campaign_index(data)
 
-    # Collect the source campaign's keyword rows.
-    src_keywords = []
+    # Collect the source campaign's TARGETING child rows — keywords
+    # (manual campaigns) AND product-targeting rows (auto campaigns' match
+    # groups: close-match / loose-match / substitutes / complements). We
+    # copy the export's OWN rows verbatim, so the exact match/expression
+    # tokens are whatever this account+locale actually uses — never
+    # hand-invented. That is what lets one command clone both a manual and
+    # an auto campaign (auto was the gap that forced ad-hoc openpyxl before).
+    src_children = []
     for r in data:
-        if not is_entity(r, 'keyword'):
+        if not (is_entity(r, 'keyword') or is_entity(r, 'product_targeting')):
             continue
         if campaign_name_of(r, id_to_name) == args.src:
-            src_keywords.append(r)
-    if not src_keywords:
+            src_children.append(r)
+    if not src_children:
         sys.exit(
-            f'error: no keyword rows found for source campaign {args.src!r} '
-            '(check the exact name via `inspect`)'
+            f'error: no keyword or product-targeting rows found for source '
+            f'campaign {args.src!r} (check the exact name via `inspect`)'
         )
+
+    # Infer targeting type from what the source actually has: a
+    # product-targeting child => AUTO campaign; otherwise MANUAL.
+    is_auto = any(is_entity(r, 'product_targeting') for r in src_children)
+    targeting_type = TARGETING_AUTO if is_auto else TARGETING_MANUAL
 
     new = args.new
     ag = args.ad_group or new
@@ -386,7 +397,7 @@ def cmd_clone_campaign(args):
     c[Col.CAMPAIGN_ID] = camp_id
     c[Col.CAMPAIGN_NAME] = new
     c[Col.START_DATE] = start_date
-    c[Col.TARGETING_TYPE] = TARGETING_MANUAL
+    c[Col.TARGETING_TYPE] = targeting_type
     c[Col.STATE] = paused
     c[Col.DAILY_BUDGET] = args.daily_budget
     c[Col.BIDDING_STRATEGY] = args.bidding_strategy
@@ -422,32 +433,41 @@ def cmd_clone_campaign(args):
         p[Col.ASIN_INFO] = args.asin
     out_rows.append(p)
 
-    # Keywords, copied from source (text + match type; bid = source bid
-    # unless overridden). Native-language columns are copied through so
-    # non-Latin keyword text survives the round trip.
-    for r in src_keywords:
-        k = blank_row()
-        k[Col.PRODUCT] = 'Sponsored Products'
-        k[Col.ENTITY] = ENTITY['keyword'][0]
-        k[Col.OPERATION] = 'Create'
-        k[Col.CAMPAIGN_ID] = camp_id
-        k[Col.AD_GROUP_ID] = ag_id
-        k[Col.CAMPAIGN_NAME] = new
-        k[Col.AD_GROUP_NAME] = ag
-        k[Col.STATE] = paused
-        k[Col.BID] = args.keyword_bid or r[Col.BID]
-        k[Col.KEYWORD_TEXT] = r[Col.KEYWORD_TEXT]
-        k[Col.NATIVE_LANGUAGE_KEYWORD] = r[Col.NATIVE_LANGUAGE_KEYWORD]
-        k[Col.NATIVE_LANGUAGE_LOCALE] = r[Col.NATIVE_LANGUAGE_LOCALE]
-        # Normalise the export's DISPLAY match token (e.g. 广泛) to the
-        # English API token (broad) the uploader requires.
-        k[Col.MATCH_TYPE] = match_type_api(r[Col.MATCH_TYPE])
-        out_rows.append(k)
+    # Re-emit each source child row under the new campaign/ad-group.
+    # Keyword rows carry text + match type; product-targeting rows carry
+    # the targeting expression (the auto match group). Bids come from the
+    # source unless overridden. Native-language columns are copied through
+    # so non-Latin text survives the round trip.
+    n_kw = n_tgt = 0
+    for r in src_children:
+        row = blank_row()
+        row[Col.PRODUCT] = 'Sponsored Products'
+        row[Col.OPERATION] = 'Create'
+        row[Col.CAMPAIGN_ID] = camp_id
+        row[Col.AD_GROUP_ID] = ag_id
+        row[Col.CAMPAIGN_NAME] = new
+        row[Col.AD_GROUP_NAME] = ag
+        row[Col.STATE] = paused
+        row[Col.BID] = args.keyword_bid or r[Col.BID]
+        if is_entity(r, 'keyword'):
+            row[Col.ENTITY] = ENTITY['keyword'][0]
+            row[Col.KEYWORD_TEXT] = r[Col.KEYWORD_TEXT]
+            row[Col.NATIVE_LANGUAGE_KEYWORD] = r[Col.NATIVE_LANGUAGE_KEYWORD]
+            row[Col.NATIVE_LANGUAGE_LOCALE] = r[Col.NATIVE_LANGUAGE_LOCALE]
+            # Normalise the export's DISPLAY match token (e.g. 广泛) to the
+            # English API token (broad) the uploader requires.
+            row[Col.MATCH_TYPE] = match_type_api(r[Col.MATCH_TYPE])
+            n_kw += 1
+        else:  # product_targeting — copy the expression verbatim (auto group)
+            row[Col.ENTITY] = ENTITY['product_targeting'][0]
+            row[Col.PRODUCT_TARGETING_EXPR] = r[Col.PRODUCT_TARGETING_EXPR]
+            n_tgt += 1
+        out_rows.append(row)
 
     print(
-        f'cloning {len(src_keywords)} keyword(s) from {args.src!r} into '
-        f'new campaign {new!r} (paused, budget={args.daily_budget}, '
-        f'sku={args.sku})'
+        f'cloning {n_kw} keyword(s) + {n_tgt} product-target(s) from '
+        f'{args.src!r} into new {targeting_type} campaign {new!r} '
+        f'(paused, budget={args.daily_budget}, sku={args.sku})'
     )
     out_path = args.out or 'bulk_create_upload.xlsx'
     write_upload(ws.title, header, out_rows, out_path)
@@ -565,6 +585,95 @@ def cmd_scope(args):
     print(json.dumps(out, ensure_ascii=False, indent=2))
 
 
+# Negative match tokens the SP uploader accepts (Config:
+# SponsoredProductsCreateNegativeKeywordMatchTypes). Map friendly/localised
+# inputs to the API token.
+NEG_MATCH_API = {
+    'negativephrase': 'negativePhrase',
+    'negativeexact': 'negativeExact',
+    'phrase': 'negativePhrase',
+    'exact': 'negativeExact',
+    '否定词组': 'negativePhrase',
+    '否定精准': 'negativeExact',
+}
+
+
+# --- negate -------------------------------------------------------------
+def cmd_negate(args):
+    """Emit Negative Keyword rows to add negatives to an existing SP
+    campaign (the SUPPORTED way to negate — never scrape the on-screen
+    virtualized keyword grid, which shows only ~13 of hundreds of rows).
+
+    Resolves the campaign id (and, for ad-group-level, its ad-group id)
+    from the export by name, then emits one Create Negative Keyword row per
+    term. NOTE: this is Sponsored **Products**. Sponsored Brands / SB-video
+    negatives live in the SB bulk sheet (or the console targeting UI) — see
+    bulk-operations.md; the principle (bulk/console, never grid-scrape) is
+    the same.
+    """
+    _wb, ws, header, data = load(args.file)
+    id_to_name = build_campaign_index(data)
+    cid = None
+    for r in data:
+        if is_entity(r, 'campaign') and r[Col.CAMPAIGN_NAME] == args.campaign:
+            cid = r[Col.CAMPAIGN_ID]
+            break
+    if not cid:
+        sys.exit(
+            f'error: campaign {args.campaign!r} not found in the export '
+            '(check the exact name via `inspect`).'
+        )
+    agid = None
+    if args.level == 'adgroup':
+        for r in data:
+            if (
+                is_entity(r, 'ad_group')
+                and campaign_name_of(r, id_to_name) == args.campaign
+                and (
+                    args.ad_group is None
+                    or r[Col.AD_GROUP_NAME] == args.ad_group
+                )
+            ):
+                agid = r[Col.AD_GROUP_ID]
+                break
+        if not agid:
+            sys.exit(
+                f'error: no ad group found for {args.campaign!r} '
+                '(needed for ad-group-level negatives; try --level campaign)'
+            )
+    match = NEG_MATCH_API.get(str(args.match).strip().lower(), args.match)
+    kws = [k.strip() for k in (args.keywords or '').split(',') if k.strip()]
+    if args.keywords_file:
+        with open(args.keywords_file, encoding='utf-8') as f:
+            kws += [ln.strip() for ln in f if ln.strip()]
+    if not kws:
+        sys.exit('error: pass --keywords "a,b,c" or --keywords-file FILE')
+    entity = (
+        'campaign_negative_keyword'
+        if args.level == 'campaign'
+        else 'negative_keyword'
+    )
+    out_rows = []
+    for kw in kws:
+        row = blank_row()
+        row[Col.PRODUCT] = 'Sponsored Products'
+        row[Col.ENTITY] = ENTITY[entity][0]
+        row[Col.OPERATION] = 'Create'
+        row[Col.CAMPAIGN_ID] = cid
+        if args.level == 'adgroup':
+            row[Col.AD_GROUP_ID] = agid
+        row[Col.STATE] = STATE_ENABLED
+        row[Col.KEYWORD_TEXT] = kw
+        row[Col.MATCH_TYPE] = match
+        out_rows.append(row)
+    print(
+        f'negating {len(out_rows)} keyword(s) as {match} at {args.level} '
+        f'level on {args.campaign!r}'
+    )
+    out_path = args.out or 'bulk_negate.xlsx'
+    write_upload(ws.title, header, out_rows, out_path)
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
     sub = ap.add_subparsers(dest='cmd', required=True)
@@ -582,13 +691,16 @@ def main():
     p.set_defaults(func=cmd_scope)
 
     p = sub.add_parser(
-        'clone-campaign', help='emit Create rows for a new manual campaign'
+        'clone-campaign',
+        help='emit Create rows for a new campaign (manual OR auto — '
+        "copies the source's keywords or product-targeting groups)",
     )
     p.add_argument('file')
     p.add_argument(
         '--src',
         required=True,
-        help='exact source campaign name (keyword source)',
+        help='exact source campaign name (its targeting rows are copied; '
+        'manual→keywords, auto→product-targeting groups)',
     )
     p.add_argument('--new', required=True, help='new campaign name')
     p.add_argument('--ad-group', help='ad group name (default: new name)')
@@ -623,6 +735,34 @@ def main():
     p.add_argument('--campaign', required=True, help='exact campaign name')
     p.add_argument('--out')
     p.set_defaults(func=cmd_archive_campaign)
+
+    p = sub.add_parser(
+        'negate',
+        help='emit Negative Keyword rows for an SP campaign (bulk negation)',
+    )
+    p.add_argument('file')
+    p.add_argument('--campaign', required=True, help='exact campaign name')
+    p.add_argument(
+        '--keywords',
+        help='comma-separated terms to negate (or --keywords-file)',
+    )
+    p.add_argument(
+        '--keywords-file', help='file with one term to negate per line'
+    )
+    p.add_argument(
+        '--match',
+        default='negativePhrase',
+        help='negativePhrase|negativeExact (phrase/exact also accepted)',
+    )
+    p.add_argument(
+        '--level',
+        choices=('adgroup', 'campaign'),
+        default='campaign',
+        help='campaign-level (default) or ad-group-level negative',
+    )
+    p.add_argument('--ad-group', help='ad group name (ad-group level only)')
+    p.add_argument('--out')
+    p.set_defaults(func=cmd_negate)
 
     args = ap.parse_args()
     args.func(args)

--- a/tests/unit/test_amazon_ads_bulk_skill.py
+++ b/tests/unit/test_amazon_ads_bulk_skill.py
@@ -30,7 +30,7 @@ openpyxl = pytest.importorskip('openpyxl')
 _SKILL_PATH = (
     Path(__file__).resolve().parents[2]
     / 'app'
-    / 'skills'
+    / 'skills_v2'
     / 'amazon-ads'
     / 'scripts'
     / 'ads_bulk.py'
@@ -126,6 +126,7 @@ def _make_export(path):
             CAMPAIGN_ID='C1',
             CAMPAIGN_NAME=SRC_CAMPAIGN,
             STATE='已启用',
+            TARGETING_TYPE='手动',
             DAILY_BUDGET=15.0,
             SPEND=100.0,
             SALES=250.0,
@@ -136,6 +137,7 @@ def _make_export(path):
         _row(
             ENTITY='广告组',
             CAMPAIGN_ID='C1',
+            AD_GROUP_ID='AG1',
             CAMPAIGN_NAME_INFO=SRC_CAMPAIGN,
             AD_GROUP_NAME='ag1',
             STATE='已启用',
@@ -376,3 +378,175 @@ class TestArchiveCampaign:
             ads_bulk.cmd_archive_campaign(
                 self._args(tmp_path, campaign='no such campaign')
             )
+
+
+def _make_targeting_export(path, targeting_type):
+    """Synthetic export: campaign + ad group + product ad + 2
+    product-targeting rows (NO keywords). Used to prove clone reads the
+    campaign's OWN Targeting Type — product-targeting rows are NOT unique
+    to AUTO (SP-Manual-Product campaigns have them too)."""
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = ZH_SHEET
+    ws.append(ZH_HEADER)
+    ws.append(
+        _row(
+            ENTITY='广告活动',
+            CAMPAIGN_ID='C2',
+            CAMPAIGN_NAME=SRC_CAMPAIGN,
+            STATE='已启用',
+            TARGETING_TYPE=targeting_type,
+            DAILY_BUDGET=15.0,
+        )
+    )
+    ws.append(
+        _row(
+            ENTITY='广告组',
+            CAMPAIGN_ID='C2',
+            AD_GROUP_ID='AG2',
+            CAMPAIGN_NAME_INFO=SRC_CAMPAIGN,
+            AD_GROUP_NAME='ag1',
+            STATE='已启用',
+            AD_GROUP_DEFAULT_BID=0.8,
+        )
+    )
+    ws.append(
+        _row(
+            ENTITY='商品广告',
+            CAMPAIGN_ID='C2',
+            CAMPAIGN_NAME_INFO=SRC_CAMPAIGN,
+            STATE='已启用',
+            SKU='WIDGET-004-Blue',
+            ASIN_INFO='B0AAAAAAAA',
+        )
+    )
+    for bid, expr in ((1.5, 'close-match'), (1.2, 'substitutes')):
+        ws.append(
+            _row(
+                ENTITY='商品定向',
+                CAMPAIGN_ID='C2',
+                CAMPAIGN_NAME_INFO=SRC_CAMPAIGN,
+                STATE='已启用',
+                BID=bid,
+                PRODUCT_TARGETING_EXPR=expr,
+            )
+        )
+    wb.save(path)
+
+
+@pytest.mark.unit
+class TestCloneAutoAndProductTargeting:
+    def _args(self, tmp_path, **over):
+        base = dict(
+            file=str(tmp_path / 'export.xlsx'),
+            src=SRC_CAMPAIGN,
+            new='acme widgets 006 auto US',
+            ad_group=None,
+            sku='WIDGET-006-Blue-M',
+            asin='B0BBBBBBBB',
+            daily_budget=10.0,
+            default_bid=0.75,
+            keyword_bid=None,
+            bidding_strategy='Dynamic bids - down only',
+            start_date='20260701',
+            out=str(tmp_path / 'create.xlsx'),
+        )
+        base.update(over)
+        return argparse.Namespace(**base)
+
+    def test_auto_source_clones_product_targeting_and_marks_auto(
+        self, tmp_path
+    ):
+        _make_targeting_export(tmp_path / 'export.xlsx', '自动')
+        ads_bulk.cmd_clone_campaign(self._args(tmp_path))
+        _t, _h, rows = _read_rows(tmp_path / 'create.xlsx')
+        assert [r[Col.ENTITY] for r in rows] == [
+            'Campaign',
+            'Ad Group',
+            'Product Ad',
+            'Product Targeting',
+            'Product Targeting',
+        ]
+        # Targeting type comes from the source campaign's column, not
+        # inferred; product-targeting expressions copied verbatim.
+        assert rows[0][Col.TARGETING_TYPE] == 'AUTO'
+        assert rows[2][Col.SKU] == 'WIDGET-006-Blue-M'  # re-pointed product
+        exprs = [
+            r[Col.PRODUCT_TARGETING_EXPR]
+            for r in rows
+            if r[Col.ENTITY] == 'Product Targeting'
+        ]
+        assert exprs == ['close-match', 'substitutes']
+        assert all(r[Col.STATE] == 'paused' for r in rows)
+
+    def test_manual_product_source_stays_manual(self, tmp_path):
+        # The Copilot bug: presence of product-targeting rows must NOT
+        # force AUTO — an SP-Manual-Product campaign keeps MANUAL.
+        _make_targeting_export(tmp_path / 'export.xlsx', '手动')
+        ads_bulk.cmd_clone_campaign(self._args(tmp_path))
+        _t, _h, rows = _read_rows(tmp_path / 'create.xlsx')
+        assert rows[0][Col.TARGETING_TYPE] == 'MANUAL'
+
+
+@pytest.mark.unit
+class TestNegate:
+    def _args(self, tmp_path, **over):
+        base = dict(
+            file=str(tmp_path / 'export.xlsx'),
+            campaign=SRC_CAMPAIGN,
+            keywords='foo,bar',
+            keywords_file=None,
+            match='negativePhrase',
+            level='campaign',
+            ad_group=None,
+            out=str(tmp_path / 'negate.xlsx'),
+        )
+        base.update(over)
+        return argparse.Namespace(**base)
+
+    def test_campaign_level_negatives(self, tmp_path):
+        _make_export(tmp_path / 'export.xlsx')
+        ads_bulk.cmd_negate(self._args(tmp_path))
+        _t, _h, rows = _read_rows(tmp_path / 'negate.xlsx')
+        assert len(rows) == 2
+        assert all(r[Col.ENTITY] == 'Campaign Negative Keyword' for r in rows)
+        assert all(r[Col.OPERATION] == 'Create' for r in rows)
+        assert all(r[Col.CAMPAIGN_ID] == 'C1' for r in rows)
+        assert all(r[Col.MATCH_TYPE] == 'negativePhrase' for r in rows)
+        assert sorted(r[Col.KEYWORD_TEXT] for r in rows) == ['bar', 'foo']
+
+    def test_adgroup_level_with_match_alias(self, tmp_path):
+        _make_export(tmp_path / 'export.xlsx')
+        ads_bulk.cmd_negate(
+            self._args(tmp_path, level='adgroup', match='exact')
+        )
+        _t, _h, rows = _read_rows(tmp_path / 'negate.xlsx')
+        assert all(r[Col.ENTITY] == 'Negative Keyword' for r in rows)
+        assert all(r[Col.AD_GROUP_ID] == 'AG1' for r in rows)
+        # 'exact' alias normalises to the negative API token.
+        assert all(r[Col.MATCH_TYPE] == 'negativeExact' for r in rows)
+
+    def test_adgroup_ambiguous_without_name_exits(self, tmp_path):
+        # Multiple ad groups + no --ad-group => refuse to guess (Copilot #2).
+        p = tmp_path / 'export.xlsx'
+        _make_export(p)
+        wb = openpyxl.load_workbook(p)
+        ws = wb.active
+        ws.append(
+            _row(
+                ENTITY='广告组',
+                CAMPAIGN_ID='C1',
+                AD_GROUP_ID='AG2',
+                CAMPAIGN_NAME_INFO=SRC_CAMPAIGN,
+                AD_GROUP_NAME='ag2',
+                STATE='已启用',
+            )
+        )
+        wb.save(p)
+        with pytest.raises(SystemExit):
+            ads_bulk.cmd_negate(self._args(tmp_path, level='adgroup'))
+
+    def test_no_keywords_exits(self, tmp_path):
+        _make_export(tmp_path / 'export.xlsx')
+        with pytest.raises(SystemExit):
+            ads_bulk.cmd_negate(self._args(tmp_path, keywords=None))


### PR DESCRIPTION
## Why

Debugging a live ad-create+tune run (a store agent, same model class as any AI agent) surfaced a pattern: **the skill was a recipe, so when reality deviated the agent improvised badly or quit mid-task** — exactly where a capable agent *should* recover. This PR closes the concrete gaps **and** adds the missing layer that lets a task reason its own way out.

## Concrete fixes

**`scripts/ads_bulk.py`**
- **`clone-campaign` now clones AUTO campaigns too.** It was manual-only; an auto campaign has no keywords, so the agent hand-built the sheet with `openpyxl` and crashed (`Exit code 1`). Now it copies **all** of the source's targeting children — keywords (manual) *or* product-targeting groups (auto: close-match/loose-match/substitutes/complements) — **verbatim from the export**, and infers AUTO/MANUAL from what the source has. No hand-invented auto-target tokens.
- **New `negate` command** — emits Negative Keyword rows (campaign- or ad-group-level) from names resolved in the export. Previously there was no bulk-negate path, so the agent tried to scrape the **virtualized ag-Grid** (~13 of hundreds of rows) and gave up.

**`references/bulk-operations.md`** — negation is a bulk op, never a grid scrape; `clone` re-points the Product Ad to the **new** product's own SKU (verify name↔product — the clone-rename trap); create emits `paused`, enable when the task says go live; SB/SB-video negatives use the SB sheet/console (same principle).

## Capstone — "recover, don't stall" (`SKILL.md`)

Following Anthropic's Agent-Skills **progressive-disclosure** philosophy (a skill is a manual to explore + a capability-intent to internalize, not a cage), a high-visibility recovery layer so a task figures its own way out instead of exiting-in-the-half:
- the **export is ground truth; never scrape virtualized grids**;
- if a command doesn't fit, **build the bulk rows from the export's own structure** (it teaches the exact tokens) — e.g. an SB negative not in the SP script;
- **poll async jobs in short separate calls; don't block on a long sleep or a Monitor** for browser/job state;
- **verify by re-reading ground truth**, not a `Success` status;
- **never exit-in-the-half**; ask a human only for a genuinely missing credential.

## Verified end-to-end (live)

Re-ran the failing scenario with the fixed skill on a MENA SA store (placeholders here). With the fixes + one nudge off a monitor-block, the agent: created the missing SP auto+manual campaigns (correct product, not the cloned-from product), **built an SB negative sheet itself** (the exact gap that stalled the original run), enabled both campaigns, and applied the SB negatives — bulk uploads `Success`, confirmed by re-reading the export (`State=enabled`, correct advertised SKU).

**Placeholders only — no account / store / SKU / ASIN / email data.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Xthn4cVTJmpHGWSvWptTa