### PR TITLE
fix(amazon-ads): ad console is per-marketplace; reflection must correct stale facts

### DIFF
--- a/app/prompts/reflection.md
+++ b/app/prompts/reflection.md
@@ -7,8 +7,20 @@ knowledge, stop without updating any file.
 ## Correct what you relied on — FIRST, before writing anything new
 
 Look back at the notes/knowledge you **read** this task. If a stored fact
-steered your work and your live observation **contradicted** it, you MUST
-fix it **in place** — this outranks recording any new learning.
+steered your work and your live observation **contradicted** it, correct
+it — this outranks recording any new learning. **Where** you correct it
+depends on which file holds the stale fact (see "Where to write" below):
+
+- **Editable L2/L3 file** (`knowledge/notes.md`, `stores/<slug>/...`,
+  user-authored skills) → fix it **in place** now.
+- **Read-only L1** (`knowledge/project/`) or a **built-in skill** (you
+  cannot durably edit either from a task) → do NOT try to edit it. Record
+  the correction under the `## Skill follow-ups` heading in
+  `stores/<slug>/notes.md` (which file+section is wrong, the corrected
+  wording, the evidence) so the human can merge it, and flag it in your
+  final message.
+
+Either way — never leave the stale fact standing unremarked.
 
 - **Update, never extend.** Overwrite the wrong line (or delete it). Do
   NOT append a "correction" beneath the stale text, and do NOT leave the

--- a/app/prompts/reflection.md
+++ b/app/prompts/reflection.md
@@ -4,6 +4,27 @@ from actions taken AFTER your last reflection. **Writing nothing is a valid
 outcome** — if this task only produced data/results and no new procedural
 knowledge, stop without updating any file.
 
+## Correct what you relied on — FIRST, before writing anything new
+
+Look back at the notes/knowledge you **read** this task. If a stored fact
+steered your work and your live observation **contradicted** it, you MUST
+fix it **in place** — this outranks recording any new learning.
+
+- **Update, never extend.** Overwrite the wrong line (or delete it). Do
+  NOT append a "correction" beneath the stale text, and do NOT leave the
+  old line while adding a fresh one elsewhere. The file must end with
+  exactly one, current answer to the question.
+- **A wrong fact is worse than a missing one.** Every future task trusts
+  what it reads. A stale "market X has 0 campaigns", a moved URL, a
+  renamed selector — each silently poisons the next run, often by
+  suppressing the very check that would reveal the truth. Correcting one
+  is the single highest-value thing this reflection can do.
+- **Point-in-time state is not knowledge — it expires.** Counts,
+  statuses, "as of <date>" snapshots (campaign/SKU counts, inventory,
+  which market has ads, current bids) must never be written as durable
+  facts (see Do NOT write #1). If you find one already sitting in a notes
+  file, delete it — even if you didn't write it.
+
 ## The only thing worth writing
 
 A **transferable learning**: something a DIFFERENT future task would need to

--- a/app/skills_v2/amazon-ads/SKILL.md
+++ b/app/skills_v2/amazon-ads/SKILL.md
@@ -36,6 +36,22 @@ back to the user ("please do X manually"). Work the problem:
   itself. If you catch yourself scrolling a grid and re-reading, stop —
   export instead.
 
+- **The export covers ONE marketplace — whichever the console is switched
+  to — so a negative is never proof.** The ad console shows a single
+  country at a time: the top-left `Sponsored ads, <Country>` control is a
+  **marketplace switcher**, and each country is frequently a *separate
+  account/entity* (even the brand name can differ per market). A bulk
+  export reflects only the currently-selected marketplace — its rows are
+  complete for *that* country and silent about every other. **Never
+  conclude "country X has no ads" from country Y's export or list**; that
+  is exactly how a live marketplace gets falsely reported as empty. When
+  the user asks about more than one country (or "all" countries, or a
+  country the console isn't currently on): **switch the console to each
+  country and export it separately** — one download per country — then
+  compare. To prove any negative ("no ads in X"), switch to X and look.
+  A stored note claiming a market is empty is a stale per-run snapshot,
+  not a fact — re-verify it live before you trust it.
+
 - **If a command/recipe doesn't cover your case, build it from the
   export's own structure.** `ads_bulk.py` has `inspect` / `clone-campaign`
   / `bid-update` / `negate` / `archive-campaign` — but if your case

--- a/app/skills_v2/amazon-ads/SKILL.md
+++ b/app/skills_v2/amazon-ads/SKILL.md
@@ -36,21 +36,30 @@ back to the user ("please do X manually"). Work the problem:
   itself. If you catch yourself scrolling a grid and re-reading, stop —
   export instead.
 
-- **The export covers ONE marketplace — whichever the console is switched
-  to — so a negative is never proof.** The ad console shows a single
-  country at a time: the top-left `Sponsored ads, <Country>` control is a
-  **marketplace switcher**, and each country is frequently a *separate
-  account/entity* (even the brand name can differ per market). A bulk
-  export reflects only the currently-selected marketplace — its rows are
-  complete for *that* country and silent about every other. **Never
-  conclude "country X has no ads" from country Y's export or list**; that
-  is exactly how a live marketplace gets falsely reported as empty. When
-  the user asks about more than one country (or "all" countries, or a
-  country the console isn't currently on): **switch the console to each
-  country and export it separately** — one download per country — then
-  compare. To prove any negative ("no ads in X"), switch to X and look.
-  A stored note claiming a market is empty is a stale per-run snapshot,
-  not a fact — re-verify it live before you trust it.
+- **Data is scoped to whatever marketplace the console is showing — so a
+  country's absence is never proof it's empty.** Amazon's ad console comes
+  in more than one shape, and you must not assume which you're on:
+    - *Per-country account* — the console shows **one marketplace at a
+      time**, selected by the top-left `Sponsored ads, <Country>` control;
+      each country is a **separate account/entity** (the brand name can
+      even differ per market). The list — and a bulk export — cover only
+      the selected country.
+    - *Unified multi-market entity* — a **single list spans several
+      countries**, distinguished by a Country column, and the export may
+      carry a marketplace/country column covering all of them.
+  Don't guess which you have — **check**: does the current view (or the
+  switcher menu) actually name the country you were asked about? Is there
+  a per-row Country column, and does the export contain that country's
+  rows? The invariant, true in every shape: **confirm each requested
+  country is actually represented in the data you read.** If a country
+  isn't present, it lives behind the switcher (or under another entity) —
+  go get it; do **not** conclude it has no ads. When the user asks about
+  more than one country (or "all", or one the console isn't currently
+  showing) and the layout is per-country, **switch to each country and
+  export separately** — one download per country — then compare. To prove
+  any negative ("no ads in X"), put X in view and look. A stored note
+  claiming a market is empty is a stale per-run snapshot, not a fact —
+  re-verify it live before you trust it.
 
 - **If a command/recipe doesn't cover your case, build it from the
   export's own structure.** `ads_bulk.py` has `inspect` / `clone-campaign`

--- a/app/skills_v2/amazon-ads/references/mechanics.md
+++ b/app/skills_v2/amazon-ads/references/mechanics.md
@@ -58,34 +58,49 @@ need it on every URL.
 
 ## 2. Reading existing campaigns
 
-### 2.0 One marketplace at a time — the country switcher
+### 2.0 Which marketplace are you looking at? (two layouts)
 
-The ad console shows the campaigns of **exactly one marketplace** — the
-one currently selected. The selector is the **top-left control labelled
-`Sponsored ads, <Country>`** (e.g. `Sponsored ads, Saudi Arabia`).
-Clicking it opens a menu of the account's marketplaces; each entry is
-often a *separate account/entity*, and the displayed brand name can even
-differ per country (observed: one entity shown as one brand for AE and a
-sibling brand for SA under the same login). Switching swaps the whole
-campaign list **and** what a bulk export contains.
+Amazon's ad console appears in **two shapes** depending on how the
+account's marketplaces are registered. Detect which one you're on before
+trusting any list or export — never assume.
 
-Consequences you must respect:
+**Layout A — per-country account (one marketplace at a time).** The
+top-left control reads `Sponsored ads, <Country>` (e.g.
+`Sponsored ads, Saudi Arabia`) and is a **switcher**. Clicking it opens a
+menu of the account's marketplaces; each entry is a *separate
+account/entity*, and the displayed brand name can differ per country
+(observed on a live account: `<brandA>  United Arab Emirates` and
+`<brandB>  Saudi Arabia` under one login). The campaign list **and any
+bulk export cover only the selected country.**
 
-- The campaign list and any **bulk export reflect only the selected
-  marketplace**. Rows are complete for *that* country and say nothing
-  about any other.
-- **Never infer that a country has no campaigns because it's absent from
-  another country's list/export.** To check country X, first switch the
-  console to X (confirm the top-left control now reads `Sponsored ads,
-  <X>`), *then* read/export.
-- **Multi-country audits = one export per country.** Loop: switch → wait
-  for the list to reload → export → repeat. Label each file by country;
-  do not merge markets in one download and assume it's complete.
+**Layout B — unified multi-market entity (one list, many countries).** A
+single campaign list spans several marketplaces, with a **Country column**
+per row, and the bulk export carries a marketplace/country column with all
+of them. No switching needed to see every market — but confirm the column
+is actually there and populated before relying on it.
 
+**How to tell them apart:** read the top-left control and the list. If the
+control names a single country and the rows have no differing Country
+values, you're on Layout A (other countries are hidden behind the
+switcher). If rows show multiple countries / there's a Country column,
+you're on Layout B.
+
+Consequences (both layouts):
+
+- **Never infer a country has no campaigns because it's absent from what's
+  currently in view.** On Layout A that just means it's not selected; on
+  Layout B it means the column filter/scope didn't include it. Put the
+  country in view first, then conclude.
+- The invariant: **every country you were asked about must be represented
+  in the data you read.** If one isn't, find where it lives (switch, or a
+  different entity) before reporting on it.
+
+**Layout-A multi-country audit = one export per country.** Loop: switch →
+wait for the list to reload → export → repeat; label each file by country.
 To switch programmatically: find the leaf element whose text matches
-`^Sponsored ads,\s*<Country>$`, `.click()` it, then click the target
-country's menu entry (`<brand>  <Country>`), and wait for the list to
-reload before reading.
+`^Sponsored ads,\s*<Country>$`, `.click()` it, click the target country's
+menu entry (`<brand>  <Country>`), and wait for the list to reload before
+reading.
 
 ### 2a. The campaign-list "Find a campaign" search
 

--- a/app/skills_v2/amazon-ads/references/mechanics.md
+++ b/app/skills_v2/amazon-ads/references/mechanics.md
@@ -58,6 +58,35 @@ need it on every URL.
 
 ## 2. Reading existing campaigns
 
+### 2.0 One marketplace at a time — the country switcher
+
+The ad console shows the campaigns of **exactly one marketplace** — the
+one currently selected. The selector is the **top-left control labelled
+`Sponsored ads, <Country>`** (e.g. `Sponsored ads, Saudi Arabia`).
+Clicking it opens a menu of the account's marketplaces; each entry is
+often a *separate account/entity*, and the displayed brand name can even
+differ per country (observed: one entity shown as one brand for AE and a
+sibling brand for SA under the same login). Switching swaps the whole
+campaign list **and** what a bulk export contains.
+
+Consequences you must respect:
+
+- The campaign list and any **bulk export reflect only the selected
+  marketplace**. Rows are complete for *that* country and say nothing
+  about any other.
+- **Never infer that a country has no campaigns because it's absent from
+  another country's list/export.** To check country X, first switch the
+  console to X (confirm the top-left control now reads `Sponsored ads,
+  <X>`), *then* read/export.
+- **Multi-country audits = one export per country.** Loop: switch → wait
+  for the list to reload → export → repeat. Label each file by country;
+  do not merge markets in one download and assume it's complete.
+
+To switch programmatically: find the leaf element whose text matches
+`^Sponsored ads,\s*<Country>$`, `.click()` it, then click the target
+country's menu entry (`<brand>  <Country>`), and wait for the list to
+reload before reading.
+
 ### 2a. The campaign-list "Find a campaign" search
 
 The campaign list has a search input with placeholder


### PR DESCRIPTION
## Why

A store review task reported **\"AE 零广告\"** (no ads in the UAE marketplace) for a store whose ad console plainly lists UAE campaigns. False negative — traced to two compounding **design** gaps, not an agent error.

### Root cause (from the agent's own logs)

The task hit the ad console **21× on `advertising.amazon.sa` and 0× on the AE marketplace.** It downloaded the **SA** bulk export (which by construction contains only SA campaigns), then concluded AE was empty — never switching the console to AE to look. Two things made that feel *correct*:

1. **"Export is ground truth" had no per-marketplace caveat.** The ad console shows **one marketplace at a time** (top-left `Sponsored ads, <Country>` switcher; each country is often a *separate account/entity* — the brand name can even differ per market). An export reflects only the selected marketplace. The capstone told the agent to trust the export but not that it's country-scoped.
2. **A stale snapshot in a per-store note.** A prior run had written *\"AE has 0 campaigns (as of <date>)\"* into `stores/<slug>/notes.md` as if durable. This run trusted it. `reflection.md` already said \"update, don't duplicate\" and banned writing counts — but nothing told the agent to **actively correct** a stored fact its own live observation contradicted, so the stale line survived and confirmed the wrong answer.

## What changed (design fixes — kill the bug class)

- **`amazon-ads/SKILL.md`** capstone: new bullet — an export covers only the **selected** marketplace; **never infer \"country X has no ads\" from country Y's export**; multi-country audits = **switch + export per country**; prove a negative by switching to that country; a stored \"market is empty\" note is a stale snapshot — re-verify live.
- **`amazon-ads/references/mechanics.md`** §2.0: the `Sponsored ads, <Country>` switcher, per-country entities, the one-export-per-country loop, and how to switch programmatically.
- **`app/prompts/reflection.md`**: new top-priority **\"Correct what you relied on\"** step — if live observation contradicts a stored fact, **overwrite it in place (update, never extend)**; point-in-time state (counts/statuses/\"as of <date>\") is not durable knowledge — delete it when found.

## Verification

- **Live-verified** on a real store's ad console: clicking the `Sponsored ads, <Country>` control reveals **per-country accounts** (`<brand>  United Arab Emirates` / `<brand>  Saudi Arabia`); the console shows a single marketplace's campaigns at a time.
- Also cleared the stale line out of the offending per-store note (runtime-local; the durable fix is this PR).
- `pre-commit` clean; `tests/unit/test_stop_reflection_hook.py` + `test_prompt_assembly.py` — **45 passed**.

## Note on timing

The task predates the recover-don't-stall capstone (#54) by ~12h, so it never had it. But #54 alone wouldn't have saved it — its \"export is ground truth\" line would have *reinforced* the wrong conclusion. This PR is the missing half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)