### PR TITLE
feat(f1,f2): listing file-upload recipe + auto-answer unattended AskUserQuestion

### DIFF
--- a/app/ai/claude_backend_hooks.py
+++ b/app/ai/claude_backend_hooks.py
@@ -26,6 +26,7 @@ from app.ai.claude_backend_utils import (
     check_review_status_for_stop,
     check_skill_prereqs,
     get_open_tasklist_items,
+    resolve_question_answer_timeout,
     validate_fanout_plan_text,
 )
 from app.ai.skill_gate_utils import find_skill_md, skill_name_from_read
@@ -40,7 +41,7 @@ from app.prompts import (
     SCHEDULED_WATERMARK_PROMPT,
     render_prompt,
 )
-from app.question_answers import expand_free_text_answers
+from app.question_answers import default_answers, expand_free_text_answers
 from app.task_states import TaskStatus
 from app.workspace.manager import VIBE_SELLER_DIR
 
@@ -754,7 +755,11 @@ class _HookMixin:
     async def _handle_ask_user_question(
         self, request_id: str, tool_input: dict
     ):
-        """Handle AskUserQuestion — emit to frontend, wait."""
+        """Emit AskUserQuestion to the UI; wait a bounded window for a
+        human answer, else AUTO-ANSWER with defaults so the agent never
+        hangs (unattended/scheduled runs have no one to click). See
+        ``resolve_question_answer_timeout`` + ``default_answers``.
+        """
         questions = tool_input.get('questions', [])
         self._pending_questions[request_id] = {
             'request_id': request_id,
@@ -769,10 +774,24 @@ class _HookMixin:
                 'questions': questions,
             },
         )
-        await self._answer_events[request_id].wait()
-        answers = self._answers.pop(request_id, {})
-        self._answer_events.pop(request_id, None)
-        self._pending_questions.pop(request_id, None)
+        timeout = await resolve_question_answer_timeout(self.task_id)
+        try:
+            await asyncio.wait_for(
+                self._answer_events[request_id].wait(), timeout
+            )
+            answers = self._answers.pop(request_id, {})
+        except TimeoutError:
+            answers = default_answers(questions)
+            logger.info(
+                'AskUserQuestion auto-answered for task %s after %ss with '
+                'defaults (no response): %s',
+                self.task_id,
+                timeout,
+                answers,
+            )
+        finally:
+            self._answer_events.pop(request_id, None)
+            self._pending_questions.pop(request_id, None)
         if not self.running or self._stopping:
             return
         # Expand the UI free-text sentinel into per-question answers (#211).

--- a/app/ai/claude_backend_utils.py
+++ b/app/ai/claude_backend_utils.py
@@ -14,7 +14,11 @@ from app.ai.bash_safety import (
     check_review_status,
 )
 from app.ai.skill_gate_utils import find_skill_md
-from app.config import WEB_BROWSER_SLUG
+from app.config import (
+    QUESTION_ANSWER_TIMEOUT_SCHEDULED_SECONDS,
+    QUESTION_ANSWER_TIMEOUT_SECONDS,
+    WEB_BROWSER_SLUG,
+)
 from app.database import async_session
 from app.env_options import Options
 from app.models.schedule import Schedule
@@ -432,3 +436,24 @@ def check_exec_review_status_for_stop(
     if task_dir is None:
         return None
     return check_exec_review_status(task_dir)
+
+
+async def resolve_question_answer_timeout(task_id: str) -> float:
+    """Seconds to wait for a human AskUserQuestion answer before the
+    server auto-answers with defaults.
+
+    Scheduled tasks run unattended → short window; a user-created
+    (interactive) task gets a generous one in case someone is watching.
+    """
+    try:
+        async with async_session() as db:
+            task = await db.get(Task, task_id)
+            if task and task.schedule_id:
+                return QUESTION_ANSWER_TIMEOUT_SCHEDULED_SECONDS
+    except Exception:
+        logger.debug(
+            'Question-timeout task load failed for %s; interactive default',
+            task_id,
+            exc_info=True,
+        )
+    return QUESTION_ANSWER_TIMEOUT_SECONDS

--- a/app/config.py
+++ b/app/config.py
@@ -97,6 +97,15 @@ FRONTEND_URL = Options.FRONTEND_URL.get() or f'http://{LOCALHOST_NAME}:5173'
 LOG_DIR = Path(Options.LOG_DIR.get() or (BASE_DIR / 'logs'))
 LOG_DIR.mkdir(exist_ok=True)
 
+# AskUserQuestion answer window. A task must never hang forever waiting
+# for a human to click an option — unattended/scheduled runs have no one
+# watching. After the window the server auto-answers with a sensible
+# default (first option) so the agent proceeds instead of stalling.
+# Interactive (user-created) tasks get a generous window; scheduled tasks
+# (definitionally unattended) answer fast.
+QUESTION_ANSWER_TIMEOUT_SECONDS = 120
+QUESTION_ANSWER_TIMEOUT_SCHEDULED_SECONDS = 10
+
 # Browser-use CLI
 BROWSER_USE_BIN_DIR = VIBE_SELLER_DIR / 'bin'
 BROWSER_USE_BIN_DIR.mkdir(parents=True, exist_ok=True)

--- a/app/question_answers.py
+++ b/app/question_answers.py
@@ -27,6 +27,38 @@ prompts or the frontend — see CLAUDE.md "Fix from design".
 FREE_TEXT_KEY = '_free_text'
 
 
+def default_answers(questions: list[dict]) -> dict:
+    """Server-side default answers for an AskUserQuestion nobody answered.
+
+    Used when no human responds within the answer window (unattended /
+    scheduled runs) so the agent proceeds instead of hanging. Picks the
+    FIRST option per question — the ``AskUserQuestion`` convention puts
+    the recommended option first — as a list for ``multiSelect``; falls
+    back to a generic "proceed with defaults" text for a question with no
+    options. Keyed by question text (the shape the agent renders by),
+    matching ``expand_free_text_answers``.
+    """
+    out: dict = {}
+    for q in questions:
+        if not isinstance(q, dict):
+            continue
+        key = q.get('question') or q.get('header') or ''
+        if not key:
+            continue
+        options = q.get('options') or []
+        if options:
+            first = options[0]
+            label = (
+                first.get('label', '')
+                if isinstance(first, dict)
+                else str(first)
+            )
+            out[key] = [label] if q.get('multiSelect') else label
+        else:
+            out[key] = 'Proceed with sensible defaults.'
+    return out
+
+
 def expand_free_text_answers(answers: dict, questions: list[dict]) -> dict:
     """Return *answers* with the free-text sentinel expanded.
 

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -163,10 +163,25 @@ validates, and its own remedy is to upload a tab-delimited text file.
 The `.txt` reaches real content validation, which is what you want.
 
 On the upload page, the file input lives in a `kat-file-upload` **open
-shadow root** (light-DOM `input[type=file]` count is 0). Locate the input
-node with `js(...)` (pierce the shadow root) and set the file on it via
-`cdp('DOM.setFileInputFiles', ...)` (see the `browser-use` skill), then
-`click_at_xy` **Submit products**. Amazon processes asynchronously; the batch row on
+shadow root** (light-DOM `input[type=file]` count is 0). Do NOT click the
+"Browse" button (it opens the OS picker you can't drive) and do NOT try
+`file://` navigation. Set the file directly on the input via CDP — get a
+Runtime `objectId` for the shadow-DOM input, then `DOM.setFileInputFiles`
+with the **absolute** `.txt` path:
+
+```bash
+browser-use <<'PY'
+sel = "document.querySelector('kat-file-upload').shadowRoot.querySelector('input[type=file]')"
+obj = cdp('Runtime.evaluate', {'expression': sel, 'returnByValue': False})
+cdp('DOM.setFileInputFiles',
+    {'objectId': obj['result']['objectId'], 'files': ['/tmp/<slug>/listing.txt']})
+print('attached')
+PY
+```
+
+(Full recipe + the plain-input variant: `browser-harness` SKILL.md §
+"Uploading a file".) Then `click_at_xy` **Submit products** and
+`wait_for_load()`. Amazon processes asynchronously; the batch row on
 **Check Upload Status** shows `SKUs successful / submitted` and a
 **Download Processing Summary** link. Save it and parse it:
 

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -106,6 +106,35 @@ print(page_info())
 PY
 ```
 
+## Uploading a file to a web `<input type=file>`
+
+There is **no native upload helper** and a coordinate-click on the
+visible "Browse" button opens the OS file picker (which you can't drive),
+so DO NOT click it. Set the file **directly on the input element via
+CDP** — the one reliable way. Get a Runtime `objectId` for the input,
+then `DOM.setFileInputFiles`:
+
+```bash
+browser-use <<'PY'
+# 1. objectId for the <input type=file>. For a plain input:
+sel = "document.querySelector('input[type=file]')"
+# For an input inside an OPEN shadow root (e.g. Amazon's kat-file-upload,
+# where the light-DOM input count is 0), pierce it:
+# sel = "document.querySelector('kat-file-upload').shadowRoot.querySelector('input[type=file]')"
+obj = cdp('Runtime.evaluate', {'expression': sel, 'returnByValue': False})
+oid = obj['result']['objectId']
+# 2. Attach the file. The path MUST be ABSOLUTE; files is a list.
+cdp('DOM.setFileInputFiles', {'objectId': oid, 'files': ['/abs/path/to/file.txt']})
+print('attached')
+PY
+```
+
+Then submit via the page's own button (`click_at_xy` the real submit
+control, not the browse button) and `wait_for_load()`. If
+`Runtime.evaluate` returns no `objectId`, the selector didn't match
+(wrong shadow root / not yet rendered) — fix the selector; don't fall
+back to clicking Browse or to `file://` navigation (both dead ends).
+
 ## Sessions
 
 - **Default (seller center):** just run `browser-use <<'PY' … PY`. The wrapper

--- a/tests/unit/test_question_answers.py
+++ b/tests/unit/test_question_answers.py
@@ -1,0 +1,63 @@
+"""Server-side AskUserQuestion answer helpers.
+
+``default_answers`` is the auto-answer used when nobody responds within
+the window (unattended/scheduled runs) so the agent proceeds instead of
+hanging (F2). ``expand_free_text_answers`` handles the UI free-text
+sentinel (issue #211).
+"""
+
+import pytest
+
+from app.question_answers import default_answers, expand_free_text_answers
+
+
+@pytest.mark.unit
+class TestDefaultAnswers:
+    def test_first_option_per_question(self):
+        qs = [
+            {
+                'question': 'Which country?',
+                'options': [{'label': 'SA'}, {'label': 'AE'}],
+            },
+        ]
+        assert default_answers(qs) == {'Which country?': 'SA'}
+
+    def test_multiselect_returns_list(self):
+        qs = [
+            {
+                'question': 'Which?',
+                'multiSelect': True,
+                'options': [{'label': 'A'}, {'label': 'B'}],
+            }
+        ]
+        assert default_answers(qs) == {'Which?': ['A']}
+
+    def test_no_options_falls_back_to_text(self):
+        qs = [{'question': 'Free?', 'options': []}]
+        assert default_answers(qs) == {
+            'Free?': 'Proceed with sensible defaults.'
+        }
+
+    def test_header_used_when_no_question_text(self):
+        qs = [{'header': 'Scope', 'options': [{'label': 'X'}]}]
+        assert default_answers(qs) == {'Scope': 'X'}
+
+    def test_empty_and_malformed_ignored(self):
+        assert default_answers([]) == {}
+        assert (
+            default_answers(['not a dict', {}, {'options': [{'label': 'x'}]}])
+            == {}
+        )
+
+
+@pytest.mark.unit
+class TestExpandFreeText:
+    def test_sentinel_expands_to_each_question(self):
+        qs = [{'question': 'Q1'}, {'question': 'Q2'}]
+        out = expand_free_text_answers({'_free_text': 'go'}, qs)
+        assert out == {'Q1': 'go', 'Q2': 'go'}
+
+    def test_no_sentinel_unchanged(self):
+        assert expand_free_text_answers({'Q1': 'A'}, [{'question': 'Q1'}]) == {
+            'Q1': 'A'
+        }


### PR DESCRIPTION
## F1 + F2 — unblock the listing-upload and unattended-question stalls

Two follow-ups from Phase 2 (PR #58), which surfaced these live. **Stacked on
#58** (base = `feature/dod-phase2-listing-reports`); retarget to `main` after #58 merges.

### F2 — never hang on `AskUserQuestion` (code) ✅ live-proven
An agent that calls `AskUserQuestion` in an **unattended** run blocked the
task forever (no human to click). Now the hook waits a bounded window,
then **auto-answers with server-side defaults** so the agent proceeds.
- `question_answers.default_answers()` — first option per question (list
  for `multiSelect`; generic text when no options). Keyed by question text.
- `claude_backend_hooks._handle_ask_user_question` — `asyncio.wait_for`
  the answer event; on timeout, auto-answer + continue.
- `claude_backend_utils.resolve_question_answer_timeout()` — scheduled
  (unattended) tasks get a short window (10s), interactive tasks 120s.
- `config`: `QUESTION_ANSWER_TIMEOUT_SECONDS` / `_SCHEDULED_SECONDS`.
- 7 unit tests (`test_question_answers.py`).

**Live e2e (debug-store, placeholder data):** a noon-export task hit its
date-range question and the log shows
`AskUserQuestion auto-answered … after 120s with defaults … '最近 30 天 (Recommended)'`
— the task advanced past the question instead of stalling (the exact
pre-fix hang, resolved).

### F1 — file-upload recipe (skill doc)
The listing flow flailed on the flat-file upload. Root cause: the browser
already exposes raw `cdp('DOM.setFileInputFiles', …)`, but the doc was
vague. Added the exact recipe — `Runtime.evaluate → objectId →
DOM.setFileInputFiles`, shadow-DOM pierce, absolute path, don't click
Browse / no `file://` — to `browser-harness` SKILL.md and the
`amazon-listing` upload step. No infra change (helpers live upstream).

**Note:** a full live listing create-run wasn't completed — a weak model
(deepseek) couldn't drive Amazon's pre-upload create UI (product-type
search + template inspect) to reach the upload step. That's orthogonal
create-flow friction, not an F1 defect; the recipe's correctness is the
standard CDP call and is reviewable as-is. Tracked as a follow-up (run
this e2e on a capable model / tighten pre-upload guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
