### PR TITLE
docs(browser): exact DOM.setFileInputFiles file-upload recipe (F1)

### DIFF
--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -163,10 +163,25 @@ validates, and its own remedy is to upload a tab-delimited text file.
 The `.txt` reaches real content validation, which is what you want.
 
 On the upload page, the file input lives in a `kat-file-upload` **open
-shadow root** (light-DOM `input[type=file]` count is 0). Locate the input
-node with `js(...)` (pierce the shadow root) and set the file on it via
-`cdp('DOM.setFileInputFiles', ...)` (see the `browser-use` skill), then
-`click_at_xy` **Submit products**. Amazon processes asynchronously; the batch row on
+shadow root** (light-DOM `input[type=file]` count is 0). Do NOT click the
+"Browse" button (it opens the OS picker you can't drive) and do NOT try
+`file://` navigation. Set the file directly on the input via CDP — get a
+Runtime `objectId` for the shadow-DOM input, then `DOM.setFileInputFiles`
+with the **absolute** `.txt` path:
+
+```bash
+browser-use <<'PY'
+sel = "document.querySelector('kat-file-upload').shadowRoot.querySelector('input[type=file]')"
+obj = cdp('Runtime.evaluate', {'expression': sel, 'returnByValue': False})
+cdp('DOM.setFileInputFiles',
+    {'objectId': obj['result']['objectId'], 'files': ['/tmp/<slug>/listing.txt']})
+print('attached')
+PY
+```
+
+(Full recipe + the plain-input variant: `browser-harness` SKILL.md §
+"Uploading a file".) Then `click_at_xy` **Submit products** and
+`wait_for_load()`. Amazon processes asynchronously; the batch row on
 **Check Upload Status** shows `SKUs successful / submitted` and a
 **Download Processing Summary** link. Save it and parse it:
 

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -106,6 +106,35 @@ print(page_info())
 PY
 ```
 
+## Uploading a file to a web `<input type=file>`
+
+There is **no native upload helper** and a coordinate-click on the
+visible "Browse" button opens the OS file picker (which you can't drive),
+so DO NOT click it. Set the file **directly on the input element via
+CDP** — the one reliable way. Get a Runtime `objectId` for the input,
+then `DOM.setFileInputFiles`:
+
+```bash
+browser-use <<'PY'
+# 1. objectId for the <input type=file>. For a plain input:
+sel = "document.querySelector('input[type=file]')"
+# For an input inside an OPEN shadow root (e.g. Amazon's kat-file-upload,
+# where the light-DOM input count is 0), pierce it:
+# sel = "document.querySelector('kat-file-upload').shadowRoot.querySelector('input[type=file]')"
+obj = cdp('Runtime.evaluate', {'expression': sel, 'returnByValue': False})
+oid = obj['result']['objectId']
+# 2. Attach the file. The path MUST be ABSOLUTE; files is a list.
+cdp('DOM.setFileInputFiles', {'objectId': oid, 'files': ['/abs/path/to/file.txt']})
+print('attached')
+PY
+```
+
+Then submit via the page's own button (`click_at_xy` the real submit
+control, not the browse button) and `wait_for_load()`. If
+`Runtime.evaluate` returns no `objectId`, the selector didn't match
+(wrong shadow root / not yet rendered) — fix the selector; don't fall
+back to clicking Browse or to `file://` navigation (both dead ends).
+
 ## Sessions
 
 - **Default (seller center):** just run `browser-use <<'PY' … PY`. The wrapper


### PR DESCRIPTION
## F1 — file-upload recipe (skill doc)

The listing flat-file upload flailed because the doc was vague — but the browser already exposes raw `cdp('DOM.setFileInputFiles', …)`. Documents the exact recipe (`Runtime.evaluate → objectId → setFileInputFiles`, shadow-DOM pierce, absolute path, do NOT click Browse / no `file://`) in `browser-harness` SKILL.md + the `amazon-listing` upload step. No code change.

**F2 was reverted:** `AskUserQuestion` is meant to block until a human answers (human-in-the-loop); my earlier e2e stall was a test-harness error (should answer via `/questions/answer`, not `/messages`), not a product bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)