### PR TITLE
fix(amazon-listing): vision-free flat-file CRUD — create+delete a live variation family

### DIFF
--- a/app/skills_v2/MANIFEST.txt
+++ b/app/skills_v2/MANIFEST.txt
@@ -21,6 +21,7 @@ amazon-listing/SKILL.md
 amazon-listing/references/template-round-trip.md
 amazon-listing/references/1688-sourcing.md
 amazon-listing/scripts/listing_bulk.py
+amazon-listing/scripts/marketplace_ids.py
 amazon-listing/scripts/ocr_1688.py
 amazon-listing/requirements.txt
 amazon-invoice/SKILL.md

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -139,13 +139,18 @@ a family that the parent shows **"Variations (N)"**.
     so the ASIN can be minted.
   Either way, set `update_delete` on **every** row including children —
   never leave a child's operation blank.
-- **Offer/price is per-marketplace, and only `our_price` matters.** The
-  buyable offer is one block per marketplace:
-  `purchasable_offer[marketplace_id=<MKT>]#1.our_price#1.schedule#1.value_with_tax`
-  (+ `fulfillment_availability#1.quantity`). Of the many price columns
-  only `our_price` is needed. Fill the block for the marketplace you're
-  selling on; **verify it in THAT marketplace's Pricing view** — the feed
-  "N/N successful" count does not reflect price, and quantity can apply
+- **Offer/price is per-marketplace — set `our_price` + a top-level
+  `marketplace`, don't hand-pick the column.** A multi-marketplace
+  template has one `purchasable_offer[marketplace_id=<MKT>]` block per
+  marketplace and marks the account's *home* marketplace's block Required
+  — so hand-picking a column silently puts the price in the wrong
+  marketplace, creating an ASIN with **no live offer** ("Missing offer",
+  never live) even though the feed says success. Instead give the spec a
+  top-level `"marketplace": "<CC>"` (the country you're listing on) and a
+  bare `"our_price"` on each child; `fill` routes it to the right block
+  (+ `fulfillment_availability#1.quantity`). **Verify it in THAT
+  marketplace's Pricing view** — the feed "N/N successful" count does not
+  reflect price, and quantity can apply
   while price shows `--` if you set a different marketplace's column.
 - **A multi-marketplace account's template bundles every marketplace's
   offer columns** (e.g. a Europe account yields both SA + AE columns even

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -144,7 +144,12 @@ fields.
 > block creates an **ASIN with no live offer** — the listing sits in
 > **"Missing offer"** and never goes live, even though the feed reports
 > success. (Pass `--marketplace SA` to `fill` as an alternative to the
-> top-level key.) Omit `main_image_url` when the only image you have is a
+> top-level key.) Any Amazon country code works (`US`, `UK`, `DE`, `JP`,
+> `AE`, `SA`, …); a raw marketplace id is also accepted. If you omit
+> `marketplace` entirely and the template has offer columns for exactly
+> one marketplace, `fill` auto-detects it from the template — so a
+> marketplace not in the built-in table still works. Omit `main_image_url`
+> when the only image you have is a
 > hotlinked supplier URL. Give each child its category's full required
 > set, not just the differentiator (see the Parent-vs-Child note below).
 

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -208,6 +208,24 @@ parent-child relationship** is an update: re-submit the child with the
 new `parent_sku` / `variation_theme` (or clear `parent_sku` and set
 `parent_child` appropriately to detach).
 
+> **Deleting a variation family — first ENUMERATE every SKU (don't guess).**
+> You usually know only the parent SKU (or its title). Do NOT try to
+> expand the parent's "Variations (N)" in Manage Inventory to read the
+> child SKUs — the New-Seller-Central inventory grid is a **virtualized
+> table** whose child rows aren't reachable from the DOM, and it will
+> waste the whole run. Instead get the authoritative SKU list from a
+> **fresh All Listings Report**: Seller Central → **Reports → Inventory
+> Reports → All Listings Report → Request** (a few min), then download the
+> TSV to `~/.vibe-seller/downloads/<slug>/`. It lists **every** SKU
+> (parent + children) with `seller-sku`, `asin`, and the parent linkage.
+> Grep the family (by your SKU prefix, or the parent ASIN),
+> collect all its SKUs, then delete: a spec with `operation: delete` for
+> **each CHILD first, then the parent** (a parent can't delete while it
+> still has live children). Upload the `.txt`, then verify each SKU is
+> gone (its `skucentral?mSku=<sku>` **redirects** to /myinventory instead
+> of staying). Never rely on a local spec/file from the create step — a
+> delete task is independent and must discover SKUs from the account.
+
 ```bash
 $PY $S/listing_bulk.py fill TEMPLATE.xlsm --spec SPEC.json --out /tmp/<slug>/out.xlsm
 ```

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -39,11 +39,21 @@ and multi-marketplace disables Listing Preferences), then **Generate
 Spreadsheet**. The file lands in `~/.vibe-seller/downloads/<slug>/`
 (a macro-enabled `.xlsm`).
 
-> **Product-Type search gotcha (Beta modal):** the search box is a
-> locked `kat-input` — setting its value via `js(...)` alone does **not**
-> open the candidate list. `click_at_xy` the **search icon** at the right
-> of the input row to trigger the suggestions, then `click_at_xy` the
-> **Select** button on the matched product type.
+> **Getting TO the product-type search (current Beta flow — don't
+> reverse-engineer it):** Spreadsheet → **Download Blank Template** lands
+> on `/product-search/bulk/generate` showing **template cards** (e.g.
+> "List products that are not currently in Amazon's catalog"). The card
+> body text is NOT the button — the clickable control is a **`kat-button`
+> in the card's FOOTER**. Find it via the DOM, not a screenshot:
+> `js` for `kat-card kat-button` → `getBoundingClientRect` → `click_at_xy`
+> (see browser-harness "Locate & click without vision"). That navigates to
+> `/product-search/bulk/generate/add-product`, the product-type search page.
+>
+> **Product-Type search gotcha:** the search box is a locked `kat-input` —
+> setting its value via `js(...)` alone does **not** open the candidate
+> list. Locate and `click_at_xy` the **search icon** (`kat-icon
+> name=search`) at the right of the input row to trigger the suggestions,
+> then `click_at_xy` the **Select** button on the matched product type.
 
 > **The create template generates asynchronously** — "Generate
 > Spreadsheet" does not always land a direct download. If it doesn't

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -112,6 +112,7 @@ fields.
 {
   "product_type": "socks",
   "brand": "ACME",
+  "marketplace": "SA",
   "rows": [
     { "sku": "WIDGET-001", "operation": "create", "parentage": "Parent",
       "variation_theme": "Color",
@@ -128,16 +129,24 @@ fields.
                   "recommended_browse_nodes": "<from Browse data>",
                   "fulfillment_availability#1.fulfillment_channel_code": "DEFAULT",
                   "fulfillment_availability#1.quantity": "100",
-                  "purchasable_offer[marketplace_id=<OWN_MKT>]#1.our_price#1.schedule#1.value_with_tax": "29.00" } }
+                  "our_price": "29.00" } }
   ]
 }
 ```
 
-> Fill only the store's **own** marketplace offer block (one
-> `purchasable_offer[marketplace_id=…]`), and omit `main_image_url` when
-> the only image you have is a hotlinked supplier URL (add images later
-> via the image flow). Give each child its category's full required set,
-> not just the differentiator (see the Parent-vs-Child note below).
+> **Set the offer price with the bare `our_price` key + a top-level
+> `marketplace` (the country you are listing on, matching the
+> seller-central domain — `amazon.sa` → `"SA"`).** `fill` routes the
+> price into `purchasable_offer[marketplace_id=<that marketplace>]` for
+> you. Do NOT hand-pick a `purchasable_offer[marketplace_id=…]` column:
+> a multi-marketplace template marks a *different* marketplace's block
+> Required (the account's home marketplace), and a price in the wrong
+> block creates an **ASIN with no live offer** — the listing sits in
+> **"Missing offer"** and never goes live, even though the feed reports
+> success. (Pass `--marketplace SA` to `fill` as an alternative to the
+> top-level key.) Omit `main_image_url` when the only image you have is a
+> hotlinked supplier URL. Give each child its category's full required
+> set, not just the differentiator (see the Parent-vs-Child note below).
 
 ### Parent vs Child — what goes where
 

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -172,32 +172,47 @@ Excel upload") — the re-save alters the macro-workbook structure Amazon
 validates, and its own remedy is to upload a tab-delimited text file.
 The `.txt` reaches real content validation, which is what you want.
 
-On the upload page, the file input lives in a `kat-file-upload` **open
-shadow root** (light-DOM `input[type=file]` count is 0). Do NOT click the
-"Browse" button (it opens the OS picker you can't drive) and do NOT try
-`file://` navigation. Set the file directly on the input via CDP — get a
-Runtime `objectId` for the shadow-DOM input, then `DOM.setFileInputFiles`
-with the **absolute** `.txt` path:
+On the upload page the file input is a `kat-file-upload` widget. Its
+`shadowRoot input#kat-file-attachment` is an **inert placeholder** — a
+`DOM.setFileInputFiles` on it returns success but leaves `files.length`
+at **0** (verified: objectId, `backendNodeId`, and `getDocument(pierce)`
+all no-op), so DON'T set that node and DON'T click "Browse"/`file://`.
 
-`cdp()` params are **keyword args**, never a positional dict — a dict in
-the 2nd slot binds to `session_id` and the proxy 400s with
-`-32600 "Message may have string 'sessionId' property"`:
+The widget creates its **real** input only when the "Upload file" button
+is clicked with a **trusted** gesture, and hands it to you via
+`Page.fileChooserOpened`. Intercept the chooser, trusted-click the button,
+set the file on that `backendNodeId` (`cdp()` params are keyword args):
 
 ```bash
 browser-use <<'PY'
-sel = "document.querySelector('kat-file-upload').shadowRoot.querySelector('input[type=file]')"
-obj = cdp('Runtime.evaluate', expression=sel, returnByValue=False)  # kwargs!
-cdp('DOM.setFileInputFiles',
-    objectId=obj['result']['objectId'], files=['/tmp/<slug>/listing.txt'])
-print('attached')
+import time
+cdp('Page.enable'); cdp('Page.setInterceptFileChooserDialog', enabled=True)
+drain_events()
+box = js("""var b=document.querySelector('kat-file-upload').shadowRoot.querySelector('#select-file');
+            var r=b.getBoundingClientRect();
+            return {x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)};""")
+click_at_xy(box['x'], box['y'])          # TRUSTED click (not JS .click())
+bnid = None
+for _ in range(8):
+    time.sleep(0.5)
+    for e in drain_events():
+        if 'fileChooserOpened' in str(e.get('method','')): bnid = e['params']['backendNodeId']
+    if bnid: break
+cdp('DOM.setFileInputFiles', backendNodeId=bnid, files=['/tmp/<slug>/listing.txt'])
+cdp('Page.setInterceptFileChooserDialog', enabled=False)
+print('attached to', bnid)
 PY
 ```
 
-(Full recipe + the plain-input variant: `browser-harness` SKILL.md §
-"Uploading a file".) Then `click_at_xy` **Submit products** and
-`wait_for_load()`. Amazon processes asynchronously; the batch row on
-**Check Upload Status** shows `SKUs successful / submitted` and a
-**Download Processing Summary** link. Save it and parse it:
+(Generic recipe + the plain-input Method 1: `browser-harness` SKILL.md §
+"Uploading a file".) Amazon stages the file, showing the filename +
+green **"File Type … (Automatically detected)"** and enabling **Submit
+products**. Confirm via `capture_screenshot()` + Read (the shadow-root
+text carries hidden "unsuccessful" strings even on success — don't trust
+it). Then `click_at_xy` **Submit products** and `wait_for_load()`. Amazon
+processes asynchronously; the batch row on **Check Upload Status** shows
+`SKUs successful / submitted` and a **Download Processing Summary** link.
+Save it and parse it:
 
 ```bash
 $PY $S/listing_bulk.py parse-feedback /tmp/<slug>/processing-summary.xlsm

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -49,11 +49,36 @@ Spreadsheet**. The file lands in `~/.vibe-seller/downloads/<slug>/`
 > (see browser-harness "Locate & click without vision"). That navigates to
 > `/product-search/bulk/generate/add-product`, the product-type search page.
 >
-> **Product-Type search gotcha:** the search box is a locked `kat-input` —
-> setting its value via `js(...)` alone does **not** open the candidate
-> list. Locate and `click_at_xy` the **search icon** (`kat-icon
-> name=search`) at the right of the input row to trigger the suggestions,
-> then `click_at_xy` the **Select** button on the matched product type.
+> **Product-Type search gotcha:** the search box is a `kat-input` whose
+> real `<input>` is in its shadow root, and Amazon's search only fires on
+> **input/change events** — a bare `value=` (or `kat-input.value=`) sets
+> the text but dispatches nothing, so the candidate list never opens. You
+> MUST set the value with the **native setter on the inner input** and then
+> **dispatch `input` + `change` with `composed:true`** (to cross the shadow
+> boundary); poking React's `_valueTracker` helps too. Then click the
+> search icon and the **Select** button. Verified recipe:
+>
+> ```bash
+> browser-use <<'PY'
+> import time
+> js(r"""
+>   var inp = document.querySelector('kat-input').shadowRoot.querySelector('input');
+>   var set = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set;
+>   set.call(inp, 'sock');                                   // product-type query
+>   inp.dispatchEvent(new Event('input',  {bubbles:true, composed:true}));
+>   inp.dispatchEvent(new Event('change', {bubbles:true, composed:true}));
+>   if (inp._valueTracker) inp._valueTracker.setValue('sock');
+> """)
+> time.sleep(2)   # async suggestions
+> # then locate the matched type's Select button via the DOM and click_at_xy it
+> print(js(r"""return [].slice.call(document.querySelectorAll('kat-button'))
+>   .map(function(b){var r=b.getBoundingClientRect();
+>     return {t:(b.innerText||'').trim().slice(0,20), x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)};})
+>   .filter(function(e){return e.t;});"""))
+> PY
+> ```
+> (Clicking the `kat-icon name=search` icon alone, without the events, is
+> what makes runs flail here — don't rely on it.)
 
 > **The create template generates asynchronously** — "Generate
 > Spreadsheet" does not always land a direct download. If it doesn't

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -148,6 +148,27 @@ fields.
 > hotlinked supplier URL. Give each child its category's full required
 > set, not just the differentiator (see the Parent-vs-Child note below).
 
+> **Apparel (socks, clothing, …) — the full `apparel_size` composite is
+> required on EVERY row, parent included.** Verified live: a socks
+> variation only goes live when each row (parent + children) carries the
+> WHOLE size composite — `apparel_size_system`, `apparel_size_class`,
+> `apparel_size`, `apparel_body_type`, `apparel_height_type` — each a
+> valid enum from the template (e.g. system `UAE/KSA`, class `Alpha`,
+> size `One Size`, body/height `Regular`). Miss any one and the report
+> says *"the field 'height_type'/'body_type' for attribute 'Apparel Size'
+> does not have enough values"* (parent) or *"A value is required for
+> apparel_body_type"* (child) — and nothing goes live. `fill` auto-adds
+> `relationship_type: Variation` to every variation row (a child without
+> it errors `relationship_type = null` and never creates), so you don't
+> hand-write it. **A brand-new variation family often needs two passes:**
+> the parent creates first; the children attach on a re-upload. The feed
+> "N/N successful" count is NOT liveness — always confirm on **Manage
+> Inventory** that the parent shows **Variations (N)** and each child has
+> a real ASIN. Read the processing report by opening **Check Upload
+> Status**, screenshotting to find your batch's **Download Processing
+> Summary** button, then `parse-feedback` (it reads the cell-comment
+> errors).
+
 ### Parent vs Child — what goes where
 
 - **Parent** row: shared catalogue data only (product type, brand,

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -179,12 +179,16 @@ shadow root** (light-DOM `input[type=file]` count is 0). Do NOT click the
 Runtime `objectId` for the shadow-DOM input, then `DOM.setFileInputFiles`
 with the **absolute** `.txt` path:
 
+`cdp()` params are **keyword args**, never a positional dict — a dict in
+the 2nd slot binds to `session_id` and the proxy 400s with
+`-32600 "Message may have string 'sessionId' property"`:
+
 ```bash
 browser-use <<'PY'
 sel = "document.querySelector('kat-file-upload').shadowRoot.querySelector('input[type=file]')"
-obj = cdp('Runtime.evaluate', {'expression': sel, 'returnByValue': False})
+obj = cdp('Runtime.evaluate', expression=sel, returnByValue=False)  # kwargs!
 cdp('DOM.setFileInputFiles',
-    {'objectId': obj['result']['objectId'], 'files': ['/tmp/<slug>/listing.txt']})
+    objectId=obj['result']['objectId'], files=['/tmp/<slug>/listing.txt'])
 print('attached')
 PY
 ```

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -86,14 +86,10 @@ PRODUCT_TYPE_FIELD = 'feed_product_type'
 BRAND_FIELD = 'brand_name'
 
 # Marketplace (country) -> Amazon marketplace id. A multi-marketplace
-# template carries a separate `purchasable_offer[marketplace_id=<id>]`
-# block PER marketplace the account sells on; the price MUST go in the
-# block for the marketplace you are listing on, or the product is created
-# ASIN-only and the listing sits in "Missing offer" (a draft, never live).
-# The agent only knows the country (from the seller-central domain, e.g.
-# amazon.sa -> SA), so we resolve the id here instead of trusting it to
-# hand-pick a raw id (which is exactly how a run put the SA price into the
-# UAE column and never went live).
+# template has a `purchasable_offer[marketplace_id=<id>]` block per
+# marketplace; the price MUST go in the block for the one you're listing
+# on, or the product is ASIN-only ("Missing offer", never live). The agent
+# knows only the country (from the seller-central domain), so resolve here.
 MARKETPLACE_IDS = {
     'SA': 'A17E79C6D8DWNP',  # Saudi Arabia  (amazon.sa)
     'AE': 'A2VIGQ35RCS4UG',  # UAE           (amazon.ae)
@@ -105,10 +101,8 @@ MARKETPLACE_IDS = {
     'DE': 'A1PA6795UKMFR9',  # Germany       (amazon.de)
 }
 
-# Bare offer shorthand -> the marketplace-scoped column template. The
-# agent supplies `our_price` on a child row plus a top-level
-# `marketplace`; we expand it to the exact column for that marketplace so
-# it can never land in the wrong block. `{id}` is filled per-marketplace.
+# Bare `our_price` + top-level `marketplace` -> the exact marketplace-
+# scoped column, so the price can never land in the wrong block.
 _OUR_PRICE_TEMPLATE = (
     'purchasable_offer[marketplace_id={id}]#1.our_price#1.schedule'
     '#1.value_with_tax'
@@ -409,58 +403,40 @@ def _resolve_marketplace_id(marketplace):
 
 
 def _route_offer_price(fields, cols, mkt_id, i, sku, warnings):
-    """Place the child offer price in the TARGET marketplace's column.
+    """Route a bare ``our_price`` to the TARGET marketplace's offer column.
 
-    Expands a bare ``our_price``/``price`` shorthand into
-    ``purchasable_offer[marketplace_id=<mkt_id>]#1.our_price...`` and flags
-    a price already written to a *different* marketplace's block (the
-    "listed but Missing offer / never live" trap). Mutates ``fields``.
+    Expands ``our_price``/``price`` into
+    ``purchasable_offer[marketplace_id=<mkt_id>]#1.our_price...``. Explicit
+    full offer columns are left exactly as written (no silent move); we
+    only WARN when the target marketplace ends up with no price -- the
+    "Missing offer / never live" trap. Mutates ``fields``.
     """
+    target_col = _OUR_PRICE_TEMPLATE.format(id=mkt_id) if mkt_id else None
     shorthand = next((k for k in _OFFER_PRICE_SHORTHANDS if k in fields), None)
-    # A full offer-price column aimed at a DIFFERENT marketplace than the
-    # target -- only meaningful once we know the target. When no target is
-    # given, an explicit full column is left as-is (backward compatible).
-    misplaced = (
-        [
-            k
-            for k in fields
-            if k.startswith('purchasable_offer[marketplace_id=')
-            and '.our_price' in k
-            and f'marketplace_id={mkt_id}]' not in k
-        ]
-        if mkt_id is not None
-        else []
-    )
-    if not shorthand and not misplaced:
-        return  # parent rows / rows without a price to route.
-    if mkt_id is None:
-        # Only reachable via a bare shorthand, which needs a target.
-        raise SystemExit(
-            f"error: row {i} sku={sku} sets a price but the spec has no "
-            f"'marketplace' -- add e.g. \"marketplace\": \"SA\" so the offer "
-            f'lands in the right block (the marketplace you are listing on)'
-        )
-    target_col = _OUR_PRICE_TEMPLATE.format(id=mkt_id)
-    if target_col not in cols:
-        raise SystemExit(
-            f'error: row {i} sku={sku}: this template has no offer column '
-            f'for marketplace_id={mkt_id} -- the account may not sell on that '
-            f'marketplace, or you downloaded the template from the wrong site'
-        )
     if shorthand:
+        if mkt_id is None:
+            raise SystemExit(
+                f"error: row {i} sku={sku} sets a price but the spec has no "
+                f"'marketplace' -- add e.g. \"marketplace\": \"SA\""
+            )
+        if target_col not in cols:
+            raise SystemExit(
+                f'error: row {i} sku={sku}: template has no offer column for '
+                f'marketplace_id={mkt_id} (account may not sell there)'
+            )
         fields[target_col] = fields.pop(shorthand)
-    for k in misplaced:
-        # Re-home the price to the target marketplace rather than leave it
-        # in the wrong block, where it would create an ASIN with no live
-        # offer on the marketplace being listed.
-        warnings.append(
-            f'row {i} sku={sku}: offer price was set on {k} but you are '
-            f'listing on marketplace_id={mkt_id} -- moved it to the target '
-            f'block (a price in the wrong marketplace => Missing offer, '
-            f'never live)'
-        )
-        fields.setdefault(target_col, fields[k])
-        del fields[k]
+    if mkt_id is not None and target_col not in fields:
+        other = [
+            k for k in fields
+            if k.startswith('purchasable_offer[marketplace_id=')
+            and '.our_price' in k and f'marketplace_id={mkt_id}]' not in k
+        ]
+        if other:
+            warnings.append(
+                f'row {i} sku={sku}: offer price is on {other[0]} but you are '
+                f'listing on marketplace_id={mkt_id}, which has NO offer -- the '
+                f'listing will be "Missing offer" (never live). Use "our_price".'
+            )
 
 
 def cmd_fill(args):
@@ -644,14 +620,69 @@ def _template_cell_errors(path):
         wb.close()
 
 
+def _report_comment_errors(path):
+    """Per-SKU errors from a processing summary's Template-tab CELL COMMENTS.
+
+    Amazon writes each error/warning as a cell comment on the Template tab
+    (orange = error, yellow = warning) keyed to the offending field's
+    column -- NOT as a table row. The comment is the only reliable error
+    source; a table scan lands on the localized instructions instead.
+    Returns [(sku, field, severity, message)].
+    """
+    if not path.lower().endswith(('.xlsm', '.xlsx')):
+        return []
+    try:
+        wb = openpyxl.load_workbook(path)
+    except Exception:
+        return []
+    if TEMPLATE_SHEET not in wb.sheetnames:
+        return []
+    ws = wb[TEMPLATE_SHEET]
+    try:
+        hdr = _find_header_row(ws)
+    except ValueError:
+        return []
+    names = [c.value for c in ws[hdr]]
+    if IDENTITY_FIELD not in names:
+        return []
+    sku_col = names.index(IDENTITY_FIELD)
+    out = []
+    for r in range(hdr + 1, ws.max_row + 1):
+        sku = ws.cell(r, sku_col + 1).value
+        if not sku:
+            continue
+        for c in ws[r]:
+            if not (c.comment and c.comment.text.strip()):
+                continue
+            field = names[c.column - 1] if c.column - 1 < len(names) else ''
+            text = ' '.join(c.comment.text.split())
+            sev = 'error' if text.lstrip().upper().startswith('ERROR') else (
+                'warning' if 'WARNING' in text[:20].upper() else 'info'
+            )
+            out.append((str(sku), str(field or ''), sev, text[:400]))
+    return out
+
+
 def cmd_parse_feedback(args):
     """Summarise Amazon's processing report: per-SKU errors/warnings.
 
-    Report layouts vary (a summary header block then a table). We locate
-    the table header by finding a row that names an error/SKU column,
-    then emit each data row's SKU + type + message. Falls back to
-    printing every row that mentions 'error' if no header is found.
+    Prefer the Template-tab cell comments (the authoritative per-field
+    error source); fall back to a table scan for report layouts that use
+    one. A parent SKU's errors block its children -- fix the parent first.
     """
+    comment_errs = _report_comment_errors(args.file)
+    if comment_errs:
+        n_err = sum(1 for _s in comment_errs if _s[2] == 'error')
+        n_warn = sum(1 for _s in comment_errs if _s[2] == 'warning')
+        for sku, field, sev, msg in comment_errs:
+            print(f'  [{sev}] sku={sku} field={field}: {msg}')
+        print(f'\n{n_err} error(s), {n_warn} warning(s) across '
+              f'{len({s for s, *_ in comment_errs})} SKU(s).')
+        if n_err:
+            print('Fix ALL errors (parent first) and re-upload; a SKU with '
+                  'any error is NOT created (feed "successful" != live).')
+        return
+
     rows = list(_iter_report_rows(args.file))
     if not rows:
         raise SystemExit('error: empty report')

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -374,6 +374,10 @@ def _row_fields(spec_row, top):
         out['parent_child'] = spec_row['parentage']
     if spec_row.get('variation_theme'):
         out['variation_theme'] = spec_row['variation_theme']
+    # Any variation row MUST carry relationship_type or a child errors
+    # "relationship_type = null" and never creates. Derive it (explicit wins).
+    if spec_row.get('parentage') or spec_row.get('variation_theme'):
+        out.setdefault('relationship_type', 'Variation')
     if spec_row.get('asin'):
         out['external_product_id'] = spec_row['asin']
         out.setdefault('external_product_id_type', 'asin')

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -85,6 +85,36 @@ IDENTITY_FIELD = 'item_sku'
 PRODUCT_TYPE_FIELD = 'feed_product_type'
 BRAND_FIELD = 'brand_name'
 
+# Marketplace (country) -> Amazon marketplace id. A multi-marketplace
+# template carries a separate `purchasable_offer[marketplace_id=<id>]`
+# block PER marketplace the account sells on; the price MUST go in the
+# block for the marketplace you are listing on, or the product is created
+# ASIN-only and the listing sits in "Missing offer" (a draft, never live).
+# The agent only knows the country (from the seller-central domain, e.g.
+# amazon.sa -> SA), so we resolve the id here instead of trusting it to
+# hand-pick a raw id (which is exactly how a run put the SA price into the
+# UAE column and never went live).
+MARKETPLACE_IDS = {
+    'SA': 'A17E79C6D8DWNP',  # Saudi Arabia  (amazon.sa)
+    'AE': 'A2VIGQ35RCS4UG',  # UAE           (amazon.ae)
+    'EG': 'ARBP9OOSHTCHU',   # Egypt         (amazon.eg)
+    'AU': 'A39IBJ37TRP1C6',  # Australia     (amazon.com.au)
+    'US': 'ATVPDKIKX0DER',   # United States (amazon.com)
+    'MX': 'A1AM78C64UM0Y8',  # Mexico        (amazon.com.mx)
+    'UK': 'A1F83G8C2ARO7P',  # United Kingdom(amazon.co.uk)
+    'DE': 'A1PA6795UKMFR9',  # Germany       (amazon.de)
+}
+
+# Bare offer shorthand -> the marketplace-scoped column template. The
+# agent supplies `our_price` on a child row plus a top-level
+# `marketplace`; we expand it to the exact column for that marketplace so
+# it can never land in the wrong block. `{id}` is filled per-marketplace.
+_OUR_PRICE_TEMPLATE = (
+    'purchasable_offer[marketplace_id={id}]#1.our_price#1.schedule'
+    '#1.value_with_tax'
+)
+_OFFER_PRICE_SHORTHANDS = ('our_price', 'price', 'standard_price')
+
 # A Parent (relationship) row carries only the shared catalogue data;
 # the offer, stock, images and product-id live on the Child rows. So a
 # Parent legitimately omits these even when the template marks them
@@ -357,6 +387,82 @@ def _row_fields(spec_row, top):
     return {k: v for k, v in out.items() if v not in (None, '')}
 
 
+def _resolve_marketplace_id(marketplace):
+    """Accept a country code ('SA') or a raw marketplace id; return the id.
+
+    Returns None when nothing was supplied. Raises on an unrecognised
+    country code so a typo fails loudly instead of silently placing the
+    offer nowhere.
+    """
+    if not marketplace:
+        return None
+    m = str(marketplace).strip()
+    if m.upper() in MARKETPLACE_IDS:
+        return MARKETPLACE_IDS[m.upper()]
+    if m in MARKETPLACE_IDS.values():  # already a raw id
+        return m
+    codes = ', '.join(sorted(MARKETPLACE_IDS))
+    raise SystemExit(
+        f'error: unknown marketplace {marketplace!r} -- use a country code '
+        f'({codes}) or a raw marketplace id'
+    )
+
+
+def _route_offer_price(fields, cols, mkt_id, i, sku, warnings):
+    """Place the child offer price in the TARGET marketplace's column.
+
+    Expands a bare ``our_price``/``price`` shorthand into
+    ``purchasable_offer[marketplace_id=<mkt_id>]#1.our_price...`` and flags
+    a price already written to a *different* marketplace's block (the
+    "listed but Missing offer / never live" trap). Mutates ``fields``.
+    """
+    shorthand = next((k for k in _OFFER_PRICE_SHORTHANDS if k in fields), None)
+    # A full offer-price column aimed at a DIFFERENT marketplace than the
+    # target -- only meaningful once we know the target. When no target is
+    # given, an explicit full column is left as-is (backward compatible).
+    misplaced = (
+        [
+            k
+            for k in fields
+            if k.startswith('purchasable_offer[marketplace_id=')
+            and '.our_price' in k
+            and f'marketplace_id={mkt_id}]' not in k
+        ]
+        if mkt_id is not None
+        else []
+    )
+    if not shorthand and not misplaced:
+        return  # parent rows / rows without a price to route.
+    if mkt_id is None:
+        # Only reachable via a bare shorthand, which needs a target.
+        raise SystemExit(
+            f"error: row {i} sku={sku} sets a price but the spec has no "
+            f"'marketplace' -- add e.g. \"marketplace\": \"SA\" so the offer "
+            f'lands in the right block (the marketplace you are listing on)'
+        )
+    target_col = _OUR_PRICE_TEMPLATE.format(id=mkt_id)
+    if target_col not in cols:
+        raise SystemExit(
+            f'error: row {i} sku={sku}: this template has no offer column '
+            f'for marketplace_id={mkt_id} -- the account may not sell on that '
+            f'marketplace, or you downloaded the template from the wrong site'
+        )
+    if shorthand:
+        fields[target_col] = fields.pop(shorthand)
+    for k in misplaced:
+        # Re-home the price to the target marketplace rather than leave it
+        # in the wrong block, where it would create an ASIN with no live
+        # offer on the marketplace being listed.
+        warnings.append(
+            f'row {i} sku={sku}: offer price was set on {k} but you are '
+            f'listing on marketplace_id={mkt_id} -- moved it to the target '
+            f'block (a price in the wrong marketplace => Missing offer, '
+            f'never live)'
+        )
+        fields.setdefault(target_col, fields[k])
+        del fields[k]
+
+
 def cmd_fill(args):
     with open(args.spec, encoding='utf-8') as fh:
         spec = json.load(fh)
@@ -375,6 +481,12 @@ def cmd_fill(args):
     valid = _load_valid_values(wb)
     case = _valid_value_case(wb)
 
+    # The offer price is per-marketplace; resolve the target once (CLI
+    # --marketplace wins, else spec's top-level "marketplace").
+    mkt_id = _resolve_marketplace_id(
+        getattr(args, 'marketplace', None) or spec.get('marketplace')
+    )
+
     unknown_fields = set()
     warnings = []
     write_at = header_row + 1
@@ -390,6 +502,11 @@ def cmd_fill(args):
         sku = fields.get(IDENTITY_FIELD)
         if not sku:
             raise SystemExit(f'error: row {i} has no sku')
+
+        # Route the child offer price into the marketplace being listed on,
+        # so it can't land in the wrong `purchasable_offer` block (which
+        # creates an ASIN-only listing stuck in "Missing offer").
+        _route_offer_price(fields, cols, mkt_id, i, sku, warnings)
 
         # Enum validation: reject an invalid operation-family token hard;
         # warn (never fail) on other enums so an unseen-but-valid token
@@ -628,6 +745,12 @@ def main():
     p.add_argument('file', help='the category template (.xlsm)')
     p.add_argument('--spec', required=True, help='JSON spec of rows')
     p.add_argument('--out', required=True, help='output .xlsm path')
+    p.add_argument(
+        '--marketplace',
+        help='country code (SA/AE/AU/…) or raw marketplace id you are '
+        'listing on; routes the offer price to the right block. Overrides '
+        "the spec's top-level \"marketplace\".",
+    )
     p.set_defaults(func=cmd_fill)
 
     p = sub.add_parser('parse-feedback', help='summarise a processing report')

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -53,6 +53,7 @@ Requires: openpyxl.
 import argparse
 import csv
 import json
+import os
 import shutil
 import sys
 
@@ -61,6 +62,15 @@ try:
 except ImportError:
     sys.exit('error: openpyxl is required (pip install openpyxl)')
 
+# Global marketplace table + resolution, kept in a sibling data module.
+# The script dir is on sys.path when run as a CLI; add it for path-based
+# imports (tests) too.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from marketplace_ids import (  # noqa: E402,F401
+    MARKETPLACE_IDS,  # re-exported for callers/tests
+    ids_in_template as _marketplace_ids_in_template,
+    resolve as _resolve_marketplace_id,
+)
 
 # The Template sheet holds the flat file. Metadata lives in siblings.
 TEMPLATE_SHEET = 'Template'
@@ -85,19 +95,10 @@ IDENTITY_FIELD = 'item_sku'
 PRODUCT_TYPE_FIELD = 'feed_product_type'
 BRAND_FIELD = 'brand_name'
 
-# Marketplace (country) -> Amazon marketplace id. Price MUST go in the
-# `purchasable_offer[marketplace_id=<id>]` block for the marketplace being
-# listed on, else the product is ASIN-only ("Missing offer", never live).
-MARKETPLACE_IDS = {
-    'SA': 'A17E79C6D8DWNP',  # Saudi Arabia  (amazon.sa)
-    'AE': 'A2VIGQ35RCS4UG',  # UAE           (amazon.ae)
-    'EG': 'ARBP9OOSHTCHU',  # Egypt         (amazon.eg)
-    'AU': 'A39IBJ37TRP1C6',  # Australia     (amazon.com.au)
-    'US': 'ATVPDKIKX0DER',  # United States (amazon.com)
-    'MX': 'A1AM78C64UM0Y8',  # Mexico        (amazon.com.mx)
-    'UK': 'A1F83G8C2ARO7P',  # United Kingdom(amazon.co.uk)
-    'DE': 'A1PA6795UKMFR9',  # Germany       (amazon.de)
-}
+# Price MUST go in the `purchasable_offer[marketplace_id=<id>]` block for
+# the marketplace being listed on, else the product is ASIN-only ("Missing
+# offer", never live). The full country->id table and the resolver live in
+# `marketplace_ids`; the id is read straight off the template's columns.
 
 # Bare `our_price` + top-level `marketplace` -> the exact marketplace-
 # scoped column, so the price can never land in the wrong block.
@@ -381,27 +382,6 @@ def _row_fields(spec_row, top):
     return {k: v for k, v in out.items() if v not in (None, '')}
 
 
-def _resolve_marketplace_id(marketplace):
-    """Accept a country code ('SA') or a raw marketplace id; return the id.
-
-    Returns None when nothing was supplied. Raises on an unrecognised
-    country code so a typo fails loudly instead of silently placing the
-    offer nowhere.
-    """
-    if not marketplace:
-        return None
-    m = str(marketplace).strip()
-    if m.upper() in MARKETPLACE_IDS:
-        return MARKETPLACE_IDS[m.upper()]
-    if m in MARKETPLACE_IDS.values():  # already a raw id
-        return m
-    codes = ', '.join(sorted(MARKETPLACE_IDS))
-    raise SystemExit(
-        f'error: unknown marketplace {marketplace!r} -- use a country code '
-        f'({codes}) or a raw marketplace id'
-    )
-
-
 def _route_offer_price(fields, cols, mkt_id, i, sku, warnings):
     """Route a bare ``our_price`` to the TARGET marketplace's offer column.
 
@@ -460,9 +440,11 @@ def cmd_fill(args):
     case = _valid_value_case(wb)
 
     # The offer price is per-marketplace; resolve the target once (CLI
-    # --marketplace wins, else spec's top-level "marketplace").
+    # --marketplace wins, else spec's top-level "marketplace", else the
+    # template itself if it names exactly one marketplace).
     mkt_id = _resolve_marketplace_id(
-        getattr(args, 'marketplace', None) or spec.get('marketplace')
+        getattr(args, 'marketplace', None) or spec.get('marketplace'),
+        _marketplace_ids_in_template(cols),
     )
 
     unknown_fields = set()

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -85,17 +85,15 @@ IDENTITY_FIELD = 'item_sku'
 PRODUCT_TYPE_FIELD = 'feed_product_type'
 BRAND_FIELD = 'brand_name'
 
-# Marketplace (country) -> Amazon marketplace id. A multi-marketplace
-# template has a `purchasable_offer[marketplace_id=<id>]` block per
-# marketplace; the price MUST go in the block for the one you're listing
-# on, or the product is ASIN-only ("Missing offer", never live). The agent
-# knows only the country (from the seller-central domain), so resolve here.
+# Marketplace (country) -> Amazon marketplace id. Price MUST go in the
+# `purchasable_offer[marketplace_id=<id>]` block for the marketplace being
+# listed on, else the product is ASIN-only ("Missing offer", never live).
 MARKETPLACE_IDS = {
     'SA': 'A17E79C6D8DWNP',  # Saudi Arabia  (amazon.sa)
     'AE': 'A2VIGQ35RCS4UG',  # UAE           (amazon.ae)
-    'EG': 'ARBP9OOSHTCHU',   # Egypt         (amazon.eg)
+    'EG': 'ARBP9OOSHTCHU',  # Egypt         (amazon.eg)
     'AU': 'A39IBJ37TRP1C6',  # Australia     (amazon.com.au)
-    'US': 'ATVPDKIKX0DER',   # United States (amazon.com)
+    'US': 'ATVPDKIKX0DER',  # United States (amazon.com)
     'MX': 'A1AM78C64UM0Y8',  # Mexico        (amazon.com.mx)
     'UK': 'A1F83G8C2ARO7P',  # United Kingdom(amazon.co.uk)
     'DE': 'A1PA6795UKMFR9',  # Germany       (amazon.de)
@@ -109,10 +107,9 @@ _OUR_PRICE_TEMPLATE = (
 )
 _OFFER_PRICE_SHORTHANDS = ('our_price', 'price', 'standard_price')
 
-# A Parent (relationship) row carries only the shared catalogue data;
-# the offer, stock, images and product-id live on the Child rows. So a
-# Parent legitimately omits these even when the template marks them
-# Required -- don't warn about them for a Parent.
+# A Parent row carries only shared catalogue data; offer, stock, images
+# and product-id live on Child rows -- so a Parent legitimately omits
+# these even when the template marks them Required (don't warn).
 CHILD_LEVEL_PREFIXES = (
     'purchasable_offer',
     'fulfillment_availability',
@@ -125,10 +122,9 @@ CHILD_LEVEL_PREFIXES = (
     'apparel_size',
 )
 
-# Battery / hazmat / dangerous-goods fields are marked Required in the
-# Data Definitions but are only *conditionally* required -- Amazon
-# accepts them blank when the item has no batteries. Suppress the noise
-# when the row declares no batteries.
+# Battery / hazmat fields are marked Required but are only *conditionally*
+# required -- Amazon accepts them blank when the item has no batteries, so
+# suppress the noise when the row declares none.
 BATTERY_TOKENS = (
     'battery',
     'batteries',
@@ -420,8 +416,8 @@ def _route_offer_price(fields, cols, mkt_id, i, sku, warnings):
     if shorthand:
         if mkt_id is None:
             raise SystemExit(
-                f"error: row {i} sku={sku} sets a price but the spec has no "
-                f"'marketplace' -- add e.g. \"marketplace\": \"SA\""
+                f'error: row {i} sku={sku} sets a price but the spec has no '
+                f'\'marketplace\' -- add e.g. "marketplace": "SA"'
             )
         if target_col not in cols:
             raise SystemExit(
@@ -431,9 +427,11 @@ def _route_offer_price(fields, cols, mkt_id, i, sku, warnings):
         fields[target_col] = fields.pop(shorthand)
     if mkt_id is not None and target_col not in fields:
         other = [
-            k for k in fields
+            k
+            for k in fields
             if k.startswith('purchasable_offer[marketplace_id=')
-            and '.our_price' in k and f'marketplace_id={mkt_id}]' not in k
+            and '.our_price' in k
+            and f'marketplace_id={mkt_id}]' not in k
         ]
         if other:
             warnings.append(
@@ -470,10 +468,8 @@ def cmd_fill(args):
     unknown_fields = set()
     warnings = []
     write_at = header_row + 1
-    # Clear any pre-existing data rows before writing the spec, so stale
-    # rows from an Example row or a previously-filled template can't be
-    # uploaded as unintended SKUs. A freshly-generated blank template has
-    # none, but a reused workbook might.
+    # Clear pre-existing data rows first, so an Example row or a reused
+    # workbook's stale rows can't upload as unintended SKUs.
     if ws.max_row >= write_at:
         ws.delete_rows(write_at, ws.max_row - write_at + 1)
     for i, spec_row in enumerate(rows):
@@ -611,10 +607,8 @@ def _template_cell_errors(path):
                 if not (c.comment and c.comment.text):
                     continue
                 field = names.get(c.column, f'col{c.column}')
-                # A cell comment can stack several messages, separated by
-                # Excel's literal carriage-return marker `_x000d_`. Split
-                # into individual ERROR/WARNING lines so each is one
-                # actionable item.
+                # A cell comment stacks several messages on Excel's literal
+                # `_x000d_` CR marker; split so each is one actionable line.
                 raw = str(c.comment.text).replace('_x000d_', '\n')
                 for line in raw.split('\n'):
                     line = ' '.join(line.split())
@@ -660,8 +654,10 @@ def _report_comment_errors(path):
                 continue
             field = names[c.column - 1] if c.column - 1 < len(names) else ''
             text = ' '.join(c.comment.text.split())
-            sev = 'error' if text.lstrip().upper().startswith('ERROR') else (
-                'warning' if 'WARNING' in text[:20].upper() else 'info'
+            sev = (
+                'error'
+                if text.lstrip().upper().startswith('ERROR')
+                else ('warning' if 'WARNING' in text[:20].upper() else 'info')
             )
             out.append((str(sku), str(field or ''), sev, text[:400]))
     return out
@@ -680,11 +676,15 @@ def cmd_parse_feedback(args):
         n_warn = sum(1 for _s in comment_errs if _s[2] == 'warning')
         for sku, field, sev, msg in comment_errs:
             print(f'  [{sev}] sku={sku} field={field}: {msg}')
-        print(f'\n{n_err} error(s), {n_warn} warning(s) across '
-              f'{len({s for s, *_ in comment_errs})} SKU(s).')
+        print(
+            f'\n{n_err} error(s), {n_warn} warning(s) across '
+            f'{len({s for s, *_ in comment_errs})} SKU(s).'
+        )
         if n_err:
-            print('Fix ALL errors (parent first) and re-upload; a SKU with '
-                  'any error is NOT created (feed "successful" != live).')
+            print(
+                'Fix ALL errors (parent first) and re-upload; a SKU with '
+                'any error is NOT created (feed "successful" != live).'
+            )
         return
 
     rows = list(_iter_report_rows(args.file))
@@ -784,7 +784,7 @@ def main():
         '--marketplace',
         help='country code (SA/AE/AU/…) or raw marketplace id you are '
         'listing on; routes the offer price to the right block. Overrides '
-        "the spec's top-level \"marketplace\".",
+        'the spec\'s top-level "marketplace".',
     )
     p.set_defaults(func=cmd_fill)
 

--- a/app/skills_v2/amazon-listing/scripts/marketplace_ids.py
+++ b/app/skills_v2/amazon-listing/scripts/marketplace_ids.py
@@ -1,0 +1,90 @@
+"""Amazon marketplace (country) -> marketplace id.
+
+A marketplace id identifies a *marketplace* (a country storefront), NOT a
+seller -- it is a public constant of the platform, identical for every
+seller on that marketplace, and published in Amazon's SP-API "Marketplace
+IDs" reference. Kept as a standalone data module so the full global set
+lives in one place and `listing_bulk.py` stays within the line cap.
+
+Verified 2026-07 against the Amazon SP-API docs and two independent
+mirrors. `listing_bulk` also auto-detects the id straight from a
+template's `purchasable_offer[marketplace_id=<id>]` columns, so a
+marketplace Amazon adds *after* this table still works without an edit.
+"""
+
+MARKETPLACE_IDS = {
+    # North America
+    'US': 'ATVPDKIKX0DER',  # amazon.com
+    'CA': 'A2EUQ1WTGCTBG2',  # amazon.ca
+    'MX': 'A1AM78C64UM0Y8',  # amazon.com.mx
+    'BR': 'A2Q3Y263D00KWC',  # amazon.com.br
+    # Europe
+    'UK': 'A1F83G8C2ARO7P',  # amazon.co.uk
+    'DE': 'A1PA6795UKMFR9',  # amazon.de
+    'FR': 'A13V1IB3VIYZZH',  # amazon.fr
+    'IT': 'APJ6JRA9NG5V4',  # amazon.it
+    'ES': 'A1RKKUPIHCS9HS',  # amazon.es
+    'NL': 'A1805IZSGTT6HS',  # amazon.nl
+    'SE': 'A2NODRKZP88ZB9',  # amazon.se
+    'PL': 'A1C3SOZRARQ6R3',  # amazon.pl
+    'BE': 'AMEN7PMS3EDWL',  # amazon.com.be
+    'TR': 'A33AVAJ2PDY3EV',  # amazon.com.tr
+    'IE': 'A28R8C7NBKEWEA',  # amazon.ie
+    # Middle East / Africa
+    'AE': 'A2VIGQ35RCS4UG',  # amazon.ae
+    'SA': 'A17E79C6D8DWNP',  # amazon.sa
+    'EG': 'ARBP9OOSHTCHU',  # amazon.eg
+    # Asia-Pacific
+    'IN': 'A21TJRUUN4KGV',  # amazon.in
+    'JP': 'A1VC38T7YXB528',  # amazon.co.jp
+    'AU': 'A39IBJ37TRP1C6',  # amazon.com.au
+    'SG': 'A19VAU5U5O7RUS',  # amazon.sg
+}
+
+# id -> country code, for reverse lookups / labelling.
+COUNTRY_BY_ID = {v: k for k, v in MARKETPLACE_IDS.items()}
+
+_MKT_ID_IN_COLUMN = __import__('re').compile(r'marketplace_id=([A-Za-z0-9]+)')
+
+
+def ids_in_template(cols):
+    """Marketplace ids named in a template's offer columns, in order.
+
+    `purchasable_offer[marketplace_id=<id>]...` columns name exactly the
+    marketplaces the template can list on -- ground truth independent of
+    the table above, so a marketplace Amazon adds later still resolves.
+    """
+    ids = []
+    for col in cols:
+        m = _MKT_ID_IN_COLUMN.search(str(col))
+        if m and m.group(1) not in ids:
+            ids.append(m.group(1))
+    return ids
+
+
+def resolve(marketplace, template_ids=None):
+    """Country code ('SA') / raw id / template auto-detect -> marketplace id.
+
+    Order, most explicit first: the country->id table, a raw id, then the
+    template's own offer columns when they name exactly one marketplace
+    (so it stays general for new marketplaces and for a caller who omits
+    `marketplace`). Returns None when nothing is supplied and the template
+    is multi-marketplace. Raises SystemExit on an unknown country code a
+    single-marketplace template can't disambiguate.
+    """
+    template_ids = list(template_ids or [])
+    single = template_ids[0] if len(set(template_ids)) == 1 else None
+    if not marketplace:
+        return single
+    m = str(marketplace).strip()
+    if m.upper() in MARKETPLACE_IDS:
+        return MARKETPLACE_IDS[m.upper()]
+    if m in COUNTRY_BY_ID or m in template_ids:  # already a raw id
+        return m
+    if single:  # unknown code, template offers exactly one marketplace
+        return single
+    codes = ', '.join(sorted(MARKETPLACE_IDS))
+    raise SystemExit(
+        f'error: unknown marketplace {marketplace!r} -- use a country code '
+        f'({codes}) or a raw marketplace id'
+    )

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -87,7 +87,8 @@ click_at_xy(x, y)  # click at pixel coordinates
 wait_for_load()  # wait for navigation/network to settle
 ensure_real_tab()  # switch off a stale/internal (chrome://) tab
 js('<javascript>')  # run JS; returns the SERIALIZABLE result only
-cdp('Domain.method', ...)  # raw Chrome DevTools Protocol call
+cdp('Domain.method', **params)  # raw CDP — params are KEYWORDS, not a dict
+                                # e.g. cdp('Page.navigate', url='...')
 ```
 
 - **`js()` returns serializable values only.** `js("document.title")` and
@@ -95,7 +96,9 @@ cdp('Domain.method', ...)  # raw Chrome DevTools Protocol call
   a useless `{}` (a DOM node can't serialize). Return **numbers, strings,
   or plain objects/arrays** — e.g. an element's coordinates (below), not
   the element itself. For an element *reference* (to set a file input) use
-  `cdp('Runtime.evaluate', {..., 'returnByValue': False})` → `objectId`.
+  `cdp('Runtime.evaluate', expression=..., returnByValue=False)` → `objectId`
+  (note: `cdp()` params are **keyword args**, never a positional dict —
+  see "Uploading a file").
 
 ## Locate & click an element WITHOUT vision (the preferred path)
 
@@ -164,6 +167,13 @@ so DO NOT click it. Set the file **directly on the input element via
 CDP** — the one reliable way. Get a Runtime `objectId` for the input,
 then `DOM.setFileInputFiles`:
 
+**`cdp()` takes keyword args, NOT a params dict.** The signature is
+`cdp(method, session_id=None, **params)` — the second positional slot is
+`session_id`, so passing a dict there (`cdp('Runtime.evaluate', {...})`)
+binds your params to `session_id` and the proxy rejects it with
+`-32600 "Message may have string 'sessionId' property"`. Always spell
+the CDP params as keywords: `cdp('Runtime.evaluate', expression=..., returnByValue=False)`.
+
 ```bash
 browser-use <<'PY'
 # 1. objectId for the <input type=file>. For a plain input:
@@ -171,10 +181,10 @@ sel = "document.querySelector('input[type=file]')"
 # For an input inside an OPEN shadow root (e.g. Amazon's kat-file-upload,
 # where the light-DOM input count is 0), pierce it:
 # sel = "document.querySelector('kat-file-upload').shadowRoot.querySelector('input[type=file]')"
-obj = cdp('Runtime.evaluate', {'expression': sel, 'returnByValue': False})
+obj = cdp('Runtime.evaluate', expression=sel, returnByValue=False)  # kwargs!
 oid = obj['result']['objectId']
 # 2. Attach the file. The path MUST be ABSOLUTE; files is a list.
-cdp('DOM.setFileInputFiles', {'objectId': oid, 'files': ['/abs/path/to/file.txt']})
+cdp('DOM.setFileInputFiles', objectId=oid, files=['/abs/path/to/file.txt'])
 print('attached')
 PY
 ```

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -161,39 +161,79 @@ PY
 
 ## Uploading a file to a web `<input type=file>`
 
-There is **no native upload helper** and a coordinate-click on the
-visible "Browse" button opens the OS file picker (which you can't drive),
-so DO NOT click it. Set the file **directly on the input element via
-CDP** — the one reliable way. Get a Runtime `objectId` for the input,
-then `DOM.setFileInputFiles`:
+There is **no native upload helper**. Never coordinate-click the visible
+"Browse"/"Upload file" button expecting to then drive the OS file picker
+(you can't). Attach the file via CDP. **`cdp()` takes keyword args, NOT a
+params dict** — the signature is `cdp(method, session_id=None, **params)`,
+so a dict in the 2nd slot binds to `session_id` and the proxy rejects it
+with `-32600 "Message may have string 'sessionId' property"`. Always use
+keywords: `cdp('Runtime.evaluate', expression=..., returnByValue=False)`.
 
-**`cdp()` takes keyword args, NOT a params dict.** The signature is
-`cdp(method, session_id=None, **params)` — the second positional slot is
-`session_id`, so passing a dict there (`cdp('Runtime.evaluate', {...})`)
-binds your params to `session_id` and the proxy rejects it with
-`-32600 "Message may have string 'sessionId' property"`. Always spell
-the CDP params as keywords: `cdp('Runtime.evaluate', expression=..., returnByValue=False)`.
+There are **two kinds of file input** — pick the matching method:
+
+### Method 1 — a plain `<input type=file>` (set the node directly)
+
+Works for a normal light-DOM input, or a simple open-shadow-DOM input
+whose node the component actually reads from. Get an objectId, set files:
 
 ```bash
 browser-use <<'PY'
-# 1. objectId for the <input type=file>. For a plain input:
 sel = "document.querySelector('input[type=file]')"
-# For an input inside an OPEN shadow root (e.g. Amazon's kat-file-upload,
-# where the light-DOM input count is 0), pierce it:
-# sel = "document.querySelector('kat-file-upload').shadowRoot.querySelector('input[type=file]')"
+# shadow-DOM variant: "document.querySelector('host').shadowRoot.querySelector('input[type=file]')"
 obj = cdp('Runtime.evaluate', expression=sel, returnByValue=False)  # kwargs!
 oid = obj['result']['objectId']
-# 2. Attach the file. The path MUST be ABSOLUTE; files is a list.
-cdp('DOM.setFileInputFiles', objectId=oid, files=['/abs/path/to/file.txt'])
-print('attached')
+cdp('DOM.setFileInputFiles', objectId=oid, files=['/abs/path/to/file.txt'])  # ABSOLUTE path
+print('files.length:', js(sel + ".files.length"))   # MUST verify → 1, not 0
 PY
 ```
 
-Then submit via the page's own button (`click_at_xy` the real submit
-control, not the browse button) and `wait_for_load()`. If
-`Runtime.evaluate` returns no `objectId`, the selector didn't match
-(wrong shadow root / not yet rendered) — fix the selector; don't fall
-back to clicking Browse or to `file://` navigation (both dead ends).
+**Always verify `files.length` right after.** If it stays **0** while the
+call returned success, the node you set is an **inert placeholder** the
+component doesn't read from (common with design-system upload widgets like
+Amazon's `kat-file-upload`, whose `input#kat-file-attachment` is a decoy).
+`setFileInputFiles` silently no-ops on it — objectId, `backendNodeId`, and
+`getDocument(pierce=True)` all give 0. Switch to Method 2.
+
+### Method 2 — a component-managed widget (file-chooser interception)
+
+For widgets that open the file picker via a button and create the *real*
+input on demand (Amazon `kat-file-upload`, most React uploaders). Suppress
+the OS dialog, do a **trusted** click on the widget's button, and take the
+`backendNodeId` Chrome hands you in `Page.fileChooserOpened`:
+
+```bash
+browser-use <<'PY'
+import time
+cdp('Page.enable')
+cdp('Page.setInterceptFileChooserDialog', enabled=True)   # OS dialog suppressed
+drain_events()                                            # clear the buffer
+# TRUSTED click on the visible upload button. click_at_xy is a CDP Input
+# event (trusted) — a JS .click() is UNtrusted and the browser will NOT
+# open a chooser for it (this is why setting the placeholder input fails).
+box = js("""var b=document.querySelector('kat-file-upload').shadowRoot.querySelector('#select-file');
+            var r=b.getBoundingClientRect();
+            return {x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)};""")
+click_at_xy(box['x'], box['y'])
+bnid = None
+for _ in range(8):                     # poll for the event (~4s)
+    time.sleep(0.5)
+    for e in drain_events():
+        if 'fileChooserOpened' in str(e.get('method', '')):
+            bnid = e['params']['backendNodeId']
+    if bnid: break
+cdp('DOM.setFileInputFiles', backendNodeId=bnid, files=['/abs/path/to/file.txt'])
+cdp('Page.setInterceptFileChooserDialog', enabled=False)
+print('attached to backendNodeId', bnid)
+PY
+```
+
+The widget then reads and stages the file itself — the visible field shows
+the filename and (for Amazon) a green "File Type … (Automatically
+detected)". **Don't trust the shadow-root `textContent`** to confirm — it
+carries hidden error-state strings ("File upload was unsuccessful") even on
+success; confirm with a `capture_screenshot()` + Read, or by the Submit
+button becoming enabled. Then `click_at_xy` the page's own **Submit** and
+`wait_for_load()`.
 
 ## Sessions
 

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -43,11 +43,8 @@ print(page_info())
 PY
 ```
 
-Single statements can use `-c`:
-
-```bash
-browser-use -c 'print(page_info())'
-```
+The wrapper takes the heredoc form **only** — there is no `-c` flag
+(passing one just prints usage). Put every statement inside the heredoc.
 
 ## Prerequisites
 
@@ -61,11 +58,20 @@ browser-use --doctor    # verify installation / CDP connectivity
    navigation**. There is **no `page` object** in the heredoc scope, so
    `page.goto(url)` raises `NameError`; use `new_tab(url)` (or click a link)
    to move around.
-2. **Understand visible state**: `capture_screenshot()` — screenshot first.
-3. **Inspect / extract**: `page_info()` for a structured summary; `js("...")`
-   for DOM queries when coordinates are the wrong tool.
-4. **Interact**: screenshot → read the pixel location → `click_at_xy(x, y)` →
-   screenshot again to confirm.
+2. **Understand state — via the DOM (PREFERRED, no vision needed):**
+   `page_info()` for page-level facts (url/title/size), and **`js(...)` to
+   read the DOM** — text content AND every element's on-screen coordinates
+   via `getBoundingClientRect` (see "Locate & click without vision"). This
+   is the primary way to drive the browser; a non-vision model completes
+   the whole flow this way.
+3. **See the layout (OPTIONAL — vision models only):**
+   `capture_screenshot()` returns a PNG path (`~/.vibe-seller/bh-tmp/shot.png`,
+   overwritten each call); `print()` it and **Read that PNG** to view it.
+   Use it only to disambiguate a crowded layout — never *depend* on it. If
+   your model can't view images, skip screenshots entirely and use step 2.
+4. **Interact**: get an element's centre coords from step 2, then
+   `click_at_xy(x, y)`; set input values with `js(...)`. Re-read with
+   `page_info()` / `js(...)` after to confirm.
 5. **After navigation**: `wait_for_load()`; if the tab is stale/internal,
    `ensure_real_tab()`.
 
@@ -76,13 +82,57 @@ Helpers are pre-imported into the heredoc namespace:
 ```python
 new_tab(url)  # open a new tab and navigate (use for EVERY navigation)
 page_info()  # structured summary of the current page
-capture_screenshot()  # screenshot the visible viewport (understand state)
+capture_screenshot()  # → PNG path (~/.vibe-seller/bh-tmp/shot.png); Read it to VIEW
 click_at_xy(x, y)  # click at pixel coordinates
 wait_for_load()  # wait for navigation/network to settle
 ensure_real_tab()  # switch off a stale/internal (chrome://) tab
-js('<javascript>')  # run JS in the page; returns the result
+js('<javascript>')  # run JS; returns the SERIALIZABLE result only
 cdp('Domain.method', ...)  # raw Chrome DevTools Protocol call
 ```
+
+- **`js()` returns serializable values only.** `js("document.title")` and
+  `js("return 1+1")` work; but `js("document.querySelector(...)")` returns
+  a useless `{}` (a DOM node can't serialize). Return **numbers, strings,
+  or plain objects/arrays** — e.g. an element's coordinates (below), not
+  the element itself. For an element *reference* (to set a file input) use
+  `cdp('Runtime.evaluate', {..., 'returnByValue': False})` → `objectId`.
+
+## Locate & click an element WITHOUT vision (the preferred path)
+
+You do not need to see the page. Read the DOM and compute click
+coordinates from `getBoundingClientRect`, then `click_at_xy`. This drives
+any page — buttons, links, shadow-DOM `kat-*` components — with no
+screenshot:
+
+```bash
+browser-use <<'PY'
+# one element by selector → its centre coords + text (None if not found):
+box = js("""
+  var el = document.querySelector('button.submit');   // any CSS selector
+  if(!el) return null;
+  var r = el.getBoundingClientRect();
+  return {text:(el.innerText||el.value||'').slice(0,40),
+          x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)};
+""")
+print("target:", box)
+if box: click_at_xy(box["x"], box["y"])
+
+# OR enumerate all clickables to find the right one by its text:
+els = js("""
+  return [].slice.call(document.querySelectorAll('a,button,input,[role=button],kat-button'))
+    .map(function(el){var r=el.getBoundingClientRect();
+      return {text:(el.innerText||el.value||'').slice(0,40),
+              x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)};})
+    .filter(function(e){return e.x>0 && e.y>0;});
+""")
+print(els)          # pick the one whose text matches, then click_at_xy(it.x, it.y)
+PY
+```
+
+For an element inside an **open shadow root** (Amazon `kat-*`), pierce it
+in the selector: `document.querySelector('kat-file-upload').shadowRoot.querySelector('input')`.
+Set an input's value with `js("document.querySelector('#q').value='socks'")`
+(then click its search icon — some inputs need the click to fire events).
 
 Only the helpers above (plus Python builtins) are in scope — the heredoc
 runs as a plain Python script. **`time`, `json`, `re`, etc. are NOT
@@ -162,8 +212,10 @@ The wrapper rejects these — do not use them:
 
 ## Tips
 
-1. **Screenshot first**, then act on what you see — `capture_screenshot()`
-   before `click_at_xy`.
+1. **DOM first, not screenshots.** Locate targets with `js(...)` +
+   `getBoundingClientRect` (see "Locate & click without vision") and act on
+   the coords — this works with or without vision. A screenshot is an
+   optional cross-check for vision models, never a prerequisite.
 2. **`new_tab(url)` is how you navigate — every time**, not `goto` (there
    is no `page` object in the heredoc scope).
 3. Prefer `page_info()` / `js(...)` over screenshots for text extraction.

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -33,7 +33,9 @@ from openpyxl.comments import Comment  # noqa: E402  (after importorskip guard)
 _SKILL_PATH = (
     Path(__file__).resolve().parents[2]
     / 'app'
-    / 'skills'
+    # Live skill tree (config.SKILLS_SUBDIR); matches the ads-bulk test.
+    # ``app/skills`` is the frozen 0.12.x copy and is not what ships.
+    / 'skills_v2'
     / 'amazon-listing'
     / 'scripts'
     / 'listing_bulk.py'
@@ -508,3 +510,84 @@ def test_parse_feedback_extracts_cell_comments(tmp_path):
     assert any(m.startswith('WARNING') and 'material' in m for m in msgs)
     # _x000d_ artifact must be cleaned (split into separate lines).
     assert not any('_x000d_' in m for m in msgs)
+
+
+# --- offer routing to the target marketplace (multi-marketplace bug) ---
+
+_SA = 'A17E79C6D8DWNP'
+_AE = 'A2VIGQ35RCS4UG'
+_SA_PRICE = f'purchasable_offer[marketplace_id={_SA}]#1.our_price#1.schedule#1.value_with_tax'
+_AE_PRICE = f'purchasable_offer[marketplace_id={_AE}]#1.our_price#1.schedule#1.value_with_tax'
+
+
+def _make_mkt_template(path):
+    """A template with a SEPARATE offer-price column per marketplace."""
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = listing_bulk.TEMPLATE_SHEET
+    fields = [
+        'feed_product_type', 'item_sku', 'brand_name', 'update_delete',
+        'item_name', 'parent_child', 'variation_theme', 'parent_sku',
+        'color_name', 'fulfillment_availability#1.quantity',
+        _SA_PRICE, _AE_PRICE,
+    ]
+    ws.append(['TemplateType=fptcustom'])
+    ws.append(['label:' + f for f in fields])  # localised label row
+    ws.append(list(fields))  # field API-name row (header)
+    dd = wb.create_sheet(listing_bulk.DEFN_SHEET)
+    dd.append(['x'])
+    dd.append(['Group Name', 'Field Name', 'Local Label Name',
+               'Definition and Use', 'Accepted Values', 'Example', 'Required?'])
+    for f in fields:
+        # The template marks the AE block required (the account is UAE-primary)
+        # -- exactly the trap that made a run fill AE for an SA listing.
+        dd.append(['', f, f, '', '', '', 'Required' if f == _AE_PRICE else 'Optional'])
+    wb.save(path)
+
+
+@pytest.fixture
+def mkt_template(tmp_path):
+    p = tmp_path / 'mkt.xlsx'
+    _make_mkt_template(str(p))
+    return str(p)
+
+
+def test_fill_routes_bare_our_price_to_target_marketplace(mkt_template, tmp_path):
+    spec = _spec(tmp_path, {
+        'marketplace': 'SA', 'product_type': 'socks',
+        'rows': [{'sku': 'K-WHT', 'parentage': 'Child', 'variation_theme': 'Color',
+                  'fields': {'item_name': 'x', 'color_name': 'White',
+                             'feed_product_type': 'socks', 'our_price': '19.99'}}],
+    })
+    out = str(tmp_path / 'out.xlsx')
+    _run(['fill', mkt_template, '--spec', spec, '--out', out])
+    row = _read_rows(out)[0]
+    assert row[_SA_PRICE] == '19.99'   # target marketplace got the price
+    assert row[_AE_PRICE] in (None, '')  # the wrong block stayed empty
+
+
+def test_fill_rehomes_price_from_wrong_marketplace(mkt_template, tmp_path):
+    # Agent hand-picked the AE column but is listing on SA -> re-home to SA.
+    spec = _spec(tmp_path, {
+        'marketplace': 'SA', 'product_type': 'socks',
+        'rows': [{'sku': 'K-WHT', 'parentage': 'Child', 'variation_theme': 'Color',
+                  'fields': {'item_name': 'x', 'color_name': 'White',
+                             'feed_product_type': 'socks', _AE_PRICE: '19.99'}}],
+    })
+    out = str(tmp_path / 'out.xlsx')
+    _run(['fill', mkt_template, '--spec', spec, '--out', out])
+    row = _read_rows(out)[0]
+    assert row[_SA_PRICE] == '19.99'
+    assert row[_AE_PRICE] in (None, '')
+
+
+def test_fill_errors_when_price_set_without_marketplace(mkt_template, tmp_path):
+    spec = _spec(tmp_path, {
+        'product_type': 'socks',
+        'rows': [{'sku': 'K-WHT', 'parentage': 'Child',
+                  'fields': {'item_name': 'x', 'our_price': '19.99'}}],
+    })
+    out = str(tmp_path / 'out.xlsx')
+    with pytest.raises(SystemExit) as e:
+        _run(['fill', mkt_template, '--spec', spec, '--out', out])
+    assert 'marketplace' in str(e.value)

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -698,3 +698,47 @@ def test_fill_auto_derives_relationship_type_for_variation(
     rows = {r['item_sku']: r for r in _read_rows(out)}
     assert rows['K-P']['relationship_type'] == 'Variation'
     assert rows['K-WHT']['relationship_type'] == 'Variation'
+
+
+def test_marketplace_table_is_global():
+    # The country->id table must cover Amazon's global marketplaces, not
+    # just the few we happened to list on. Spot-check one per region and a
+    # healthy total so a truncated table fails loudly.
+    ids = listing_bulk.MARKETPLACE_IDS
+    for code, mid in {
+        'US': 'ATVPDKIKX0DER',
+        'UK': 'A1F83G8C2ARO7P',
+        'JP': 'A1VC38T7YXB528',
+        'AU': 'A39IBJ37TRP1C6',
+        'SA': 'A17E79C6D8DWNP',
+        'AE': 'A2VIGQ35RCS4UG',
+        'BR': 'A2Q3Y263D00KWC',
+    }.items():
+        assert ids[code] == mid
+    assert len(ids) >= 20  # NA + EU + ME + APAC, not a partial subset
+
+
+def test_resolve_marketplace_by_code_and_raw_id():
+    r = listing_bulk._resolve_marketplace_id
+    assert r('SA') == _SA
+    assert r('sa') == _SA  # case-insensitive country code
+    assert r(_AE) == _AE  # a raw id passes through unchanged
+    assert r(None) is None  # nothing supplied, no template hint
+
+
+def test_marketplace_ids_read_from_template_columns():
+    cols = {'item_sku': 1, _SA_PRICE: 2, _AE_PRICE: 3}
+    assert listing_bulk._marketplace_ids_in_template(cols) == [_SA, _AE]
+    assert listing_bulk._marketplace_ids_in_template({'item_sku': 1}) == []
+
+
+def test_resolve_auto_detects_single_marketplace_template():
+    r = listing_bulk._resolve_marketplace_id
+    # No marketplace given, but the template offers exactly one -> use it.
+    assert r(None, [_SA]) == _SA
+    # A marketplace code Amazon added after our table, disambiguated by a
+    # single-marketplace template -> still resolves (stays general).
+    assert r('ZA', [_SA]) == _SA
+    # Ambiguous: unknown code + multi-marketplace template -> fail loudly.
+    with pytest.raises(SystemExit):
+        r('ZA', [_SA, _AE])

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -527,8 +527,8 @@ def _make_mkt_template(path):
     ws.title = listing_bulk.TEMPLATE_SHEET
     fields = [
         'feed_product_type', 'item_sku', 'brand_name', 'update_delete',
-        'item_name', 'parent_child', 'variation_theme', 'parent_sku',
-        'color_name', 'fulfillment_availability#1.quantity',
+        'item_name', 'parent_child', 'relationship_type', 'variation_theme',
+        'parent_sku', 'color_name', 'fulfillment_availability#1.quantity',
         _SA_PRICE, _AE_PRICE,
     ]
     ws.append(['TemplateType=fptcustom'])
@@ -594,3 +594,24 @@ def test_fill_errors_when_price_set_without_marketplace(mkt_template, tmp_path):
     with pytest.raises(SystemExit) as e:
         _run(['fill', mkt_template, '--spec', spec, '--out', out])
     assert 'marketplace' in str(e.value)
+
+
+def test_fill_auto_derives_relationship_type_for_variation(mkt_template, tmp_path):
+    # A child with parent_sku + variation_theme but NO relationship_type must
+    # still get relationship_type=Variation (else Amazon errors
+    # "relationship_type = null" and the child never creates).
+    spec = _spec(tmp_path, {
+        'marketplace': 'SA', 'product_type': 'socks',
+        'rows': [
+            {'sku': 'K-P', 'parentage': 'Parent', 'variation_theme': 'Color',
+             'fields': {'item_name': 'p'}},
+            {'sku': 'K-WHT', 'parentage': 'Child', 'parent_sku': 'K-P',
+             'variation_theme': 'Color',
+             'fields': {'item_name': 'w', 'color_name': 'White', 'our_price': '9.99'}},
+        ],
+    })
+    out = str(tmp_path / 'out.xlsx')
+    _run(['fill', mkt_template, '--spec', spec, '--out', out])
+    rows = {r['item_sku']: r for r in _read_rows(out)}
+    assert rows['K-P']['relationship_type'] == 'Variation'
+    assert rows['K-WHT']['relationship_type'] == 'Variation'

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -526,23 +526,47 @@ def _make_mkt_template(path):
     ws = wb.active
     ws.title = listing_bulk.TEMPLATE_SHEET
     fields = [
-        'feed_product_type', 'item_sku', 'brand_name', 'update_delete',
-        'item_name', 'parent_child', 'relationship_type', 'variation_theme',
-        'parent_sku', 'color_name', 'fulfillment_availability#1.quantity',
-        _SA_PRICE, _AE_PRICE,
+        'feed_product_type',
+        'item_sku',
+        'brand_name',
+        'update_delete',
+        'item_name',
+        'parent_child',
+        'relationship_type',
+        'variation_theme',
+        'parent_sku',
+        'color_name',
+        'fulfillment_availability#1.quantity',
+        _SA_PRICE,
+        _AE_PRICE,
     ]
     ws.append(['TemplateType=fptcustom'])
     ws.append(['label:' + f for f in fields])  # localised label row
     ws.append(list(fields))  # field API-name row (header)
     dd = wb.create_sheet(listing_bulk.DEFN_SHEET)
     dd.append(['x'])
-    dd.append(['Group Name', 'Field Name', 'Local Label Name',
-               'Definition and Use', 'Accepted Values', 'Example', 'Required?'])
+    dd.append([
+        'Group Name',
+        'Field Name',
+        'Local Label Name',
+        'Definition and Use',
+        'Accepted Values',
+        'Example',
+        'Required?',
+    ])
     for f in fields:
         # A multi-marketplace template marks a *different* marketplace's
         # offer block Required than the one we're listing on -- exactly the
         # trap that silently fills the wrong marketplace's price.
-        dd.append(['', f, f, '', '', '', 'Required' if f == _AE_PRICE else 'Optional'])
+        dd.append([
+            '',
+            f,
+            f,
+            '',
+            '',
+            '',
+            'Required' if f == _AE_PRICE else 'Optional',
+        ])
     wb.save(path)
 
 
@@ -553,64 +577,122 @@ def mkt_template(tmp_path):
     return str(p)
 
 
-def test_fill_routes_bare_our_price_to_target_marketplace(mkt_template, tmp_path):
-    spec = _spec(tmp_path, {
-        'marketplace': 'SA', 'product_type': 'socks',
-        'rows': [{'sku': 'K-WHT', 'parentage': 'Child', 'variation_theme': 'Color',
-                  'fields': {'item_name': 'x', 'color_name': 'White',
-                             'feed_product_type': 'socks', 'our_price': '19.99'}}],
-    })
+def test_fill_routes_bare_our_price_to_target_marketplace(
+    mkt_template, tmp_path
+):
+    spec = _spec(
+        tmp_path,
+        {
+            'marketplace': 'SA',
+            'product_type': 'socks',
+            'rows': [
+                {
+                    'sku': 'K-WHT',
+                    'parentage': 'Child',
+                    'variation_theme': 'Color',
+                    'fields': {
+                        'item_name': 'x',
+                        'color_name': 'White',
+                        'feed_product_type': 'socks',
+                        'our_price': '19.99',
+                    },
+                }
+            ],
+        },
+    )
     out = str(tmp_path / 'out.xlsx')
     _run(['fill', mkt_template, '--spec', spec, '--out', out])
     row = _read_rows(out)[0]
-    assert row[_SA_PRICE] == '19.99'   # target marketplace got the price
+    assert row[_SA_PRICE] == '19.99'  # target marketplace got the price
     assert row[_AE_PRICE] in (None, '')  # the wrong block stayed empty
 
 
-def test_fill_warns_when_target_marketplace_has_no_offer(mkt_template, tmp_path, capsys):
+def test_fill_warns_when_target_marketplace_has_no_offer(
+    mkt_template, tmp_path, capsys
+):
     # Agent hand-picked the AE column but is listing on SA. We DON'T silently
     # move it (that confused agents) -- leave it as written and WARN that SA
     # has no offer (=> Missing offer).
-    spec = _spec(tmp_path, {
-        'marketplace': 'SA', 'product_type': 'socks',
-        'rows': [{'sku': 'K-WHT', 'parentage': 'Child', 'variation_theme': 'Color',
-                  'fields': {'item_name': 'x', 'color_name': 'White',
-                             'feed_product_type': 'socks', _AE_PRICE: '19.99'}}],
-    })
+    spec = _spec(
+        tmp_path,
+        {
+            'marketplace': 'SA',
+            'product_type': 'socks',
+            'rows': [
+                {
+                    'sku': 'K-WHT',
+                    'parentage': 'Child',
+                    'variation_theme': 'Color',
+                    'fields': {
+                        'item_name': 'x',
+                        'color_name': 'White',
+                        'feed_product_type': 'socks',
+                        _AE_PRICE: '19.99',
+                    },
+                }
+            ],
+        },
+    )
     out = str(tmp_path / 'out.xlsx')
     _run(['fill', mkt_template, '--spec', spec, '--out', out])
     row = _read_rows(out)[0]
-    assert row[_AE_PRICE] == '19.99'      # explicit column left as written
+    assert row[_AE_PRICE] == '19.99'  # explicit column left as written
     assert row[_SA_PRICE] in (None, '')
     assert 'Missing offer' in capsys.readouterr().err
 
 
 def test_fill_errors_when_price_set_without_marketplace(mkt_template, tmp_path):
-    spec = _spec(tmp_path, {
-        'product_type': 'socks',
-        'rows': [{'sku': 'K-WHT', 'parentage': 'Child',
-                  'fields': {'item_name': 'x', 'our_price': '19.99'}}],
-    })
+    spec = _spec(
+        tmp_path,
+        {
+            'product_type': 'socks',
+            'rows': [
+                {
+                    'sku': 'K-WHT',
+                    'parentage': 'Child',
+                    'fields': {'item_name': 'x', 'our_price': '19.99'},
+                }
+            ],
+        },
+    )
     out = str(tmp_path / 'out.xlsx')
     with pytest.raises(SystemExit) as e:
         _run(['fill', mkt_template, '--spec', spec, '--out', out])
     assert 'marketplace' in str(e.value)
 
 
-def test_fill_auto_derives_relationship_type_for_variation(mkt_template, tmp_path):
+def test_fill_auto_derives_relationship_type_for_variation(
+    mkt_template, tmp_path
+):
     # A child with parent_sku + variation_theme but NO relationship_type must
     # still get relationship_type=Variation (else Amazon errors
     # "relationship_type = null" and the child never creates).
-    spec = _spec(tmp_path, {
-        'marketplace': 'SA', 'product_type': 'socks',
-        'rows': [
-            {'sku': 'K-P', 'parentage': 'Parent', 'variation_theme': 'Color',
-             'fields': {'item_name': 'p'}},
-            {'sku': 'K-WHT', 'parentage': 'Child', 'parent_sku': 'K-P',
-             'variation_theme': 'Color',
-             'fields': {'item_name': 'w', 'color_name': 'White', 'our_price': '9.99'}},
-        ],
-    })
+    spec = _spec(
+        tmp_path,
+        {
+            'marketplace': 'SA',
+            'product_type': 'socks',
+            'rows': [
+                {
+                    'sku': 'K-P',
+                    'parentage': 'Parent',
+                    'variation_theme': 'Color',
+                    'fields': {'item_name': 'p'},
+                },
+                {
+                    'sku': 'K-WHT',
+                    'parentage': 'Child',
+                    'parent_sku': 'K-P',
+                    'variation_theme': 'Color',
+                    'fields': {
+                        'item_name': 'w',
+                        'color_name': 'White',
+                        'our_price': '9.99',
+                    },
+                },
+            ],
+        },
+    )
     out = str(tmp_path / 'out.xlsx')
     _run(['fill', mkt_template, '--spec', spec, '--out', out])
     rows = {r['item_sku']: r for r in _read_rows(out)}

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -566,8 +566,10 @@ def test_fill_routes_bare_our_price_to_target_marketplace(mkt_template, tmp_path
     assert row[_AE_PRICE] in (None, '')  # the wrong block stayed empty
 
 
-def test_fill_rehomes_price_from_wrong_marketplace(mkt_template, tmp_path):
-    # Agent hand-picked the AE column but is listing on SA -> re-home to SA.
+def test_fill_warns_when_target_marketplace_has_no_offer(mkt_template, tmp_path, capsys):
+    # Agent hand-picked the AE column but is listing on SA. We DON'T silently
+    # move it (that confused agents) -- leave it as written and WARN that SA
+    # has no offer (=> Missing offer).
     spec = _spec(tmp_path, {
         'marketplace': 'SA', 'product_type': 'socks',
         'rows': [{'sku': 'K-WHT', 'parentage': 'Child', 'variation_theme': 'Color',
@@ -577,8 +579,9 @@ def test_fill_rehomes_price_from_wrong_marketplace(mkt_template, tmp_path):
     out = str(tmp_path / 'out.xlsx')
     _run(['fill', mkt_template, '--spec', spec, '--out', out])
     row = _read_rows(out)[0]
-    assert row[_SA_PRICE] == '19.99'
-    assert row[_AE_PRICE] in (None, '')
+    assert row[_AE_PRICE] == '19.99'      # explicit column left as written
+    assert row[_SA_PRICE] in (None, '')
+    assert 'Missing offer' in capsys.readouterr().err
 
 
 def test_fill_errors_when_price_set_without_marketplace(mkt_template, tmp_path):

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -539,8 +539,9 @@ def _make_mkt_template(path):
     dd.append(['Group Name', 'Field Name', 'Local Label Name',
                'Definition and Use', 'Accepted Values', 'Example', 'Required?'])
     for f in fields:
-        # The template marks the AE block required (the account is UAE-primary)
-        # -- exactly the trap that made a run fill AE for an SA listing.
+        # A multi-marketplace template marks a *different* marketplace's
+        # offer block Required than the one we're listing on -- exactly the
+        # trap that silently fills the wrong marketplace's price.
         dd.append(['', f, f, '', '', '', 'Required' if f == _AE_PRICE else 'Optional'])
     wb.save(path)
 


### PR DESCRIPTION
## What

Makes the **amazon-listing** skill actually work end-to-end for a
vision-free agent (DeepSeek, no screenshots) driving the flat-file
**Add Products via Upload** flow — create *and* delete a full variation
family, verified live in Manage Inventory, not just "feed accepted".

Every fix below was surfaced by running a real create→delete e2e on a
live seller account and reading the actual processing report at each
failure — no assumptions.

## Fixes (each one unblocked a concrete live failure)

- **`cdp()` takes kwargs, not a positional dict** — passing a params
  dict positionally bound it to `session_id` → `-32600 "Message may
  have string 'sessionId' property"`. All recipes now use the kwargs
  form.
- **kat-file-upload via file-chooser interception** — a direct
  `DOM.setFileInputFiles` on the shadow input no-ops (inert
  placeholder). Now: `Page.setInterceptFileChooserDialog` + a *trusted*
  click on `#select-file` + poll for `Page.fileChooserOpened` +
  `setFileInputFiles` on the reported backendNodeId.
- **Product-type search needs real events** — setting the input value
  bare doesn't trigger the type-ahead; dispatch `input`/`change`
  (`composed: true`) via the native setter.
- **Offer price routes to the target marketplace's block** — a
  multi-marketplace template has one
  `purchasable_offer[marketplace_id=<id>]` block per marketplace;
  hand-picking a column silently puts the price in the wrong one
  ("Missing offer", never live). Now a bare `our_price` + a top-level
  `marketplace` (country code) routes to the right block, and *warns*
  (doesn't silently move) when the target marketplace has no offer
  column.
- **`parse-feedback` reads the cell comments** — real per-field errors
  live as orange cell comments on the report's Template tab, not a
  summary table row. It now extracts `sku=… field=… : MESSAGE` from
  those.
- **Auto-derive `relationship_type=Variation`** — a child left with a
  null relationship_type silently fails to join its family; now derived
  for any row that has parentage / a variation theme.
- **Delete recipe** — enumerate a variation family from a **fresh All
  Listings Report** (the New-Seller-Central inventory grid is
  virtualized, so child rows aren't in the DOM to scrape); grep the
  family, delete children then parent (`update_delete=delete`), and
  verify each SKU redirects off `skucentral`. Never rely on the UI
  variation-expand or a local spec.

Docs: apparel-variation recipe (full `apparel_size` composite on every
row incl. parent, valid enums, two-pass parent→children), offer-via-
`our_price`+`marketplace`, read-report-via-comments, and the delete
walkthrough. Browser-harness reference updated to prefer the vision-free
DOM path.

Tests: `tests/unit/test_amazon_listing_bulk_skill.py` — 15 unit tests
(repointed to `skills_v2`), covering offer routing (route / warn-not-
move / error-no-marketplace) and relationship_type auto-derive.

## Verification (live, on a real account, DeepSeek — no vision)

Ran the two e2e as a real seller would type them, **zero herding** (no
technical follow-ups, no me driving the browser, no me supplying SKUs),
and re-ran them clean after `restart.sh --dev` re-synced the skill:

- **CREATE** one-shot → a **live** variation family: parent
  `Variations (2)` + both children with real ASINs, verified by me
  read-only on `skucentral` (stays = live).
- **DELETE** one-shot → the family **removed**: both children redirect
  off `skucentral` and the prefix is absent from Manage Inventory
  (verified by me read-only).

Both agents ran their own built-in DoD review loop to `Status: ok`
before finishing; I then independently re-verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
