### PR TITLE
fix(amazon-listing): 6 gaps a clean-state create+delete e2e exposed (A–F)

### DIFF
--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -99,6 +99,23 @@ listing. **Always confirm on Manage Inventory** (or
 false-negates incomplete listings). Confirm the SKU has an ASIN, and for
 a family that the parent shows **"Variations (N)"**.
 
+> **"Missing Information / ASIN -" is usually NOT a failure — don't
+> thrash.** Two benign causes, and re-uploading fixes neither:
+> 1. **ASINs mint asynchronously.** A just-submitted family can show
+>    `ASIN -` / a "Complete drafts → Submitted: Provide missing
+>    information" entry for **10–30 minutes** while Amazon mints the
+>    ASINs. Re-check Manage Inventory later — the parent flips to
+>    `Variations (N)` with real child ASINs on its own. Do NOT re-upload
+>    (that just spawns duplicate batches).
+> 2. **Only the main image is missing.** We intentionally don't upload
+>    images, so a no-image product parks in "provide missing information"
+>    for the image alone. **That is an acceptable DONE state** — the
+>    seller adds the image later. The listing is **finished** once Manage
+>    Inventory shows it with the variation relationship (`Variations (N)`),
+>    real child ASINs, and correct **title / price / bullets**; a blank
+>    image does not block "done". Only treat it as unfinished if the
+>    processing report names a **non-image** blocking error.
+
 > **Do NOT re-upload just because Check Upload Status shows "N/A".** After
 > a submit, the batch's "SKUs successful / N/A" column stays `N/A` for
 > minutes (and CREATE/DELETE feeds can sit at N/A a long time) — that is

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -125,9 +125,11 @@ a family that the parent shows **"Variations (N)"**.
 - **Compound attributes come as a set** — e.g. Apparel Size needs
   `apparel_size_class` + `apparel_size_system` + `apparel_body_type` +
   `apparel_height_type` together; a partial set errors (99001/99022).
-- **Own-country only** — in the generator, select the store's **single**
-  marketplace (multi-marketplace disables Listing Preferences and adds
-  offer blocks you don't need). Fill only that marketplace's offer.
+- **Don't fight the marketplace checkboxes in the generator** — just make
+  sure your **target** marketplace is ticked and Generate; do NOT try to
+  uncheck the others. A bundled multi-marketplace template is fine (`fill`
+  routes offer + quantity to your target's block); the store `kat-checkbox`
+  toggles are unreliable and unchecking buys nothing but a stuck run.
 - **Main image is not required by default** — we do **not** upload
   images from here (the seller adds them separately). So a `18320`
   ("main image is missing") error is *expected noise*, not a blocker;

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -147,11 +147,18 @@ a family that the parent shows **"Variations (N)"**.
   marketplace, creating an ASIN with **no live offer** ("Missing offer",
   never live) even though the feed says success. Instead give the spec a
   top-level `"marketplace": "<CC>"` (the country you're listing on) and a
-  bare `"our_price"` on each child; `fill` routes it to the right block
-  (+ `fulfillment_availability#1.quantity`). **Verify it in THAT
-  marketplace's Pricing view** — the feed "N/N successful" count does not
-  reflect price, and quantity can apply
-  while price shows `--` if you set a different marketplace's column.
+  bare `"our_price"` **and bare `"quantity"`** on each child; `fill` routes
+  BOTH to that marketplace's block. **Stock is per-marketplace too, and it
+  is NOT bracketed like the price** — each `fulfillment_availability#N`
+  group is tied by *position* to one marketplace's offer block, so `#1` is
+  a *different* marketplace than you may think. Never hand-pick a
+  `fulfillment_availability#N.quantity` column; use the bare `quantity` and
+  let `fill` pick the group adjacent to the target offer (it also
+  normalises a wrong-index `fulfillment_availability#k.*` to the right
+  one). Putting stock on the wrong group = an offer with no stock = never
+  live. **Verify it in THAT marketplace's Pricing view** — the feed "N/N
+  successful" count does not reflect price, and quantity can apply while
+  price shows `--` if you set a different marketplace's column.
 - **A multi-marketplace account's template bundles every marketplace's
   offer columns** (e.g. a Europe account yields both SA + AE columns even
   when you select one) — a truly single-country template may not be

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -99,6 +99,17 @@ listing. **Always confirm on Manage Inventory** (or
 false-negates incomplete listings). Confirm the SKU has an ASIN, and for
 a family that the parent shows **"Variations (N)"**.
 
+> **Do NOT re-upload just because Check Upload Status shows "N/A".** After
+> a submit, the batch's "SKUs successful / N/A" column stays `N/A` for
+> minutes (and CREATE/DELETE feeds can sit at N/A a long time) — that is
+> **normal, not a failure**, and the widget's shadow-root text may even
+> read "File not uploaded" on a submit that *did* go through. Re-uploading
+> on N/A just creates duplicate batches and wastes the run. Once you have
+> a batch reference_id, the upload was accepted: **go straight to Manage
+> Inventory** (search your SKU prefix) to verify the family is live —
+> that is the source of truth, not the feed status. Only re-upload if the
+> **downloaded processing report** names a real per-SKU error to fix.
+
 ### Priors that recur across categories
 
 - **Upload a tab-delimited `.txt`, not the `.xlsm`.** `fill` writes the

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -50,46 +50,47 @@ Spreadsheet**. The file lands in `~/.vibe-seller/downloads/<slug>/`
 > `getBoundingClientRect` centre, poll the downloads dir for the new
 > `.xlsm`, then `cdp("Emulation.clearDeviceMetricsOverride")`.
 
-> **Getting TO the product-type search (current Beta flow — don't
-> reverse-engineer it):** Spreadsheet → **Download Blank Template** lands
-> on `/product-search/bulk/generate` showing **template cards** (e.g.
-> "List products that are not currently in Amazon's catalog"). The card
-> body text is NOT the button — the clickable control is a **`kat-button`
-> in the card's FOOTER**. Find it via the DOM, not a screenshot:
-> `js` for `kat-card kat-button` → `getBoundingClientRect` → `click_at_xy`
-> (see browser-harness "Locate & click without vision"). That navigates to
-> `/product-search/bulk/generate/add-product`, the product-type search page.
+> **Getting TO the product-type search (verified 2026-07, NGS beta).**
+> On `/product-search/bulk` a right-side **"Choose a template"** panel
+> opens; click the **Download Product Spreadsheet** button under **"List
+> products that are not currently in Amazon's catalog"** (that's the
+> create-new-ASIN card — NOT "Get Listing Loader", which is for existing
+> ASINs). It opens the **Download Product Spreadsheet** panel at
+> `/product-search/bulk/generate/add-product` (language dropdown +
+> product-type search + store checkboxes + Generate). Locate the button by
+> its label text via the DOM and `click_at_xy` it.
 >
-> **Product-Type search gotcha:** the search box is a `kat-input` whose
-> real `<input>` is in its shadow root, and Amazon's search only fires on
-> **input/change events** — a bare `value=` (or `kat-input.value=`) sets
-> the text but dispatches nothing, so the candidate list never opens. You
-> MUST set the value with the **native setter on the inner input** and then
-> **dispatch `input` + `change` with `composed:true`** (to cross the shadow
-> boundary); poking React's `_valueTracker` helps too. Then click the
-> search icon and the **Select** button. Verified recipe:
+> **Product-Type search — it's a PLAIN `<input>` + a separate search-icon
+> button, NOT a shadow-dropdown.** Setting `value` or dispatching
+> input/change does NOT open a suggestion list (there is none); you must
+> TYPE into it and click the magnifying-glass button beside it. Verified
+> recipe:
 >
 > ```bash
 > browser-use <<'PY'
 > import time
-> js(r"""
->   var inp = document.querySelector('kat-input').shadowRoot.querySelector('input');
->   var set = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set;
->   set.call(inp, 'sock');                                   // product-type query
->   inp.dispatchEvent(new Event('input',  {bubbles:true, composed:true}));
->   inp.dispatchEvent(new Event('change', {bubbles:true, composed:true}));
->   if (inp._valueTracker) inp._valueTracker.setValue('sock');
-> """)
-> time.sleep(2)   # async suggestions
-> # then locate the matched type's Select button via the DOM and click_at_xy it
-> print(js(r"""return [].slice.call(document.querySelectorAll('kat-button'))
+> box = js(r"""var i=document.querySelector('input[placeholder*="Product keyword"]');
+>   if(!i)return null;var r=i.getBoundingClientRect();
+>   return {x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)};""")
+> click_at_xy(box["x"], box["y"])                 # focus the input
+> cdp("Input.insertText", text="socks")           # TRUSTED typing (value= / events don't stick)
+> time.sleep(1)
+> # click the search-icon button just right of the input (find it by position),
+> # then the matched type's **Select** button (e.g. the "Sock" row):
+> print(js(r"""return [].slice.call(document.querySelectorAll('button,kat-button'))
 >   .map(function(b){var r=b.getBoundingClientRect();
->     return {t:(b.innerText||'').trim().slice(0,20), x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)};})
->   .filter(function(e){return e.t;});"""))
+>     return {t:(b.innerText||b.getAttribute('label')||'').trim().slice(0,20),
+>             x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)};})
+>   .filter(function(e){return e.x>0;});"""))   # → click the search icon, then Select
 > PY
 > ```
-> (Clicking the `kat-icon name=search` icon alone, without the events, is
-> what makes runs flail here — don't rely on it.)
+> After **Select**, the right column shows "Product Type Selected: Sock".
+> Then tick the store(s) (the account's home marketplace may be force-
+> checked; ensure the marketplace you're listing on is ticked), and click
+> **Generate Spreadsheet** — which is below the fold, so use the CDP
+> viewport-resize recipe above. A fresh `.xlsm` lands in the downloads dir
+> within ~30s. (`cdp("Input.insertText", ...)` needs the element focused
+> first — click it, don't just querySelector it.)
 
 > **The create template generates asynchronously** — "Generate
 > Spreadsheet" does not always land a direct download. If it doesn't

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -33,11 +33,25 @@ Seller Central → **Catalogue → Add Products via Upload**
 (`sellercentral.amazon.<tld>/listing/upload` → `/product-search/bulk`).
 Open **Spreadsheet → Download Blank Template → Download Product
 Spreadsheet**, search the product type (e.g. "socks" → **Select**
-"Sock"), choose the language, then **select the store's own single
-marketplace only** (uncheck the others — the picker defaults to several,
-and multi-marketplace disables Listing Preferences), then **Generate
-Spreadsheet**. The file lands in `~/.vibe-seller/downloads/<slug>/`
+"Sock"), choose the language, then **just make sure your TARGET
+marketplace's checkbox is ticked** (it usually is by default) and
+**Generate Spreadsheet**. The file lands in `~/.vibe-seller/downloads/<slug>/`
 (a macro-enabled `.xlsm`).
+
+> **Do NOT try to uncheck the other marketplaces.** A bundled
+> multi-marketplace template (e.g. SA + AE) is perfectly fine — `fill`
+> routes the offer AND the quantity to your target marketplace's block
+> (see the per-marketplace offer/stock rule below), so extra marketplaces
+> in the template are harmless. Fighting the store `kat-checkbox`es wastes
+> the run: their state doesn't reliably toggle via `click_at_xy`/JS, and
+> the whole point (single-marketplace) buys you nothing. Leave them as-is
+> and Generate.
+>
+> **Coordinate gotcha after a viewport resize:** if you used
+> `Emulation.setDeviceMetricsOverride` (below-fold recipe) to reach the
+> Generate button, every element's `getBoundingClientRect` is now in the
+> NEW tall viewport — **re-read the coordinates after the override**
+> before `click_at_xy`; the pre-resize x/y are stale.
 
 > **The "Generate Spreadsheet" button is usually BELOW the fold** (it sits
 > at the bottom of a tall `kat-popover`, and the Ziniao window is only

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -39,6 +39,17 @@ and multi-marketplace disables Listing Preferences), then **Generate
 Spreadsheet**. The file lands in `~/.vibe-seller/downloads/<slug>/`
 (a macro-enabled `.xlsm`).
 
+> **The "Generate Spreadsheet" button is usually BELOW the fold** (it sits
+> at the bottom of a tall `kat-popover`, and the Ziniao window is only
+> ~839px tall — `scrollIntoView`/`scrollTo` can't bring it up, so a normal
+> `click_at_xy` can't reach it). Don't reuse a stale template to dodge
+> this. Grow the viewport with CDP, then click: see browser-harness
+> **"A control BELOW the fold that won't scroll into view"** —
+> `cdp("Emulation.setDeviceMetricsOverride", width=1920, height=2400,
+> deviceScaleFactor=1, mobile=False)`, `click_at_xy` the button's
+> `getBoundingClientRect` centre, poll the downloads dir for the new
+> `.xlsm`, then `cdp("Emulation.clearDeviceMetricsOverride")`.
+
 > **Getting TO the product-type search (current Beta flow — don't
 > reverse-engineer it):** Spreadsheet → **Download Blank Template** lands
 > on `/product-search/bulk/generate` showing **template cards** (e.g.

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -128,7 +128,7 @@ fields.
                   "age_range_description": "Adult",
                   "recommended_browse_nodes": "<from Browse data>",
                   "fulfillment_availability#1.fulfillment_channel_code": "DEFAULT",
-                  "fulfillment_availability#1.quantity": "100",
+                  "quantity": "100",
                   "our_price": "29.00" } }
   ]
 }
@@ -182,8 +182,9 @@ fields.
   images, colour/size, or product-id — those are child-level.
 - **Child** rows: `parent_child: Child`, `parent_sku` = the parent's
   SKU, the differentiating attribute (`color_name` / `size_name`), plus
-  the **offer** (`fulfillment_availability#1.*`) and **price**
-  (`purchasable_offer[marketplace_id=…]#1.our_price#1.schedule#1.value_with_tax`,
+  the **stock** (bare `quantity` — `fill` routes it to the marketplace's
+  own `fulfillment_availability#N` group) and **price** (bare `our_price`
+  → `purchasable_offer[marketplace_id=…]#1.our_price#1.schedule#1.value_with_tax`,
   one block per target marketplace).
 
 `fill` knows this: it suppresses child-level required-field warnings on
@@ -337,11 +338,14 @@ re-uploads can complete them.
 - **Offer/price is per-marketplace; verify in that marketplace's Pricing
   view.** Fill one offer block —
   `purchasable_offer[marketplace_id=<MKT>]#1.our_price#1.schedule#1.value_with_tax`
-  (`our_price` is the only price column that matters) +
-  `fulfillment_availability#1.quantity`. The feed count doesn't reflect
-  price; quantity can apply while Pricing shows `--` if you set a
-  different marketplace's column. On a bundled multi-marketplace
-  template, fill only the intended marketplace's block.
+  (`our_price` is the only price column that matters) + a bare `quantity`
+  for stock. **Stock is per-marketplace but NOT bracketed** — each
+  `fulfillment_availability#N` group is tied by *position* to one
+  marketplace's offer block, so don't hand-pick `#1`; use bare `quantity`
+  and `fill` routes it to the group adjacent to the target offer. The feed
+  count doesn't reflect price; quantity can apply while Pricing shows `--`
+  if you set a different marketplace's column. On a bundled
+  multi-marketplace template, fill only the intended marketplace's block.
 - **`main_image_url`:** by default not uploaded here (seller adds images)
   — a `18320` image error is *expected*, not a blocker. Never hotlink a
   supplier CDN URL (1688/alibaba `cbu01.alicdn.com`, tmall) — Amazon

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -68,6 +68,7 @@ except ImportError:
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from marketplace_ids import (  # noqa: E402,F401
     MARKETPLACE_IDS,  # re-exported for callers/tests
+    fulfillment_index as _fulfillment_index_for_marketplace,
     ids_in_template as _marketplace_ids_in_template,
     resolve as _resolve_marketplace_id,
 )
@@ -419,6 +420,23 @@ def _route_offer_price(fields, cols, mkt_id, i, sku, warnings):
                 f'listing on marketplace_id={mkt_id}, which has NO offer -- the '
                 f'listing will be "Missing offer" (never live). Use "our_price".'
             )
+    # Fulfillment/stock is NOT marketplace-bracketed: each
+    # `fulfillment_availability#N` group is tied by position to one
+    # marketplace's offer block. Route a bare `quantity` + normalise any
+    # `fulfillment_availability#k.*` to the TARGET marketplace's index, so
+    # stock can't land on the wrong marketplace (SA offer + AE qty = dead).
+    if mkt_id is not None:
+        n = _fulfillment_index_for_marketplace(cols, mkt_id)
+        if n is not None:
+            if 'quantity' in fields:
+                fields[f'fulfillment_availability#{n}.quantity'] = fields.pop(
+                    'quantity'
+                )
+            for k in list(fields):
+                if k.startswith('fulfillment_availability#') and '.' in k:
+                    tgt = f'fulfillment_availability#{n}.{k.split(".", 1)[1]}'
+                    if tgt != k:
+                        fields[tgt] = fields.pop(k)
 
 
 def cmd_fill(args):

--- a/app/skills_v2/amazon-listing/scripts/marketplace_ids.py
+++ b/app/skills_v2/amazon-listing/scripts/marketplace_ids.py
@@ -12,6 +12,8 @@ template's `purchasable_offer[marketplace_id=<id>]` columns, so a
 marketplace Amazon adds *after* this table still works without an edit.
 """
 
+import re
+
 MARKETPLACE_IDS = {
     # North America
     'US': 'ATVPDKIKX0DER',  # amazon.com
@@ -44,7 +46,38 @@ MARKETPLACE_IDS = {
 # id -> country code, for reverse lookups / labelling.
 COUNTRY_BY_ID = {v: k for k, v in MARKETPLACE_IDS.items()}
 
-_MKT_ID_IN_COLUMN = __import__('re').compile(r'marketplace_id=([A-Za-z0-9]+)')
+_MKT_ID_IN_COLUMN = re.compile(r'marketplace_id=([A-Za-z0-9]+)')
+_FULFILL_GROUP = re.compile(r'fulfillment_availability#(\d+)\.')
+
+
+def fulfillment_index(cols, mkt_id):
+    """Which `fulfillment_availability#N` group belongs to a marketplace.
+
+    Fulfillment columns are NOT marketplace-bracketed like
+    `purchasable_offer[marketplace_id=...]`; each `fulfillment_availability#N`
+    group instead sits just before that marketplace's offer block. So stock
+    for marketplace X must use the N whose columns most-closely precede X's
+    offer block -- else quantity lands on the wrong marketplace (an SA offer
+    with AE stock never goes live). `cols` maps field name -> list of 1-based
+    column indices. Returns N (int) or None.
+    """
+    offer = [
+        c
+        for k, v in cols.items()
+        if f'marketplace_id={mkt_id}]' in k
+        for c in v
+    ]
+    if not offer:
+        return None
+    target = min(offer)
+    best = None  # (min_col, N) of the nearest group preceding the offer
+    for k, v in cols.items():
+        m = _FULFILL_GROUP.match(str(k))
+        if m:
+            col = min(v)
+            if col < target and (best is None or col > best[0]):
+                best = (col, int(m.group(1)))
+    return best[1] if best else None
 
 
 def ids_in_template(cols):

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -132,6 +132,39 @@ print(els)          # pick the one whose text matches, then click_at_xy(it.x, it
 PY
 ```
 
+### A control BELOW the fold that won't scroll into view
+
+Some pages (e.g. Amazon's "Generate Spreadsheet" popover) put the button
+you need **below the viewport**, inside a `kat-popover`/panel that
+`scrollTo`/`scrollIntoView` can't bring up — the window is short (e.g.
+839px tall) and `click_at_xy` can't hit an off-screen y. Don't fight the
+scroll: **grow the layout viewport with CDP so the whole panel fits**,
+then click the (now on-screen) coordinate, then restore:
+
+```bash
+browser-use <<'PY'
+import time
+cdp("Emulation.setDeviceMetricsOverride",
+    width=1920, height=2400, deviceScaleFactor=1, mobile=False)  # tall viewport
+time.sleep(1)
+box = js("""
+  var els=document.querySelectorAll('kat-button,button,[role=button]');
+  for(var i=0;i<els.length;i++){var t=(els[i].innerText||els[i].getAttribute('label')||'').trim();
+    if(/generate spreadsheet/i.test(t)){var r=els[i].getBoundingClientRect();
+      return {x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)};}}
+  return null;
+""")
+if box: click_at_xy(box["x"], box["y"])   # trusted click, now on-screen
+time.sleep(3)
+cdp("Emulation.clearDeviceMetricsOverride")   # restore the real viewport
+PY
+```
+
+(Verified: the override raises `window.innerHeight` to the set value, so a
+below-fold button becomes reachable; `clearDeviceMetricsOverride` undoes
+it. A plain JS `.click()` still no-ops on `kat-*` — you need the trusted
+`click_at_xy`.)
+
 For an element inside an **open shadow root** (Amazon `kat-*`), pierce it
 in the selector: `document.querySelector('kat-file-upload').shadowRoot.querySelector('input')`.
 Set an input's value with `js("document.querySelector('#q').value='socks'")`

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -742,3 +742,42 @@ def test_resolve_auto_detects_single_marketplace_template():
     # Ambiguous: unknown code + multi-marketplace template -> fail loudly.
     with pytest.raises(SystemExit):
         r('ZA', [_SA, _AE])
+
+
+# A real multi-marketplace template interleaves each marketplace's
+# fulfillment_availability#N group with its offer block: AE (#1) then SA
+# (#2). Column order matters -- the resolver picks the group by position.
+_AE_QTY = 'fulfillment_availability#1.quantity'
+_SA_QTY = 'fulfillment_availability#2.quantity'
+_MKT_COLS = {
+    'item_sku': [2],
+    _AE_QTY: [165],
+    _AE_PRICE: [171],
+    _SA_QTY: [181],
+    _SA_PRICE: [186],
+}
+
+
+def test_fulfillment_index_maps_to_the_marketplaces_own_group():
+    f = listing_bulk._fulfillment_index_for_marketplace
+    assert f(_MKT_COLS, _AE) == 1  # AE's stock group precedes AE's offer
+    assert f(_MKT_COLS, _SA) == 2  # SA's stock group precedes SA's offer
+
+
+def test_route_sends_quantity_to_target_marketplace_group():
+    # Listing on SA: a bare `quantity` must land in SA's group (#2), NOT the
+    # first group (#1 = AE) -- else the SA offer has no stock and never lives.
+    fields = {'our_price': '19.99', 'quantity': '100'}
+    listing_bulk._route_offer_price(fields, _MKT_COLS, _SA, 0, 'K-WHT', [])
+    assert fields[_SA_QTY] == '100'
+    assert _AE_QTY not in fields
+    assert fields[_SA_PRICE] == '19.99'
+
+
+def test_route_remaps_wrong_index_fulfillment_to_target():
+    # The agent wrote fulfillment_availability#1 (AE) but is listing on SA;
+    # normalise it to SA's group (#2).
+    fields = {_AE_QTY: '100', 'our_price': '19.99'}
+    listing_bulk._route_offer_price(fields, _MKT_COLS, _SA, 0, 'K-WHT', [])
+    assert fields[_SA_QTY] == '100'
+    assert _AE_QTY not in fields


### PR DESCRIPTION
## What

Fixes **six** real gaps in the amazon-listing skill that a **clean-state**
end-to-end test exposed — a vision-free agent (DeepSeek) creating and then
deleting a variation family on a live seller account, from scratch, with no
leftover files to lean on.

The headline finding: **the fresh-template-download step was never actually
robust.** Earlier "one-shot" runs had been quietly reusing a leftover product
spreadsheet in the downloads dir. Removing it surfaced three separate blockers
before the agent could even fill a template, plus a fill bug, a
don't-re-upload bug, and a don't-misread-async-state bug.

## The six gaps

- **A — the "Generate Spreadsheet" button is below the fold.** It sits at the
  bottom of a tall `kat-popover`; the window is ~839px, so
  `scrollIntoView`/`scrollTo` can't bring it up and `click_at_xy` can't reach
  an off-screen y. Fix (verified live: viewport grew 839→2600): CDP
  `Emulation.setDeviceMetricsOverride` → `click_at_xy` → `clearDeviceMetricsOverride`.
  Added as a general browser-harness recipe. (`899618a`)

- **B — stock/quantity routed to the wrong marketplace.** On a
  multi-marketplace template, `fulfillment_availability` is NOT bracketed by
  `marketplace_id` like `purchasable_offer` is; each `#N` group is tied by
  *column position* to one marketplace's offer block. `fill` only routed
  `our_price`, so a bare/`#1` quantity landed on the *first* marketplace — the
  target offer got no stock and never went live even though the feed said
  success. Added `marketplace_ids.fulfillment_index()` + bare-`quantity`
  routing. **22 unit tests.** (`df70311`)

- **C — the NGS product-type search recipe was wrong.** The old doc assumed a
  `kat-input` shadow-dropdown that auto-opens on input/change events. On the
  current NGS beta it's a **plain `<input>` + a separate search-icon button**
  with no auto-suggest, so `value=`/events never open a list and runs got
  stuck. Replaced with the recipe verified live via vision + debug-store:
  open Download Product Spreadsheet, click-focus the input, type via CDP
  `Input.insertText`, click the search icon, click Select on the matched type,
  tick the store, Generate. **Confirmed a fresh template downloads.** (`90ab79c`)

- **D — don't re-upload on "N/A" status.** After a submit, Check Upload Status
  shows `N/A` for minutes and the widget's shadow-root text can even read
  "File not uploaded" on a submit that *did* go through. An agent mis-read
  that as failure and re-uploaded in a loop. Strengthened the verify guidance:
  once you have a batch reference id the submit was accepted; go straight to
  Manage Inventory; only re-upload if the downloaded report names a real error.
  (`88fdbe4`)

- **E — don't fight the generator's marketplace checkboxes.** The old doc told
  the agent to *uncheck* the other marketplaces to force a single-marketplace
  template. On the live generator the store's marketplaces come pre-ticked and
  unchecking them is fragile (coordinates shift after the viewport resize from
  gap A) — the agent burned ~150 messages fighting them. A multi-marketplace
  template is fine (gap B already routes per-marketplace); leave the checkboxes
  alone and re-read `getBoundingClientRect` after any resize. (`88b77c5`)

- **F — "Missing Information / ASIN -" is usually NOT a failure.** After a
  successful create, variation child ASINs mint **asynchronously** (10–30 min)
  and the products park in "Complete drafts → Submitted: Provide missing
  information" until minted — and a product whose only missing field is the
  main image parks there too. An agent read that as a hard failure and
  thrashed for ~45 min. Guidance now: re-check, don't re-upload; a listing is
  **done** when it's in Manage Inventory with the variation relationship, real
  child ASINs, and correct title/price/bullets — a blank image is an accepted
  done-state the seller fills in later. (`7a7d0e4`)

## Verified live (DeepSeek, clean state, on a real account)

Both flows ran as real vibe-seller agent tasks. The operator answered **only
the agent's own seller-choice questions** (which marketplace) — no technical
herding, no driving the browser to advance the task.

- **CREATE — hands-off, produced a live variation family.** The agent
  downloaded a fresh template (gaps A+C), filled it with correct
  per-marketplace quantity routing (gap B), uploaded it, and the family went
  **live in Manage Inventory**: parent + 2 children, real child ASINs,
  `Variations (2)`, correct title/price/bullets. The main image was left blank
  (an accepted done-state — the seller uploads it). Confirmed read-only in
  Manage Inventory. Reaching the clean hands-off run took **1 N-1** (gap E, the
  checkbox fight) plus **gap F** (the async-ASIN / image-only verification
  confusion) — both now fixed here.

- **DELETE — hands-off, family gone.** The agent built a delete flat-file (3
  rows, `delete` action), uploaded it, correctly did **not** re-upload on the
  N/A batch status (gap D), and self-verified each SKU via skucentral plus an
  inventory recount (item count dropped by exactly 3; the family absent from
  search; cross-checked the second marketplace to be sure nothing lingered).
  Independently confirmed read-only: all three SKUs' skucentral pages redirect
  to the inventory list, and an inventory search for the family returns zero.

## Tests

- 22 unit tests pass (`tests/unit/test_amazon_listing_bulk_skill.py`).
- Full `pytest -m unit`: 1192 passed, 1 skipped. One unrelated failure
  (`test_platform.py::test_finds_own_listener`, a socket-introspection probe)
  is environmental to the local macOS sandbox shell and outside this diff —
  the diff touches only `app/skills_v2/amazon-listing/*` + `browser-harness`
  docs + the skill test.
- pre-commit clean (incl. 800-line limit); scanned diff / commits / body for
  real-account data — none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
