### PR TITLE
DoD gate fail-closed fix + noon-listing verified live (dual-path create + delete)

### DIFF
--- a/app/ai/bash_safety.py
+++ b/app/ai/bash_safety.py
@@ -404,10 +404,9 @@ def check_report_overwrite(
 # The REPORT-reviewer verdict logic lives in
 # ``stop_gates.report_reviewer`` so BOTH completion paths (this Stop hook
 # AND set_task_result) enforce the same sign-off — see that module's
-# docstring. These two regexes are still used by the EXEC-review guard
-# below (phase-4 ``EXEC_REVIEW_*`` files share the ``Status:``/``_iter``
-# format).
-_REVIEW_STATUS_RE = re.compile(r'^Status:\s*(\w+)', re.MULTILINE)
+# docstring. Status parsing lives there too (``effective_status``, shared
+# by the EXEC-review guard below so the fail-closed rule has one home);
+# only the iter-number regex is still needed locally.
 _REVIEW_ITER_RE = re.compile(r'_iter(\d+)\.md$')
 
 # Audits a SERVER-side completeness gate reviews at set_task_result.
@@ -559,8 +558,11 @@ def check_exec_review_status(task_dir) -> str | None:
             'execution-review file.'
         )
 
-    match = _REVIEW_STATUS_RE.search(content)
-    if not match:
+    # Fail-closed on a self-contradictory verdict (a leading ``ok`` with a
+    # bolded ``incomplete`` conclusion) — same rule as the report gate,
+    # shared so the bug class can't recur in only one path.
+    status, _statuses = report_reviewer.effective_status(content)
+    if status is None:
         return (
             f'{latest.name} has no ``Status:`` line. The execution '
             'reviewer output must begin with one of: ``Status: ok`` '
@@ -569,7 +571,6 @@ def check_exec_review_status(task_dir) -> str | None:
             'Execution-review mode``.'
         )
 
-    status = match.group(1).lower()
     iter_num = _iter_of(latest)
     # Stale-review guard: a Status: ok review predating the latest
     # EXECUTION_LOG row count is no longer valid. Compare mtimes.

--- a/app/ai/stop_gates/report_reviewer.py
+++ b/app/ai/stop_gates/report_reviewer.py
@@ -33,7 +33,15 @@ import re
 # Ad skills whose tasks carry a Definition-of-Done reviewer contract.
 AD_SKILLS = frozenset({'amazon-ads', 'noon-ads', 'qianniu-ads'})
 
-_REVIEW_STATUS_RE = re.compile(r'^Status:\s*(\w+)', re.MULTILINE)
+# Match a ``Status:`` verdict anywhere it can legitimately appear — plain
+# at line start (``Status: ok``) OR emphasised/indented (``**Status:
+# incomplete**``, ``- Status: gaps``). A reviewer that stamps a leading
+# ``ok`` but concludes ``incomplete`` in a bolded footer is a real failure
+# mode; the gate must SEE both lines so it can fail-closed on the conflict
+# (see ``reviewer_verdict``). Case-insensitive so ``status:`` also counts.
+_REVIEW_STATUS_RE = re.compile(
+    r'^[\s*_>#-]*Status:\s*(\w+)', re.MULTILINE | re.IGNORECASE
+)
 _REVIEW_ITER_RE = re.compile(r'_iter(\d+)\.md$')
 # A review file carries ``review`` as a distinct token (case-insensitive,
 # not a substring of another word). Accepts ``REVIEW_...``,
@@ -129,8 +137,16 @@ def reviewer_verdict(task_dir) -> str | None:
     except OSError:
         return f'{latest.name} could not be read; rewrite the review file.'
 
-    match = _REVIEW_STATUS_RE.search(content)
-    if not match:
+    # Collect EVERY status the review states, not just the first. A DoD
+    # gate exists to block half-done work, so it must fail-closed on a
+    # self-contradictory review: a reviewer that stamps a leading
+    # ``Status: ok`` but concludes ``incomplete``/``gaps`` in its body
+    # (observed live — a mis-added total the reviewer caught yet still
+    # top-stamped ``ok``) must be read at its MOST-CONSERVATIVE verdict,
+    # never the stray ``ok``. Severity, least→most likely to pass:
+    # gaps (never passes) > incomplete (passes only at max iter) > ok.
+    statuses = [s.lower() for s in _REVIEW_STATUS_RE.findall(content)]
+    if not statuses:
         return (
             f'{latest.name} has no ``Status:`` line. The reviewer '
             'output must begin with one of: ``Status: ok`` | '
@@ -139,8 +155,25 @@ def reviewer_verdict(task_dir) -> str | None:
             'canonical format.'
         )
 
-    status = match.group(1).lower()
     iter_num = _iter_of(latest)
+    known = {'ok', 'gaps', 'incomplete'}
+    conflict = len(set(statuses)) > 1
+    if 'gaps' in statuses:
+        status = 'gaps'
+    elif 'incomplete' in statuses:
+        status = 'incomplete'
+    elif set(statuses) <= {'ok'}:
+        status = 'ok'
+    else:  # an unrecognised token is present — surface it, don't pass
+        status = next(s for s in statuses if s not in known)
+    conflict_note = (
+        f' NOTE: {latest.name} states conflicting Status lines '
+        f'{sorted(set(statuses))} — a review must reach ONE verdict. '
+        'Rewrite it so the top ``Status:`` line matches your conclusion.'
+        if conflict
+        else ''
+    )
+
     if status == 'ok':
         return None
     if status == 'incomplete' and iter_num >= REVIEW_MAX_ITERS:
@@ -153,13 +186,13 @@ def reviewer_verdict(task_dir) -> str | None:
             'reviewer again to write '
             f'``REVIEW_*_iter{iter_num + 1}.md``. Repeat until '
             f'Status: ok or iter {REVIEW_MAX_ITERS} with '
-            'Status: incomplete.'
+            f'Status: incomplete.{conflict_note}'
         )
     if status == 'incomplete' and iter_num < REVIEW_MAX_ITERS:
         return (
             f'``Status: incomplete`` only valid at iter '
             f'{REVIEW_MAX_ITERS}+. Current is iter {iter_num} — '
-            'keep iterating.'
+            f'keep iterating.{conflict_note}'
         )
     return (
         f'Unknown reviewer status {status!r} in {latest.name}. '

--- a/app/ai/stop_gates/report_reviewer.py
+++ b/app/ai/stop_gates/report_reviewer.py
@@ -76,6 +76,33 @@ def partial_banner() -> str:
     return _PARTIAL_BANNER
 
 
+def effective_status(content: str) -> tuple[str | None, list[str]]:
+    """The most-conservative ``Status:`` verdict stated in a review body.
+
+    A review may (wrongly) state more than one ``Status:`` line — e.g. a
+    leading ``ok`` with a bolded ``**Status: incomplete**`` conclusion.
+    A DoD gate must never be fooled by the stray ``ok``, so this returns
+    the verdict LEAST likely to pass: ``gaps`` (never passes) >
+    ``incomplete`` (passes only at max iter) > ``ok`` — an unrecognised
+    token is surfaced verbatim so the caller rejects it. Returns
+    ``(status, raw_statuses)``; ``status`` is ``None`` when no ``Status:``
+    line exists, and ``len(set(raw_statuses)) > 1`` signals a conflict.
+    Shared by BOTH review gates (this module and the execution-review
+    check in ``bash_safety``) so the fail-closed rule has one home.
+    """
+    statuses = [s.lower() for s in _REVIEW_STATUS_RE.findall(content)]
+    if not statuses:
+        return None, statuses
+    if 'gaps' in statuses:
+        return 'gaps', statuses
+    if 'incomplete' in statuses:
+        return 'incomplete', statuses
+    if set(statuses) <= {'ok'}:
+        return 'ok', statuses
+    known = {'ok', 'gaps', 'incomplete'}
+    return next(s for s in statuses if s not in known), statuses
+
+
 def reviewer_verdict(task_dir) -> str | None:
     """Deny reason if the reviewer hasn't signed off; else ``None``.
 
@@ -137,16 +164,13 @@ def reviewer_verdict(task_dir) -> str | None:
     except OSError:
         return f'{latest.name} could not be read; rewrite the review file.'
 
-    # Collect EVERY status the review states, not just the first. A DoD
-    # gate exists to block half-done work, so it must fail-closed on a
-    # self-contradictory review: a reviewer that stamps a leading
-    # ``Status: ok`` but concludes ``incomplete``/``gaps`` in its body
-    # (observed live — a mis-added total the reviewer caught yet still
-    # top-stamped ``ok``) must be read at its MOST-CONSERVATIVE verdict,
-    # never the stray ``ok``. Severity, least→most likely to pass:
-    # gaps (never passes) > incomplete (passes only at max iter) > ok.
-    statuses = [s.lower() for s in _REVIEW_STATUS_RE.findall(content)]
-    if not statuses:
+    # Fail-closed on a self-contradictory review: a reviewer that stamps
+    # a leading ``Status: ok`` but concludes ``incomplete``/``gaps`` in
+    # its body (observed live — a mis-added total the reviewer caught yet
+    # still top-stamped ``ok``) must be read at its MOST-CONSERVATIVE
+    # verdict, never the stray ``ok``. ``effective_status`` owns that rule.
+    status, statuses = effective_status(content)
+    if status is None:
         return (
             f'{latest.name} has no ``Status:`` line. The reviewer '
             'output must begin with one of: ``Status: ok`` | '
@@ -156,16 +180,7 @@ def reviewer_verdict(task_dir) -> str | None:
         )
 
     iter_num = _iter_of(latest)
-    known = {'ok', 'gaps', 'incomplete'}
     conflict = len(set(statuses)) > 1
-    if 'gaps' in statuses:
-        status = 'gaps'
-    elif 'incomplete' in statuses:
-        status = 'incomplete'
-    elif set(statuses) <= {'ok'}:
-        status = 'ok'
-    else:  # an unrecognised token is present — surface it, don't pass
-        status = next(s for s in statuses if s not in known)
     conflict_note = (
         f' NOTE: {latest.name} states conflicting Status lines '
         f'{sorted(set(statuses))} — a review must reach ONE verdict. '

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -99,6 +99,34 @@ listing. **Always confirm on Manage Inventory** (or
 false-negates incomplete listings). Confirm the SKU has an ASIN, and for
 a family that the parent shows **"Variations (N)"**.
 
+> **"Missing Information / ASIN -" is usually NOT a failure — don't
+> thrash.** Two benign causes, and re-uploading fixes neither:
+> 1. **ASINs mint asynchronously.** A just-submitted family can show
+>    `ASIN -` / a "Complete drafts → Submitted: Provide missing
+>    information" entry for **10–30 minutes** while Amazon mints the
+>    ASINs. Re-check Manage Inventory later — the parent flips to
+>    `Variations (N)` with real child ASINs on its own. Do NOT re-upload
+>    (that just spawns duplicate batches).
+> 2. **Only the main image is missing.** We intentionally don't upload
+>    images, so a no-image product parks in "provide missing information"
+>    for the image alone. **That is an acceptable DONE state** — the
+>    seller adds the image later. The listing is **finished** once Manage
+>    Inventory shows it with the variation relationship (`Variations (N)`),
+>    real child ASINs, and correct **title / price / bullets**; a blank
+>    image does not block "done". Only treat it as unfinished if the
+>    processing report names a **non-image** blocking error.
+
+> **Do NOT re-upload just because Check Upload Status shows "N/A".** After
+> a submit, the batch's "SKUs successful / N/A" column stays `N/A` for
+> minutes (and CREATE/DELETE feeds can sit at N/A a long time) — that is
+> **normal, not a failure**, and the widget's shadow-root text may even
+> read "File not uploaded" on a submit that *did* go through. Re-uploading
+> on N/A just creates duplicate batches and wastes the run. Once you have
+> a batch reference_id, the upload was accepted: **go straight to Manage
+> Inventory** (search your SKU prefix) to verify the family is live —
+> that is the source of truth, not the feed status. Only re-upload if the
+> **downloaded processing report** names a real per-SKU error to fix.
+
 ### Priors that recur across categories
 
 - **Upload a tab-delimited `.txt`, not the `.xlsm`.** `fill` writes the
@@ -114,9 +142,11 @@ a family that the parent shows **"Variations (N)"**.
 - **Compound attributes come as a set** — e.g. Apparel Size needs
   `apparel_size_class` + `apparel_size_system` + `apparel_body_type` +
   `apparel_height_type` together; a partial set errors (99001/99022).
-- **Own-country only** — in the generator, select the store's **single**
-  marketplace (multi-marketplace disables Listing Preferences and adds
-  offer blocks you don't need). Fill only that marketplace's offer.
+- **Don't fight the marketplace checkboxes in the generator** — just make
+  sure your **target** marketplace is ticked and Generate; do NOT try to
+  uncheck the others. A bundled multi-marketplace template is fine (`fill`
+  routes offer + quantity to your target's block); the store `kat-checkbox`
+  toggles are unreliable and unchecking buys nothing but a stuck run.
 - **Main image is not required by default** — we do **not** upload
   images from here (the seller adds them separately). So a `18320`
   ("main image is missing") error is *expected noise*, not a blocker;
@@ -147,11 +177,18 @@ a family that the parent shows **"Variations (N)"**.
   marketplace, creating an ASIN with **no live offer** ("Missing offer",
   never live) even though the feed says success. Instead give the spec a
   top-level `"marketplace": "<CC>"` (the country you're listing on) and a
-  bare `"our_price"` on each child; `fill` routes it to the right block
-  (+ `fulfillment_availability#1.quantity`). **Verify it in THAT
-  marketplace's Pricing view** — the feed "N/N successful" count does not
-  reflect price, and quantity can apply
-  while price shows `--` if you set a different marketplace's column.
+  bare `"our_price"` **and bare `"quantity"`** on each child; `fill` routes
+  BOTH to that marketplace's block. **Stock is per-marketplace too, and it
+  is NOT bracketed like the price** — each `fulfillment_availability#N`
+  group is tied by *position* to one marketplace's offer block, so `#1` is
+  a *different* marketplace than you may think. Never hand-pick a
+  `fulfillment_availability#N.quantity` column; use the bare `quantity` and
+  let `fill` pick the group adjacent to the target offer (it also
+  normalises a wrong-index `fulfillment_availability#k.*` to the right
+  one). Putting stock on the wrong group = an offer with no stock = never
+  live. **Verify it in THAT marketplace's Pricing view** — the feed "N/N
+  successful" count does not reflect price, and quantity can apply while
+  price shows `--` if you set a different marketplace's column.
 - **A multi-marketplace account's template bundles every marketplace's
   offer columns** (e.g. a Europe account yields both SA + AE columns even
   when you select one) — a truly single-country template may not be

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -33,52 +33,78 @@ Seller Central → **Catalogue → Add Products via Upload**
 (`sellercentral.amazon.<tld>/listing/upload` → `/product-search/bulk`).
 Open **Spreadsheet → Download Blank Template → Download Product
 Spreadsheet**, search the product type (e.g. "socks" → **Select**
-"Sock"), choose the language, then **select the store's own single
-marketplace only** (uncheck the others — the picker defaults to several,
-and multi-marketplace disables Listing Preferences), then **Generate
-Spreadsheet**. The file lands in `~/.vibe-seller/downloads/<slug>/`
+"Sock"), choose the language, then **just make sure your TARGET
+marketplace's checkbox is ticked** (it usually is by default) and
+**Generate Spreadsheet**. The file lands in `~/.vibe-seller/downloads/<slug>/`
 (a macro-enabled `.xlsm`).
 
-> **Getting TO the product-type search (current Beta flow — don't
-> reverse-engineer it):** Spreadsheet → **Download Blank Template** lands
-> on `/product-search/bulk/generate` showing **template cards** (e.g.
-> "List products that are not currently in Amazon's catalog"). The card
-> body text is NOT the button — the clickable control is a **`kat-button`
-> in the card's FOOTER**. Find it via the DOM, not a screenshot:
-> `js` for `kat-card kat-button` → `getBoundingClientRect` → `click_at_xy`
-> (see browser-harness "Locate & click without vision"). That navigates to
-> `/product-search/bulk/generate/add-product`, the product-type search page.
+> **Do NOT try to uncheck the other marketplaces.** A bundled
+> multi-marketplace template (e.g. SA + AE) is perfectly fine — `fill`
+> routes the offer AND the quantity to your target marketplace's block
+> (see the per-marketplace offer/stock rule below), so extra marketplaces
+> in the template are harmless. Fighting the store `kat-checkbox`es wastes
+> the run: their state doesn't reliably toggle via `click_at_xy`/JS, and
+> the whole point (single-marketplace) buys you nothing. Leave them as-is
+> and Generate.
 >
-> **Product-Type search gotcha:** the search box is a `kat-input` whose
-> real `<input>` is in its shadow root, and Amazon's search only fires on
-> **input/change events** — a bare `value=` (or `kat-input.value=`) sets
-> the text but dispatches nothing, so the candidate list never opens. You
-> MUST set the value with the **native setter on the inner input** and then
-> **dispatch `input` + `change` with `composed:true`** (to cross the shadow
-> boundary); poking React's `_valueTracker` helps too. Then click the
-> search icon and the **Select** button. Verified recipe:
+> **Coordinate gotcha after a viewport resize:** if you used
+> `Emulation.setDeviceMetricsOverride` (below-fold recipe) to reach the
+> Generate button, every element's `getBoundingClientRect` is now in the
+> NEW tall viewport — **re-read the coordinates after the override**
+> before `click_at_xy`; the pre-resize x/y are stale.
+
+> **The "Generate Spreadsheet" button is usually BELOW the fold** (it sits
+> at the bottom of a tall `kat-popover`, and the Ziniao window is only
+> ~839px tall — `scrollIntoView`/`scrollTo` can't bring it up, so a normal
+> `click_at_xy` can't reach it). Don't reuse a stale template to dodge
+> this. Grow the viewport with CDP, then click: see browser-harness
+> **"A control BELOW the fold that won't scroll into view"** —
+> `cdp("Emulation.setDeviceMetricsOverride", width=1920, height=2400,
+> deviceScaleFactor=1, mobile=False)`, `click_at_xy` the button's
+> `getBoundingClientRect` centre, poll the downloads dir for the new
+> `.xlsm`, then `cdp("Emulation.clearDeviceMetricsOverride")`.
+
+> **Getting TO the product-type search (verified 2026-07, NGS beta).**
+> On `/product-search/bulk` a right-side **"Choose a template"** panel
+> opens; click the **Download Product Spreadsheet** button under **"List
+> products that are not currently in Amazon's catalog"** (that's the
+> create-new-ASIN card — NOT "Get Listing Loader", which is for existing
+> ASINs). It opens the **Download Product Spreadsheet** panel at
+> `/product-search/bulk/generate/add-product` (language dropdown +
+> product-type search + store checkboxes + Generate). Locate the button by
+> its label text via the DOM and `click_at_xy` it.
+>
+> **Product-Type search — it's a PLAIN `<input>` + a separate search-icon
+> button, NOT a shadow-dropdown.** Setting `value` or dispatching
+> input/change does NOT open a suggestion list (there is none); you must
+> TYPE into it and click the magnifying-glass button beside it. Verified
+> recipe:
 >
 > ```bash
 > browser-use <<'PY'
 > import time
-> js(r"""
->   var inp = document.querySelector('kat-input').shadowRoot.querySelector('input');
->   var set = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set;
->   set.call(inp, 'sock');                                   // product-type query
->   inp.dispatchEvent(new Event('input',  {bubbles:true, composed:true}));
->   inp.dispatchEvent(new Event('change', {bubbles:true, composed:true}));
->   if (inp._valueTracker) inp._valueTracker.setValue('sock');
-> """)
-> time.sleep(2)   # async suggestions
-> # then locate the matched type's Select button via the DOM and click_at_xy it
-> print(js(r"""return [].slice.call(document.querySelectorAll('kat-button'))
+> box = js(r"""var i=document.querySelector('input[placeholder*="Product keyword"]');
+>   if(!i)return null;var r=i.getBoundingClientRect();
+>   return {x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)};""")
+> click_at_xy(box["x"], box["y"])                 # focus the input
+> cdp("Input.insertText", text="socks")           # TRUSTED typing (value= / events don't stick)
+> time.sleep(1)
+> # click the search-icon button just right of the input (find it by position),
+> # then the matched type's **Select** button (e.g. the "Sock" row):
+> print(js(r"""return [].slice.call(document.querySelectorAll('button,kat-button'))
 >   .map(function(b){var r=b.getBoundingClientRect();
->     return {t:(b.innerText||'').trim().slice(0,20), x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)};})
->   .filter(function(e){return e.t;});"""))
+>     return {t:(b.innerText||b.getAttribute('label')||'').trim().slice(0,20),
+>             x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)};})
+>   .filter(function(e){return e.x>0;});"""))   # → click the search icon, then Select
 > PY
 > ```
-> (Clicking the `kat-icon name=search` icon alone, without the events, is
-> what makes runs flail here — don't rely on it.)
+> After **Select**, the right column shows "Product Type Selected: Sock".
+> Then tick the store(s) (the account's home marketplace may be force-
+> checked; ensure the marketplace you're listing on is ticked), and click
+> **Generate Spreadsheet** — which is below the fold, so use the CDP
+> viewport-resize recipe above. A fresh `.xlsm` lands in the downloads dir
+> within ~30s. (`cdp("Input.insertText", ...)` needs the element focused
+> first — click it, don't just querySelector it.)
 
 > **The create template generates asynchronously** — "Generate
 > Spreadsheet" does not always land a direct download. If it doesn't
@@ -128,7 +154,7 @@ fields.
                   "age_range_description": "Adult",
                   "recommended_browse_nodes": "<from Browse data>",
                   "fulfillment_availability#1.fulfillment_channel_code": "DEFAULT",
-                  "fulfillment_availability#1.quantity": "100",
+                  "quantity": "100",
                   "our_price": "29.00" } }
   ]
 }
@@ -182,8 +208,9 @@ fields.
   images, colour/size, or product-id — those are child-level.
 - **Child** rows: `parent_child: Child`, `parent_sku` = the parent's
   SKU, the differentiating attribute (`color_name` / `size_name`), plus
-  the **offer** (`fulfillment_availability#1.*`) and **price**
-  (`purchasable_offer[marketplace_id=…]#1.our_price#1.schedule#1.value_with_tax`,
+  the **stock** (bare `quantity` — `fill` routes it to the marketplace's
+  own `fulfillment_availability#N` group) and **price** (bare `our_price`
+  → `purchasable_offer[marketplace_id=…]#1.our_price#1.schedule#1.value_with_tax`,
   one block per target marketplace).
 
 `fill` knows this: it suppresses child-level required-field warnings on
@@ -337,11 +364,14 @@ re-uploads can complete them.
 - **Offer/price is per-marketplace; verify in that marketplace's Pricing
   view.** Fill one offer block —
   `purchasable_offer[marketplace_id=<MKT>]#1.our_price#1.schedule#1.value_with_tax`
-  (`our_price` is the only price column that matters) +
-  `fulfillment_availability#1.quantity`. The feed count doesn't reflect
-  price; quantity can apply while Pricing shows `--` if you set a
-  different marketplace's column. On a bundled multi-marketplace
-  template, fill only the intended marketplace's block.
+  (`our_price` is the only price column that matters) + a bare `quantity`
+  for stock. **Stock is per-marketplace but NOT bracketed** — each
+  `fulfillment_availability#N` group is tied by *position* to one
+  marketplace's offer block, so don't hand-pick `#1`; use bare `quantity`
+  and `fill` routes it to the group adjacent to the target offer. The feed
+  count doesn't reflect price; quantity can apply while Pricing shows `--`
+  if you set a different marketplace's column. On a bundled
+  multi-marketplace template, fill only the intended marketplace's block.
 - **`main_image_url`:** by default not uploaded here (seller adds images)
   — a `18320` image error is *expected*, not a blocker. Never hotlink a
   supplier CDN URL (1688/alibaba `cbu01.alicdn.com`, tmall) — Amazon

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -68,6 +68,7 @@ except ImportError:
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from marketplace_ids import (  # noqa: E402,F401
     MARKETPLACE_IDS,  # re-exported for callers/tests
+    fulfillment_index as _fulfillment_index_for_marketplace,
     ids_in_template as _marketplace_ids_in_template,
     resolve as _resolve_marketplace_id,
 )
@@ -419,6 +420,23 @@ def _route_offer_price(fields, cols, mkt_id, i, sku, warnings):
                 f'listing on marketplace_id={mkt_id}, which has NO offer -- the '
                 f'listing will be "Missing offer" (never live). Use "our_price".'
             )
+    # Fulfillment/stock is NOT marketplace-bracketed: each
+    # `fulfillment_availability#N` group is tied by position to one
+    # marketplace's offer block. Route a bare `quantity` + normalise any
+    # `fulfillment_availability#k.*` to the TARGET marketplace's index, so
+    # stock can't land on the wrong marketplace (SA offer + AE qty = dead).
+    if mkt_id is not None:
+        n = _fulfillment_index_for_marketplace(cols, mkt_id)
+        if n is not None:
+            if 'quantity' in fields:
+                fields[f'fulfillment_availability#{n}.quantity'] = fields.pop(
+                    'quantity'
+                )
+            for k in list(fields):
+                if k.startswith('fulfillment_availability#') and '.' in k:
+                    tgt = f'fulfillment_availability#{n}.{k.split(".", 1)[1]}'
+                    if tgt != k:
+                        fields[tgt] = fields.pop(k)
 
 
 def cmd_fill(args):

--- a/app/skills_v2/amazon-listing/scripts/marketplace_ids.py
+++ b/app/skills_v2/amazon-listing/scripts/marketplace_ids.py
@@ -12,6 +12,8 @@ template's `purchasable_offer[marketplace_id=<id>]` columns, so a
 marketplace Amazon adds *after* this table still works without an edit.
 """
 
+import re
+
 MARKETPLACE_IDS = {
     # North America
     'US': 'ATVPDKIKX0DER',  # amazon.com
@@ -44,7 +46,38 @@ MARKETPLACE_IDS = {
 # id -> country code, for reverse lookups / labelling.
 COUNTRY_BY_ID = {v: k for k, v in MARKETPLACE_IDS.items()}
 
-_MKT_ID_IN_COLUMN = __import__('re').compile(r'marketplace_id=([A-Za-z0-9]+)')
+_MKT_ID_IN_COLUMN = re.compile(r'marketplace_id=([A-Za-z0-9]+)')
+_FULFILL_GROUP = re.compile(r'fulfillment_availability#(\d+)\.')
+
+
+def fulfillment_index(cols, mkt_id):
+    """Which `fulfillment_availability#N` group belongs to a marketplace.
+
+    Fulfillment columns are NOT marketplace-bracketed like
+    `purchasable_offer[marketplace_id=...]`; each `fulfillment_availability#N`
+    group instead sits just before that marketplace's offer block. So stock
+    for marketplace X must use the N whose columns most-closely precede X's
+    offer block -- else quantity lands on the wrong marketplace (an SA offer
+    with AE stock never goes live). `cols` maps field name -> list of 1-based
+    column indices. Returns N (int) or None.
+    """
+    offer = [
+        c
+        for k, v in cols.items()
+        if f'marketplace_id={mkt_id}]' in k
+        for c in v
+    ]
+    if not offer:
+        return None
+    target = min(offer)
+    best = None  # (min_col, N) of the nearest group preceding the offer
+    for k, v in cols.items():
+        m = _FULFILL_GROUP.match(str(k))
+        if m:
+            col = min(v)
+            if col < target and (best is None or col > best[0]):
+                best = (col, int(m.group(1)))
+    return best[1] if best else None
 
 
 def ids_in_template(cols):

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -132,6 +132,39 @@ print(els)          # pick the one whose text matches, then click_at_xy(it.x, it
 PY
 ```
 
+### A control BELOW the fold that won't scroll into view
+
+Some pages (e.g. Amazon's "Generate Spreadsheet" popover) put the button
+you need **below the viewport**, inside a `kat-popover`/panel that
+`scrollTo`/`scrollIntoView` can't bring up — the window is short (e.g.
+839px tall) and `click_at_xy` can't hit an off-screen y. Don't fight the
+scroll: **grow the layout viewport with CDP so the whole panel fits**,
+then click the (now on-screen) coordinate, then restore:
+
+```bash
+browser-use <<'PY'
+import time
+cdp("Emulation.setDeviceMetricsOverride",
+    width=1920, height=2400, deviceScaleFactor=1, mobile=False)  # tall viewport
+time.sleep(1)
+box = js("""
+  var els=document.querySelectorAll('kat-button,button,[role=button]');
+  for(var i=0;i<els.length;i++){var t=(els[i].innerText||els[i].getAttribute('label')||'').trim();
+    if(/generate spreadsheet/i.test(t)){var r=els[i].getBoundingClientRect();
+      return {x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)};}}
+  return null;
+""")
+if box: click_at_xy(box["x"], box["y"])   # trusted click, now on-screen
+time.sleep(3)
+cdp("Emulation.clearDeviceMetricsOverride")   # restore the real viewport
+PY
+```
+
+(Verified: the override raises `window.innerHeight` to the set value, so a
+below-fold button becomes reachable; `clearDeviceMetricsOverride` undoes
+it. A plain JS `.click()` still no-ops on `kat-*` — you need the trusted
+`click_at_xy`.)
+
 For an element inside an **open shadow root** (Amazon `kat-*`), pierce it
 in the selector: `document.querySelector('kat-file-upload').shadowRoot.querySelector('input')`.
 Set an input's value with `js("document.querySelector('#q').value='socks'")`

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -188,6 +188,32 @@ When stock is already configured, FBN section shows:
 
 ### 2.5 Content Tab
 
+> **Edit content on the `/d` detail page's Content tab, not `/p`.** The
+> editable URL is
+> `…/catalog/{noon_sku}/d?code={code}&tab=content&project=PRJ{id}` (get
+> `{code}` from the My-Catalog row's product link — the read-only `/p`
+> view loads no editable fields and is why earlier runs "couldn't fill"
+> content). Fill every field with **`fill_input`** (see §1 warning).
+>
+> **Content save is ASYNC — do NOT re-fill on immediately-stale status.**
+> After you fill the mandatory fields and click **Save Changes**, a green
+> modal says *"Your changes have been saved. The content will now be sent
+> for Quality Check (QC)… allow some time."* The **Content Check Status /
+> "N Issues" / "0/7 Attributes" indicators do NOT update instantly** —
+> they clear only after Noon's async QC (minutes). Re-filling because the
+> count still shows issues is a thrash (a live run re-typed the title 68×
+> for this exact reason — the saves *were* landing). Save ONCE, trust the
+> "sent for QC" modal, move on, and re-check later. This is the same
+> async-confirmation trap as Amazon's async-minting ASINs.
+>
+> **Mandatory content on noon = Product Title + Department + ≥1 Image.**
+> Unlike Amazon (where a blank main image is an acceptable done-state),
+> **noon requires at least one product image** for content to pass — a
+> listing with title+price but no image keeps a "Missing Image" content
+> issue. If the seller hasn't supplied an image, upload a placeholder via
+> the Content tab's **Add Image** file-chooser, or surface "Missing
+> Image" as the one remaining item for the seller.
+
 Click `rc-tabs-0-tab-content`. Left sub-nav: **Basic Content** /
 **Detailed Content**.
 

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -92,6 +92,20 @@ read it in-page before filling; do not assume.
 - Each row needs a **unique `seller_sku`**. Partial failures are
   per-row: good rows still create; fix the error file and re-upload the
   rest.
+- **A parent needs a child — a lone parent creates NOTHING.** Verified
+  live: a single row with `parent_child_variation=parent` imports
+  "successfully" but the SKU never appears, and the error file's
+  `creation_error` column reads **`child is missing`**. Every product
+  needs **two rows sharing one `parent_group_key`**: a `parent` row
+  (identity) **and** at least one `child` row (the sellable variant,
+  with its own distinct `seller_sku` and a `size_variation`/`size_map`,
+  e.g. `One Size`). The **child** is what carries the offer — follow-up
+  Pricing/Stock imports key on the **child** `seller_sku`.
+- **Reading the error file is the debug loop.** An import that shows
+  Completed but creates nothing failed row validation; open the import's
+  Result/error CSV — its trailing `partner_error` / `content_error` /
+  `creation_error` columns name the exact problem. Fix those cells
+  (use the exact valid-value strings) and re-upload.
 
 ### 1.3 Pricing import — optional high-base + long sale (a seller pattern)
 

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -129,10 +129,14 @@ and leave the sale columns blank.
 > 2. **Offer tab** → `fill_input` **Base Price**, then **set Warranty**
 >    (MANDATORY — see below), then **Save Changes** (green modal; price
 >    persists across reload).
-> 3. **Content** on `/d?code=…&tab=content` → `fill_input` **Product
->    Title** + set **Department** → **Save Changes** → "sent for QC"
->    (async — done; do NOT re-fill).
-> 4. **Image** (mandatory ≥1): upload one, or leave as the seller's item.
+> 3. **Content** on `/d?code=…&tab=content` → Product **Title** (EN via
+>    `fill_input`, Arabic via `Input.insertText` — see §2.7) + set
+>    **Gender** (MANDATORY; Department + Arabic gender auto-derive — §2.7)
+>    → **Save Changes** → Submit → "sent for review" (async QC — done;
+>    do NOT re-fill).
+> 4. **Image** (mandatory ≥1): upload the seller's **real product photo**
+>    (§2.7) — a placeholder fails noon's async image validation and the
+>    listing never goes live.
 > 5. **Seller Status → ON**.
 >
 > **Warranty is MANDATORY — but trivial: select "No Warranty".** The
@@ -148,15 +152,22 @@ and leave the sale columns blank.
 > **"No Warranty"** option in the `.ant-select-dropdown`. Verified live:
 > price + No-Warranty → Save → offer created, persists across reload.
 >
-> **SKIP the other OPTIONAL fields — do NOT fight their dropdowns.**
-> Gender, Size Unit, Feature Bullets, Long Description, Material, Colour
-> and the other detailed-content attributes are **optional** — the
-> listing saves and goes live without them, and their Ant-Design selects
-> resist programmatic opening (**trying to set them is a rathole that
-> burns the whole run** — a live run stalled dozens of steps on the
-> Gender select). Fill only what steps 2–5 require; if a seller
-> explicitly asked for an optional attribute and its dropdown won't open,
-> note it as a manual follow-up rather than looping.
+> **Gender IS MANDATORY (verified live) — Department derives from it.**
+> Content Check flags `Missing Department` until Gender is set; you do
+> NOT set Department directly (there is no Department field). Set the
+> **English `Gender *`** select (e.g. `Men`) and noon **auto-fills the
+> Arabic gender (`رجال`) and clears the Department requirement**. The
+> Gender select is the same anti-automation ant-select as Warranty — open
+> it with the virtual-list technique in §2.7 (grow viewport → scroll the
+> dropdown's `.rc-virtual-list-holder` → in-panel trusted `click_at_xy`).
+> An earlier note calling Gender "optional, skip it" was WRONG — a listing
+> without Gender never clears mandatory content and never goes live.
+>
+> **These ARE optional — skip unless the seller asked:** Size Unit,
+> Feature Bullets, Long Description, Material, Colour, and the other
+> detailed-content attributes. The listing saves and goes live without
+> them. If a seller explicitly wants one and its dropdown won't open with
+> §2.7, note it as a manual follow-up rather than looping.
 
 **Runnable Offer-tab snippet (price + No Warranty) — copy verbatim.** The
 below-fold Warranty select can't be found by an un-scrolled DOM query;
@@ -261,6 +272,80 @@ On success, redirected to:
 ```
 /en/catalog/{noon_sku}/p?code={code}&project=PRJ{project_id}
 ```
+
+### 2.7 Proven click techniques (verified end-to-end by hand)
+
+These are the exact methods that make the click path work — every one
+was a wall until pinned down. Follow them literally.
+
+- **Category tree is a scrollable drill, not a flat list.** Click the
+  top category (e.g. `Apparel`) → it shows product-types as a scrollable
+  list → the leaf you want is usually below the fold. Do NOT click a raw
+  coordinate; `scrollIntoView({block:'center'})` the leaf text, re-read
+  its live rect, then trusted `click_at_xy`. A product-type like
+  `Socks & Tights` expands to sub-types (`Socks`, `Stockings`, …) each
+  with a **`Select`** button — click that to enable `Next`.
+
+- **Ant-Design selects are VIRTUAL lists — the option you want often
+  renders BELOW the clipped dropdown panel.** Opening the select and
+  clicking the option's reported rect fails silently when that rect is
+  past the panel bottom (the click lands outside → closes it unselected).
+  The reliable recipe (Warranty, Gender, any long select):
+  ```bash
+  browser-use <<'PY'
+  import time, json
+  cdp("Emulation.setDeviceMetricsOverride", width=1500, height=3200, deviceScaleFactor=1, mobile=False); time.sleep(2)
+  # open the target select (trusted click on its centre)
+  sel=json.loads(js("(function(){var s=Array.from(document.querySelectorAll('.ant-select')).find(e=>/Gender/.test(e.textContent)); var b=s.getBoundingClientRect(); return JSON.stringify({x:Math.round(b.x+b.width/2),y:Math.round(b.y+b.height/2)});})()"))
+  click_at_xy(sel['x'], sel['y']); time.sleep(1.5)
+  # scroll the dropdown's virtual-list holder to the bottom so the option renders inside the panel
+  js("(function(){var h=document.querySelector('.ant-select-dropdown:not(.ant-select-dropdown-hidden) .rc-virtual-list-holder'); if(h)h.scrollTop=h.scrollHeight;})()"); time.sleep(1)
+  # click the option ONLY if it is inside the panel bounds
+  o=json.loads(js("(function(){var el=Array.from(document.querySelectorAll('.ant-select-dropdown:not(.ant-select-dropdown-hidden) .ant-select-item')).find(e=>e.textContent.trim()==='Men'); var dd=document.querySelector('.ant-select-dropdown:not(.ant-select-dropdown-hidden)').getBoundingClientRect(); var b=el.getBoundingClientRect(); return JSON.stringify({x:Math.round(b.x+b.width/2),y:Math.round(b.y+b.height/2),inpanel:(b.y>=dd.top&&b.bottom<=dd.bottom)});})()"))
+  if o['inpanel']: click_at_xy(o['x'], o['y'])
+  PY
+  ```
+  Verify by the field showing the value (and reload-persistence), not by
+  a DOM `selection-item` query (that selector is unreliable).
+
+- **Arabic / non-Latin text: use `Input.insertText`, NOT `fill_input`.**
+  `fill_input` types char-by-char via key events and **hangs the daemon**
+  on Arabic (no keycode mapping). Focus the field, then
+  `cdp("Input.insertText", text="…")` inserts the whole string. (Latin
+  text still uses `fill_input`.) The English↔Arabic Product Title are two
+  separate boxes with the same `placeholder="Product Title *"`; tag them
+  (`setAttribute('data-fill', …)`) to target each.
+
+- **Content edits are on `/d?...&tab=content`.** Clicking the "Content"
+  tab on the `/p` page does not switch to editable content. Navigate the
+  URL directly (`js("location.href=…")`) — do NOT `new_tab` repeatedly
+  (piled-up tabs make later reconnects attach to the wrong tab; a fresh
+  wrapper invocation reads whatever tab is active).
+
+- **Image (mandatory ≥1) — upload + the async validation gate.** The file
+  input is hidden; set it and fire `change`, then confirm the modal:
+  ```bash
+  browser-use <<'PY'
+  import time, json
+  r=cdp("Runtime.evaluate", expression="document.querySelector('input[type=file][accept*=\"image\"]')")
+  cdp("DOM.setFileInputFiles", files=["/path/to/photo.jpg"], objectId=r['result']['objectId']); time.sleep(1)
+  js("document.querySelector('input[type=file][accept*=\"image\"]').dispatchEvent(new Event('change',{bubbles:true}))"); time.sleep(4)
+  # "Review Images" modal → Upload All
+  b=json.loads(js("(function(){var x=Array.from(document.querySelectorAll('button')).find(e=>e.textContent.trim()==='Upload All'); var r=x.getBoundingClientRect(); return JSON.stringify({x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)});})()"))
+  click_at_xy(b['x'], b['y']); time.sleep(12)  # uploads to f.nooncdn.com
+  PY
+  ```
+  **The image must be a real product photo.** noon runs an async
+  image-quality **Validation** after upload; a placeholder / low-quality
+  image sits in `Validating…` and never clears `Missing Image`, so the
+  listing can't go live. Use the seller's actual photo. This is a
+  *content-quality* gate, not an automation limitation.
+
+- **Persistence rule:** every Save on this app opens a `Submit`
+  confirmation modal ("sent for review" / "are you sure"). Click
+  `Submit`, then **reload and re-read** — React state alone (and toasts)
+  are not proof. When `Save Changes` is **disabled**, there are no
+  unsaved changes (already committed).
 
 ## 3. Edit Listing — After Creation
 

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -32,6 +32,23 @@ barcode, content, visibility status).
 
 3-step wizard: **Category → Brand → Identity**.
 
+> **Use the 3-step wizard to create your OWN new product. Do NOT use the
+> "paste a noon PDP URL / copy SKU link" shortcut to create a brand-new
+> listing.** That shortcut clones an *existing* catalog item and links
+> your SKU to a parent you don't own — the product is then permanently
+> un-saveable: every Offer save fails with a red
+> `Invalid sku_parents: {...}` toast and price/content never persist.
+> The wizard below mints a clean standalone parent that saves normally.
+>
+> **Input method (critical):** fill every field with **`fill_input`**
+> (it fires the real key + input/change events React needs). Do NOT use
+> `type_text`, `Input.insertText`, or a `nativeSetter` — those set the
+> DOM value only; React never ingests it, so "Final Price" stays `-` and
+> the save drops the field. Verify a save by **reloading the page** and
+> re-reading the value (a green "changes saved" toast alone is not proof;
+> a hidden `pricing-errors.undefined` string in the DOM is NOT a real
+> error — trust the reloaded value / a screenshot, not a DOM grep).
+
 ### Step 1 — Category
 
 Hierarchical tree (e.g. Electronics > Accessories > Cables). Click
@@ -67,16 +84,17 @@ unbranded products.
 Enter Partner SKU (your internal code) or click "Generate Partner SKU".
 
 **Important**: "Generate Partner SKU" auto-fills a format like
-`PSKU_{project}_{digits}_X`. Clear it first if you want your own SKU:
+`PSKU_{project}_{digits}_X`. To use your own SKU, `fill_input` the SKU
+box (it has no stable `name=`, so target the visible text input):
 ```bash
 browser-use <<'PY'
-js("document.querySelector('input[name=partner_sku]').focus()")   # SKU input
-press_key("Control+a")
-type_text("SKU-100234")
+fill_input("input[type=text]", "SKU-100234")   # partner SKU box (clears + types via real key events)
 # Click "Create" (NOT Next — this is the final step)
-js("document.querySelectorAll('button')[1].click()")
+js("Array.from(document.querySelectorAll('button')).find(b=>b.textContent.trim()==='Create')?.click()")
 PY
 ```
+Success = redirect to `/en/catalog/{noon_sku}/p?...` (a fresh noon SKU is
+minted). Verified live: this wizard product saves price/content normally.
 
 On success, redirected to:
 ```
@@ -210,26 +228,31 @@ a direct "Add Product Title" button that scrolls to the field.
 | What's In The Box | Optional | Optional |
 | Shipping Height/Length/Weight/Width/Depth | Optional | Optional |
 
-#### Filling content via JS (bypasses shadow DOM issues)
+#### Filling content — always `fill_input`, never `nativeSetter`
 
-Some inputs are inside shadow DOM. If `fill_input` doesn't trigger
-the React onChange, use the native setter pattern via `js()`:
+Content fields are the same React-controlled inputs as the Offer tab, so
+fill each with **`fill_input`** (matches on placeholder / name). There
+are English + local-language variants per field — fill both:
 
 ```bash
 browser-use <<'PY'
-js("""
-  var nsetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
-  var inputs = document.querySelectorAll('input[placeholder="Product Title *"]');
-  inputs.forEach(function(inp, i) {
-    nsetter.call(inp, i === 0 ? 'English title' : 'local-language title');
-    inp.dispatchEvent(new Event('input', {bubbles: true}));
-  });
-""")
+# Title has an English box and a local-language box (same placeholder,
+# two elements). fill_input targets one selector; use :nth-of-type or a
+# per-element loop with real key events — NOT nativeSetter (React ignores
+# a nativeSetter value, leaving the field blank on save/reload).
+fill_input("input[placeholder='Product Title *']", "Women's Cotton Crew Socks (6-Pack)")
+# for the second (local-language) box, click it then fill:
+js("document.querySelectorAll(\"input[placeholder='Product Title *']\")[1]?.focus()")
+type_text_note = "use fill_input on a unique selector; if two share a placeholder, focus the 2nd then fill_input its id/xpath"
 PY
 ```
 
-Always click **Save Changes** after editing. Validate with the green
-"Your changes have been saved" toast.
+> A `nativeSetter` + `dispatchEvent('input')` sets the DOM value but does
+> NOT enter React state — the field looks filled yet saves blank and is
+> empty on reload. This was a real live failure. Use `fill_input`.
+
+Always click **Save Changes** after editing, then **reload and re-read**
+the field to confirm it persisted (the green toast alone is not proof).
 
 ### 2.6 Product Visibility Status
 

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -67,6 +67,41 @@ barcode, content, visibility status).
 > explicitly asked for an optional attribute and its dropdown won't open,
 > note it as a manual follow-up rather than looping.
 
+**Runnable Offer-tab snippet (price + No Warranty) — copy verbatim.** The
+below-fold Warranty select can't be found by an un-scrolled DOM query;
+this grows the viewport, trusted-clicks the Warranty card's select, and
+picks "No Warranty". It also clears the price field first (`fill_input`
+*appends* if a value is already present → `59.59.9`). Verified live:
+
+```bash
+browser-use <<'PY'
+import time, json
+# 1) price — clear first (fill_input appends to an existing value), then fill
+js("var i=document.querySelector('input[name=new_price]'); if(i){i.value='';}")
+fill_input('input[name="new_price"]', '59.90')
+# 2) Warranty = No Warranty (MANDATORY). Grow viewport (it's below fold),
+#    trusted-click the Warranty card's ant-select, option-click No Warranty.
+cdp("Emulation.setDeviceMetricsOverride", width=1500, height=2200, deviceScaleFactor=1, mobile=False)
+time.sleep(2)
+info = js("""(function(){
+  var hdr=Array.from(document.querySelectorAll('*')).find(e=>e.textContent.trim()==='Warranty'&&e.children.length<3);
+  var card=hdr.closest('div'); for(var i=0;i<5&&card;i++){if(card.querySelector('.ant-select'))break;card=card.parentElement;}
+  var sel=card.querySelector('.ant-select'); sel.scrollIntoView({block:'center'});
+  var r=sel.getBoundingClientRect(); return JSON.stringify({x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)});
+})()""")
+p=json.loads(info); click_at_xy(p['x'], p['y']); time.sleep(2)
+js("""(function(){var dd=document.querySelector('.ant-select-dropdown:not(.ant-select-dropdown-hidden)');
+  var o=Array.from(dd.querySelectorAll('.ant-select-item')).find(x=>x.textContent.trim()==='No Warranty'); if(o)o.click();})()""")
+time.sleep(1); cdp("Emulation.clearDeviceMetricsOverride")
+# 3) Save Changes, then confirm Submit
+js("(function(){var b=Array.from(document.querySelectorAll('button')).find(x=>/save changes/i.test(x.textContent)&&x.textContent.length<20); if(b)b.click();})()")
+time.sleep(3)
+js("(function(){var b=Array.from(document.querySelectorAll('button')).find(x=>/^submit$/i.test(x.textContent.trim())); if(b)b.click();})()")
+time.sleep(3)
+print(js("var t=document.body.innerText; ('Save failed: '+/Save failed/i.test(t)+' | saved: '+/have been saved/i.test(t))"))
+PY
+```
+
 > **Use the 3-step wizard to create your OWN new product. Do NOT use the
 > "paste a noon PDP URL / copy SKU link" shortcut to create a brand-new
 > listing.** That shortcut clones an *existing* catalog item and links

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -32,6 +32,27 @@ barcode, content, visibility status).
 
 3-step wizard: **Category → Brand → Identity**.
 
+> **MINIMAL PATH to a valid listing — do exactly these, in order, and
+> STOP:**
+> 1. Wizard create (Category → Brand → Identity), `fill_input` the SKU.
+> 2. **Offer tab** → `fill_input` **Base Price** → **Save Changes**
+>    (price persists across reload; green modal confirms).
+> 3. **Content** on `/d?code=…&tab=content` → `fill_input` **Product
+>    Title** + set **Department** → **Save Changes** → "sent for QC"
+>    (async — done; do NOT re-fill).
+> 4. **Image** (mandatory ≥1): upload one, or leave as the seller's item.
+> 5. **Seller Status → ON**.
+>
+> **SKIP every OPTIONAL field — do NOT fight their dropdowns.** Warranty
+> ("Choose type"), Gender, Size Unit, Feature Bullets, Long Description,
+> Material, Colour and the other detailed-content attributes are
+> **optional** — the listing saves and goes live without them. Their
+> Ant-Design selects resist programmatic opening; **trying to set them is
+> a rathole that burns the whole run** (live runs stalled for dozens of
+> steps on the Warranty and Gender selects). Fill only what step 2–5
+> require; if a seller explicitly asked for an optional attribute and its
+> dropdown won't open, note it as a manual follow-up rather than looping.
+
 > **Use the 3-step wizard to create your OWN new product. Do NOT use the
 > "paste a noon PDP URL / copy SKU link" shortcut to create a brand-new
 > listing.** That shortcut clones an *existing* catalog item and links

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -62,7 +62,7 @@ Imports are keyed by **Type → Subtype**. The relevant ones:
 | Content | Product Import | *Updates* content (title/description/attributes) of **existing** SKUs only. |
 | Pricing | **Price Update** | Base price + sale price/window for existing SKUs (see §1.3). |
 | Pricing | Price Range Update | Long-dated sale windows (the discount pattern, §1.3). |
-| Stock | (stock subtype) | On-hand quantity for existing SKUs. |
+| Stock | (stock subtype) | On-hand quantity for existing SKUs. **Match the store's warehouse type**: an FBP Stock Update fails ("no FBP warehouse") if the store has none; FBN stock requires an ASN shipment flow, not a stock import. Check the SKU's Offer→Stock section for which warehouse the store actually has before choosing the stock import. |
 | Warranty | (warranty subtype) | Warranty type for existing SKUs (file equivalent of the click "No Warranty"). |
 
 So a full file-based create is: **NIS Create/Update** (identity + images)

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -26,9 +26,100 @@ review:
 Covers SKU creation and the post-creation edit flow (price, stock,
 barcode, content, visibility status).
 
-## 1. Create Listing (SKU)
+> **Two create paths — PREFER file-based, FALL BACK to click.**
+> File-based (§1, NIS spreadsheet import) sets every hard field through a
+> spreadsheet, so it never touches the Ant-Design dropdowns (Warranty,
+> Department, Gender, Size, Content selects) that the click wizard needs
+> a *trusted mouse* to open — those dropdowns are the recurring wall on
+> the click path. Use file-based whenever creating one or more SKUs of a
+> known category. Use the click wizard (§2) only for a one-off where you
+> can drive a real trusted click, or to *edit* a SKU after creation.
+
+## 1. Create Listing — File-based (PREFERRED, NIS import)
+
+Noon's **NIS** (noon Item Sheet) importer creates SKUs in bulk from a
+spreadsheet. Everything the click wizard sets via a dropdown is a plain
+cell here, so it sidesteps the anti-automation selects entirely.
+
+**Flow:** `Imports` → **Add Import** → **Type = Content**, **Subtype =
+NIS Create/Update** → pick the category → **Download** the template →
+fill it → **Next** → upload → SKUs go to async Quality Check (QC).
+
+URL: `https://noon-catalog.noon.partners/en/imports/create?project=PRJ{project_id}`
+
+The Type / Subtype selects are Ant-Design dropdowns — open each with a
+trusted `click_at_xy` on the field, then option-click the item in
+`.ant-select-dropdown .ant-select-item` (type-to-filter does NOT work;
+see `../noon-shared`).
+
+### 1.1 Which import for which field
+
+Imports are keyed by **Type → Subtype**. The relevant ones:
+
+| Type | Subtype | Creates / sets |
+|------|---------|----------------|
+| Content | **NIS Create/Update** | **Creates new SKUs** — identity, sizes, attributes, images, in bulk. This is the create step. |
+| Content | Product Import | *Updates* content (title/description/attributes) of **existing** SKUs only. |
+| Pricing | **Price Update** | Base price + sale price/window for existing SKUs (see §1.3). |
+| Pricing | Price Range Update | Long-dated sale windows (the discount pattern, §1.3). |
+| Stock | (stock subtype) | On-hand quantity for existing SKUs. |
+| Warranty | (warranty subtype) | Warranty type for existing SKUs (file equivalent of the click "No Warranty"). |
+
+So a full file-based create is: **NIS Create/Update** (identity + images)
+→ then **Price Update** (price) and **Stock** as follow-up imports keyed
+on the `seller_sku`/`partner_sku` you assigned. Each import's own
+"ABOUT THIS UPLOAD" panel lists its exact Required/Optional columns —
+read it in-page before filling; do not assume.
+
+### 1.2 The NIS template (Content → NIS Create/Update)
+
+- **Category**: "Download templates for" → **Specific category** →
+  drill the tree (e.g. **Apparel** → product-types incl. *Socks &
+  Tights*) and select it, **plus** the target store/marketplace, to
+  enable the per-category **Download English** / **Download English +
+  Arabic** buttons (AE stores need the +Arabic template for the local
+  title). "All categories" downloads a generic shell without the
+  category attribute columns — only use it to see the structure.
+- **`With Instructions`** checkbox adds a column-guidance row — leave it
+  on the first time.
+- **Core required columns** (from the template's `valid values` sheet):
+  `family`, `product_type`, `product_subtype`, `seller_sku`,
+  `item_condition` (`New`), `parent_child_variation` (`Parent`/`Child`
+  for sized products), and per-marketplace `vat_rate_ae` / `vat_rate_sa`
+  / `vat_rate_eg` (`Std`). Category attribute columns + image-URL columns
+  follow — fill per the in-sheet guidance and the linked "How to fill out
+  the NIS sheet" article.
+- Each row needs a **unique `seller_sku`**. Partial failures are
+  per-row: good rows still create; fix the error file and re-upload the
+  rest.
+
+### 1.3 Pricing import — optional high-base + long sale (a seller pattern)
+
+Some sellers list a **high base price** and a **long-dated half-price
+sale** so the page shows a large discount on day one, while the true
+selling price is the sale price every day. This is a **guideline, not a
+requirement** — only apply it when the seller asks for it.
+
+To do it file-based, after the SKU exists run **Pricing → Price Update**
+(columns: required `country_code`, `id_partner`, `partner_sku`; optional
+`price`, `sale_price`, `sale_start`, `sale_end`, `is_active`):
+
+- `price` = the high base (e.g. `100`)
+- `sale_price` = the real everyday price (e.g. `50`)
+- `sale_start` = today, `sale_end` = a far-future date (e.g. +5 years)
+
+For a rolling window use **Pricing → Price Range Update**. If the seller
+did not ask for the discount pattern, just set `price` to the real price
+and leave the sale columns blank.
+
+## 2. Create Listing — Click wizard (FALLBACK)
 
 **URL**: `https://noon-catalog.noon.partners/en/catalog/create?project=PRJ{project_id}`
+
+> Use this only when file-based isn't practical (a true one-off you can
+> drive with a real trusted click). It needs trusted `click_at_xy` for
+> every Ant-Design select; a programmatic `.click()` / nativeSetter does
+> NOT register. If a required dropdown won't open, fall back to §1.
 
 3-step wizard: **Category → Brand → Identity**.
 
@@ -171,7 +262,7 @@ On success, redirected to:
 /en/catalog/{noon_sku}/p?code={code}&project=PRJ{project_id}
 ```
 
-## 2. Edit Listing — After Creation
+## 3. Edit Listing — After Creation
 
 **URL**: `https://noon-catalog.noon.partners/en/catalog/{sku}/d?code={code}&offerTab=noon&project=PRJ{project_id}`
 
@@ -195,7 +286,7 @@ If you switch tabs with unsaved edits, noon shows a modal:
 
 **Always save before navigating away** — discarding loses all input.
 
-### 2.1 Offer Tab — Price
+### 3.1 Offer Tab — Price
 
 Inputs (all Ant Design shadow DOM, `name=` attribute identifies):
 
@@ -222,7 +313,7 @@ PY
 After filling prices, click the blue **Save Changes** button at top-right.
 The modal "Your changes have been saved" with a green check confirms success.
 
-### 2.2 Offer Tab — Barcode
+### 3.2 Offer Tab — Barcode
 
 Labeled "Common across marketplaces". Multiple barcodes can be added.
 
@@ -238,7 +329,7 @@ PY
 Each added barcode shows as a removable chip (Amazon-ASIN-style
 strings like `XNNNXXXNNN` are typical — 10 chars, digits + caps).
 
-### 2.3 Offer Tab — Stock
+### 3.3 Offer Tab — Stock
 
 Two sections:
 - **FBN Warehouses**: "Add you products to our noon warehouses
@@ -251,12 +342,12 @@ When stock is already configured, FBN section shows:
 - Stock type badge ("Regular")
 - Last Stock Update, Stock Transferred, Stock Reserved, Net stock
 
-### 2.4 Offer Tab — Warranty & Offer Note
+### 3.4 Offer Tab — Warranty & Offer Note
 
 - **Warranty**: Select warranty duration dropdown ("No warranty" by default)
 - **Offer Note**: Free-text textarea (0/353 char counter)
 
-### 2.5 Content Tab
+### 3.5 Content Tab
 
 > **Edit content on the `/d` detail page's Content tab, not `/p`.** The
 > editable URL is
@@ -350,7 +441,7 @@ PY
 Always click **Save Changes** after editing, then **reload and re-read**
 the field to confirm it persisted (the green toast alone is not proof).
 
-### 2.6 Product Visibility Status
+### 3.6 Product Visibility Status
 
 Top of the page shows:
 - **Seller Status**: toggle (on/off) — controls whether the offer is live

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -35,23 +35,37 @@ barcode, content, visibility status).
 > **MINIMAL PATH to a valid listing — do exactly these, in order, and
 > STOP:**
 > 1. Wizard create (Category → Brand → Identity), `fill_input` the SKU.
-> 2. **Offer tab** → `fill_input` **Base Price** → **Save Changes**
->    (price persists across reload; green modal confirms).
+> 2. **Offer tab** → `fill_input` **Base Price**, then **set Warranty**
+>    (MANDATORY — see below), then **Save Changes** (green modal; price
+>    persists across reload).
 > 3. **Content** on `/d?code=…&tab=content` → `fill_input` **Product
 >    Title** + set **Department** → **Save Changes** → "sent for QC"
 >    (async — done; do NOT re-fill).
 > 4. **Image** (mandatory ≥1): upload one, or leave as the seller's item.
 > 5. **Seller Status → ON**.
 >
-> **SKIP every OPTIONAL field — do NOT fight their dropdowns.** Warranty
-> ("Choose type"), Gender, Size Unit, Feature Bullets, Long Description,
-> Material, Colour and the other detailed-content attributes are
-> **optional** — the listing saves and goes live without them. Their
-> Ant-Design selects resist programmatic opening; **trying to set them is
-> a rathole that burns the whole run** (live runs stalled for dozens of
-> steps on the Warranty and Gender selects). Fill only what step 2–5
-> require; if a seller explicitly asked for an optional attribute and its
-> dropdown won't open, note it as a manual follow-up rather than looping.
+> **Warranty is MANDATORY — but trivial: select "No Warranty".** The
+> Offer save FAILS with `Save failed — Warranty / No Offer Created`
+> unless the Warranty **type** is set. Do NOT try to configure a real
+> warranty (service center + 1–60mo duration — that path IS an
+> anti-automation rathole). Just open the Warranty **type** select and
+> pick **"No Warranty"** (options: No Warranty / Seller Warranty /
+> Manufacturer Warranty) — no service center or duration needed, and the
+> offer saves. Open it with a trusted `click_at_xy` on the select's
+> centre (it's below the fold — grow the viewport via
+> `Emulation.setDeviceMetricsOverride` first), then click the
+> **"No Warranty"** option in the `.ant-select-dropdown`. Verified live:
+> price + No-Warranty → Save → offer created, persists across reload.
+>
+> **SKIP the other OPTIONAL fields — do NOT fight their dropdowns.**
+> Gender, Size Unit, Feature Bullets, Long Description, Material, Colour
+> and the other detailed-content attributes are **optional** — the
+> listing saves and goes live without them, and their Ant-Design selects
+> resist programmatic opening (**trying to set them is a rathole that
+> burns the whole run** — a live run stalled dozens of steps on the
+> Gender select). Fill only what steps 2–5 require; if a seller
+> explicitly asked for an optional attribute and its dropdown won't open,
+> note it as a manual follow-up rather than looping.
 
 > **Use the 3-step wizard to create your OWN new product. Do NOT use the
 > "paste a noon PDP URL / copy SKU link" shortcut to create a brand-new

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -547,6 +547,25 @@ Top of the page shows:
 - **Live Status**: badge (e.g. "Offer Created", "Unavailable")
 - **Buy Box Won**: ACTIVE badge
 
+## 4. Delete (Deactivate) a Listing
+
+noon has **no hard delete** — the delete-equivalent is **Deactivate**,
+which pulls the SKU from sale across noon / supermall / Global. It is
+reversible (an **Activate SKUs** button re-lists it). Verified live:
+
+1. **My Catalog** → in the **"Search for SKU here…"** box type the
+   partner SKU and press **Enter** (typing alone does NOT filter — the
+   Enter is required; "Total N items" updates to the match).
+2. **Tick that row's checkbox.** ⚠️ Do NOT click the **header**
+   checkbox — it is select-all and would deactivate every SKU including
+   live sellers. Filter to the one SKU first, confirm **"Total 1 items"**,
+   then select. (Selecting one product may check its per-marketplace
+   sub-boxes too — that is still just the one product.)
+3. A **"Deactivate SKUs"** action button appears — click it.
+4. Confirm the modal (**"Deactivate this SKU? … across noon, supermall,
+   and Global"**) → **Deactivate**. To reverse, select it again and use
+   **Activate SKUs**.
+
 ## See also
 
 - `noon-shared` — login, page structure, modals (prerequisite)

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -742,3 +742,42 @@ def test_resolve_auto_detects_single_marketplace_template():
     # Ambiguous: unknown code + multi-marketplace template -> fail loudly.
     with pytest.raises(SystemExit):
         r('ZA', [_SA, _AE])
+
+
+# A real multi-marketplace template interleaves each marketplace's
+# fulfillment_availability#N group with its offer block: AE (#1) then SA
+# (#2). Column order matters -- the resolver picks the group by position.
+_AE_QTY = 'fulfillment_availability#1.quantity'
+_SA_QTY = 'fulfillment_availability#2.quantity'
+_MKT_COLS = {
+    'item_sku': [2],
+    _AE_QTY: [165],
+    _AE_PRICE: [171],
+    _SA_QTY: [181],
+    _SA_PRICE: [186],
+}
+
+
+def test_fulfillment_index_maps_to_the_marketplaces_own_group():
+    f = listing_bulk._fulfillment_index_for_marketplace
+    assert f(_MKT_COLS, _AE) == 1  # AE's stock group precedes AE's offer
+    assert f(_MKT_COLS, _SA) == 2  # SA's stock group precedes SA's offer
+
+
+def test_route_sends_quantity_to_target_marketplace_group():
+    # Listing on SA: a bare `quantity` must land in SA's group (#2), NOT the
+    # first group (#1 = AE) -- else the SA offer has no stock and never lives.
+    fields = {'our_price': '19.99', 'quantity': '100'}
+    listing_bulk._route_offer_price(fields, _MKT_COLS, _SA, 0, 'K-WHT', [])
+    assert fields[_SA_QTY] == '100'
+    assert _AE_QTY not in fields
+    assert fields[_SA_PRICE] == '19.99'
+
+
+def test_route_remaps_wrong_index_fulfillment_to_target():
+    # The agent wrote fulfillment_availability#1 (AE) but is listing on SA;
+    # normalise it to SA's group (#2).
+    fields = {_AE_QTY: '100', 'our_price': '19.99'}
+    listing_bulk._route_offer_price(fields, _MKT_COLS, _SA, 0, 'K-WHT', [])
+    assert fields[_SA_QTY] == '100'
+    assert _AE_QTY not in fields

--- a/tests/unit/test_report_reviewer.py
+++ b/tests/unit/test_report_reviewer.py
@@ -131,6 +131,47 @@ class TestReviewerVerdict:
         os.utime(new, (1_700_000_000, 1_700_000_000))
         assert rr.reviewer_verdict(tmp_path) is None
 
+    def test_leading_ok_but_bolded_incomplete_denies(self, tmp_path):
+        # The live failure: a reviewer top-stamps ``Status: ok`` but its
+        # conclusion is ``**Status: incomplete**`` (bolded, off line-start).
+        # The gate used to read only the leading ``ok`` and pass a report
+        # with a known error. It must fail-closed on the conflict.
+        self._audit(tmp_path)
+        (tmp_path / 'REVIEW_2026-07-09_iter1.md').write_text(
+            'Status: ok\n\n# Review\n\n'
+            '## Conclusion\n\n**Status: incomplete**\n'
+            'One numerical error: total is 140 but should be 145.\n',
+            encoding='utf-8',
+        )
+        deny = rr.reviewer_verdict(tmp_path)
+        assert deny is not None
+        # incomplete at iter 1 (< cap) → keep iterating, and the conflict
+        # is surfaced so the reviewer rewrites a single coherent verdict.
+        assert 'only valid at iter' in deny
+        assert 'conflicting Status' in deny
+
+    def test_leading_ok_but_gaps_in_body_denies(self, tmp_path):
+        # Same fail-closed rule for a body ``Status: gaps`` under a leading
+        # ``ok`` — gaps is the most-conservative verdict and must win.
+        self._audit(tmp_path)
+        (tmp_path / 'REVIEW_2026-07-09_iter2.md').write_text(
+            'Status: ok\n# Review\n- Status: gaps\nmissing drill\n',
+            encoding='utf-8',
+        )
+        deny = rr.reviewer_verdict(tmp_path)
+        assert deny is not None
+        assert 'iter 2' in deny and 'iter3' in deny
+
+    def test_repeated_ok_only_still_passes(self, tmp_path):
+        # Two ``ok`` lines is not a conflict — a genuinely clean review
+        # must still pass (no false trap).
+        self._audit(tmp_path)
+        (tmp_path / 'REVIEW_2026-07-09_iter1.md').write_text(
+            'Status: ok\n# Review\nAll totals reconcile.\nStatus: ok\n',
+            encoding='utf-8',
+        )
+        assert rr.reviewer_verdict(tmp_path) is None
+
 
 @pytest.mark.unit
 class TestPartialBanner:

--- a/tests/unit/test_report_reviewer.py
+++ b/tests/unit/test_report_reviewer.py
@@ -174,6 +174,32 @@ class TestReviewerVerdict:
 
 
 @pytest.mark.unit
+class TestEffectiveStatus:
+    """The shared fail-closed status parser (used by both review gates)."""
+
+    def test_most_conservative_wins_over_leading_ok(self):
+        status, raw = rr.effective_status(
+            'Status: ok\n\n**Status: incomplete**\n'
+        )
+        assert status == 'incomplete'
+        assert len(set(raw)) > 1  # conflict detectable
+
+    def test_gaps_beats_incomplete_and_ok(self):
+        status, _ = rr.effective_status(
+            'Status: ok\n- Status: incomplete\n> Status: gaps\n'
+        )
+        assert status == 'gaps'
+
+    def test_all_ok_is_ok(self):
+        status, _ = rr.effective_status('Status: ok\ntext\nStatus: ok\n')
+        assert status == 'ok'
+
+    def test_no_status_is_none(self):
+        status, raw = rr.effective_status('# review, no verdict\n')
+        assert status is None and raw == []
+
+
+@pytest.mark.unit
 class TestPartialBanner:
     def test_banner_marks_unverified(self):
         banner = rr.partial_banner()


### PR DESCRIPTION
## What & why

Extends the Definition-of-Done (DoD) reviewer gate to more deliverables and
proves the **noon listing** operations end-to-end on a live store, after
e2e verification showed the "extends to 商品/报表/发票/Noon" claim was only
code-level, not live-verified. Both noon **create** paths (click wizard +
file-based NIS import) and **delete** (deactivate) are now verified live,
and a real DoD-gate bypass bug is fixed.

## DoD reviewer gate — fail-closed fix

- **Bug:** `reviewer_verdict` read only the first `^Status:` line. A review
  that top-stamped `Status: ok` but concluded `**Status: incomplete**`
  (with a real numeric error) slipped through and completed the task — the
  exact "half-returns and says done" failure the gate exists to prevent.
- **Fix:** `effective_status()` scans **all** status lines and returns the
  most-conservative verdict (`gaps` > `incomplete` > `ok`); the gate
  fails-closed on a self-contradictory review and surfaces the conflict.
  Shared by both completion paths (Stop hook + `set_task_result`).
- 21 unit tests pin the verdict logic (incl. the leading-ok / bolded-
  incomplete conflict cases).

## noon-listing skill — verified live, dual-path

Restructured to **prefer file-based, fall back to click**, with only
generic placeholders (no live-account data):

- **§1 File-based (NIS import) — preferred.** `Content → NIS Create/Update`
  creates SKUs from a spreadsheet (sidesteps every anti-automation
  dropdown). Documents the import→field map, core columns, the
  **parent+child** requirement (a lone parent row fails with
  `child is missing`), the error-file debug loop, the pricing high-base +
  long-dated-sale pattern (optional per-seller guideline), and matching the
  stock import to the store's warehouse type.
- **§2 Click wizard — fallback**, with the hand-verified **§2.7 techniques**
  that were the real walls: category-tree `scrollIntoView`, the
  virtual-list ant-select scroll (options render below the clipped panel),
  Arabic via `Input.insertText` (`fill_input` hangs on Arabic), content on
  `/d?tab=content`, image upload + real-photo validation gate, verify-by-
  reload. **Corrects** a wrong "Gender is optional" note — Gender is
  mandatory and Department derives from it.
- **§4 Delete = Deactivate** (noon has no hard delete; reversible).

### Live verification (placeholder test SKUs)

- **Click create** — full listing via the herded agent (offer price+sale,
  No-Warranty, content title EN/AR + Gender, real image, Seller Status ON),
  DoD review `Status: ok`, confirmed in My Catalog.
- **File-based create** — SKU created via NIS parent+child import + Pricing
  import (price + sale applied), confirmed in My Catalog.
- **Delete** — deactivate flow confirmed (search+Enter filter → select row →
  Deactivate SKUs → confirm).

Reports and invoice DoD flows were separately verified one-shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Xthn4cVTJmpHGWSvWptTa
