### PR TITLE
docs(noon-listing): delete §4 — verify exact PSKU (search is prefix/fuzzy)

### DIFF
--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -561,6 +561,13 @@ reversible (an **Activate SKUs** button re-lists it). Verified live:
    live sellers. Filter to the one SKU first, confirm **"Total 1 items"**,
    then select. (Selecting one product may check its per-marketplace
    sub-boxes too — that is still just the one product.)
+   ⚠️ **"Total 1 items" is not enough — the search is prefix/fuzzy.** A
+   query can return a *different* single SKU (e.g. searching
+   `WIDGET-010` when only `WIDGET-011-OS` exists shows that one as
+   "Total 1 items"). **Verify the row's `PSKU:` matches your target
+   exactly before ticking** — otherwise you deactivate the wrong SKU. If
+   the exact partner SKU isn't in the result, treat it as "not listed",
+   not a match.
 3. A **"Deactivate SKUs"** action button appears — click it.
 4. Confirm the modal (**"Deactivate this SKU? … across noon, supermall,
    and Global"**) → **Deactivate**. To reverse, select it again and use


### PR DESCRIPTION
## What & why

A hands-off vibe-seller task that deactivated test SKUs on a live noon store surfaced a real safety gap in the delete (§4) guidance.

noon's My-Catalog "Search for SKU here…" box is **prefix/fuzzy**: searching for a partner SKU that isn't listed can return a *different* single SKU and still show **"Total 1 items"**. The existing guard ("filter to one SKU, confirm Total 1 items, tick the row not the header") is therefore not sufficient on its own — you could tick and deactivate the **wrong** listing.

## Change

`app/skills_v2/noon-listing/SKILL.md` §4 (Delete/Deactivate): add the guard to **verify the row's `PSKU:` matches the target exactly** before ticking; if the exact partner SKU isn't in the result, treat it as "not listed", not a match. Generic `WIDGET-*` placeholders only.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Xthn4cVTJmpHGWSvWptTa
