### PR TITLE
docs(noon-listing): multi-size parent-child variations (new style), verified live

### DIFF
--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -111,6 +111,14 @@ read it in-page before filling; do not assume.
   check the template's `valid values` / the live **Sizes tab** for the
   noon size names. This is noon's **new** variation style — always use it
   for new listings.
+  ⚠️ **NIS has no Arabic-size column — only `size_variation` (Seller Size
+  EN) and `size_map` (noon Size).** So after a NIS create the sized
+  product's **Seller Size (AR)** — a `*`-mandatory field on the Sizes tab
+  — shows `--` (empty), and the family is bound but not content-complete.
+  Fill the Arabic seller size per row on the live **Sizes tab** (edit each
+  size) after import. Verified live: a parent + S/M/L children imported
+  correctly (one parent hash, children `-1/-2/-3`, all shown bound on the
+  Sizes tab) but with `Seller Size (AR) = --` until filled by hand.
 - **Upload flow (filled NIS sheet):** Imports → Add Import → Type=Content,
   Subtype=NIS Create/Update → **Next** → drag/drop or pick the `.xlsx`
   (the hidden `input[type=file]` accepts `.csv,.xlsx`) → **Submit**. The

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -561,6 +561,13 @@ reversible (an **Activate SKUs** button re-lists it). Verified live:
    live sellers. Filter to the one SKU first, confirm **"Total 1 items"**,
    then select. (Selecting one product may check its per-marketplace
    sub-boxes too — that is still just the one product.)
+   ⚠️ **"Total 1 items" is not enough — the search is prefix/fuzzy.** A
+   query can return a *different* single SKU (e.g. searching
+   `WIDGET-010` when only `WIDGET-011-OS` exists shows that one as
+   "Total 1 items"). **Verify the row's `PSKU:` matches your target
+   exactly before ticking** — otherwise you deactivate the wrong SKU. If
+   the exact partner SKU isn't in the result, treat it as "not listed",
+   not a match.
 3. A **"Deactivate SKUs"** action button appears — click it.
 4. Confirm the modal (**"Deactivate this SKU? … across noon, supermall,
    and Global"**) → **Deactivate**. To reverse, select it again and use

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -101,6 +101,21 @@ read it in-page before filling; do not assume.
   with its own distinct `seller_sku` and a `size_variation`/`size_map`,
   e.g. `One Size`). The **child** is what carries the offer — follow-up
   Pricing/Stock imports key on the **child** `seller_sku`.
+- **Multiple sizes = one parent row + one child row PER SIZE** (all
+  sharing the parent's `parent_group_key`). Verified live: a parent +
+  three children (`size_variation`/`size_map` = `S`, `M`, `L`, distinct
+  `seller_sku`s) created one parent noon-SKU with children `-1/-2/-3`,
+  one per size — the same shape a real sized product uses (e.g. an
+  S/M/L/XL/XXL family is a parent + five child rows). `size_map` is the
+  **noon** size and may differ from your label (e.g. `XXL` → noon `2XL`);
+  check the template's `valid values` / the live **Sizes tab** for the
+  noon size names. This is noon's **new** variation style — always use it
+  for new listings.
+- **Upload flow (filled NIS sheet):** Imports → Add Import → Type=Content,
+  Subtype=NIS Create/Update → **Next** → drag/drop or pick the `.xlsx`
+  (the hidden `input[type=file]` accepts `.csv,.xlsx`) → **Submit**. The
+  import runs async (a `IMP…` code); it shows Completed even on row
+  failures, so verify the SKUs actually appear in My Catalog.
 - **Reading the error file is the debug loop.** An import that shows
   Completed but creates nothing failed row validation; open the import's
   Result/error CSV — its trailing `partner_error` / `content_error` /
@@ -371,8 +386,18 @@ The product detail/edit page has 5 primary tabs:
 |-----|----|----|
 | Offer | `rc-tabs-0-tab-offer` | Price, stock, barcode, warranty, offer note |
 | Content | `rc-tabs-0-tab-content` | Title, description, images, attributes |
-| Sizes | `rc-tabs-0-tab-sizes` | Size matrix |
+| Sizes | `rc-tabs-0-tab-sizes` | Size variants of one parent (new style) |
 | Groups | `rc-tabs-0-tab-groups` | Product groupings |
+
+> **Sizes tab = the click way to manage size variants** (the interactive
+> equivalent of NIS parent+child, §1.2). On the **parent** SKU's Sizes
+> tab: "Create size variants for this SKU" → **Add Size**, a row per size
+> with **Partner SKU / Seller Size (EN) / Seller Size (AR) / Display Size
+> / noon Size**. Each size becomes a child noon-SKU (`<parent>-1`,
+> `-2`, …) sharing the parent — this is noon's **new** variation style,
+> the only one to use for new listings. (Prefer the file-based NIS path
+> in §1.2 for creating many sizes at once; use this tab to add/adjust a
+> size on an existing parent.)
 | Product Insights | `rc-tabs-0-tab-product-insights` | Performance insights |
 
 And country/market sub-tabs: `rc-tabs-1-tab-noon`, `rc-tabs-1-tab-supermall`, `rc-tabs-1-tab-global`.


### PR DESCRIPTION
## What & why

Verifies and documents noon **parent-child (multi-size) variations** — the "new" variation style — after exploring how existing variation families are structured on a live store.

**Verified live:** a NIS Create/Update sheet with **one parent row + three child rows** (`size_variation`/`size_map` = S / M / L, distinct `seller_sku` each, shared `parent_group_key`) created **one parent noon-SKU with children `-1/-2/-3`**. Opening any variant's **Sizes tab** shows all three bound as one family (header sibling chips + Sizes matrix) — same shape as a real S/M/L/XL/XXL family.

## Docs added (`app/skills_v2/noon-listing/SKILL.md`)

- **§1.2** — multiple sizes = parent + **one child row per size** (shared `parent_group_key`); `size_map` is the **noon** size and may differ from the label (`XXL` → noon `2XL`); the filled-sheet **upload flow** (Add Import → Next → pick `.xlsx` → Submit; async `IMP…`; verify in My Catalog).
- **⚠️ NIS has no Arabic-size column** — only `size_variation` (Seller Size EN) + `size_map` (noon Size). After a NIS create the mandatory **Seller Size (AR)** shows `--`; the family is *bound* but not content-complete until you fill the Arabic seller size per row on the live **Sizes tab**. (Found by opening the created family's Sizes tab and seeing AR = `--`.)
- **Edit tabs** — the interactive **Sizes tab** (Add Size; Partner SKU / Seller Size EN-AR / Display Size / noon Size) as the click equivalent; new listings must use this new style.

Docs-only; generic placeholders; existing listings explored read-only, none touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Xthn4cVTJmpHGWSvWptTa
