### PR TITLE
fix(install): don't abort with 127 when npm is missing on a fresh machine

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -765,9 +765,18 @@ main() {
     # find tools installed by previous runs even in non-interactive shells
     # (e.g. SSH sessions, WSL launched from Windows, CI runners).
     export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
-    local _npm_bin
-    _npm_bin="$(npm config get prefix 2>/dev/null)/bin"
-    if [[ -d "$_npm_bin" && ":$PATH:" != *":$_npm_bin:"* ]]; then
+    # npm may not exist yet on a fresh machine — the DEPS loop below is
+    # what installs node/npm. Only probe npm's prefix if npm is present:
+    # a command substitution of a missing command exits 127, which
+    # `2>/dev/null` silences but does NOT neutralize, so under `set -e`
+    # the bare assignment aborts the whole installer (observed as an
+    # instant exit 127 right after the platform check on a clean macOS).
+    # This block is best-effort PATH sugar; a missing npm must be a no-op.
+    local _npm_bin=""
+    if _check npm; then
+        _npm_bin="$(npm config get prefix 2>/dev/null || true)/bin"
+    fi
+    if [[ -n "$_npm_bin" && -d "$_npm_bin" && ":$PATH:" != *":$_npm_bin:"* ]]; then
         export PATH="$_npm_bin:$PATH"
     fi
     # In GitHub Actions, PATH exports inside a script don't persist to

--- a/tests/unit/test_install_sh.py
+++ b/tests/unit/test_install_sh.py
@@ -1,0 +1,71 @@
+"""Regression tests for the `install.sh` bootstrap installer.
+
+These shell out to the real `install.sh` — they pin invariants that
+are only expressible at the script level, not in the Python package.
+"""
+
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SH = REPO_ROOT / 'install.sh'
+
+# Infra tools install.sh needs *before* the dependency checks (path
+# resolution, checkout detection, platform detection). Deliberately
+# excludes the DEPS tools (curl/git/uv/node/pnpm/sqlite3/lsof) — and
+# crucially npm/node — so the script runs as if on a fresh machine.
+_INFRA_TOOLS = ('dirname', 'grep', 'uname', 'sed', 'awk', 'cut', 'cat', 'tr')
+
+
+@pytest.mark.unit
+def test_check_only_survives_missing_npm(tmp_path):
+    """`install.sh --check-only` must not abort with 127 when npm is absent.
+
+    Regression: main()'s best-effort PATH bootstrap ran
+    `_npm_bin="$(npm config get prefix ...)/bin"` *before* the DEPS loop
+    that installs node/npm. On a fresh machine npm doesn't exist, so the
+    command substitution exits 127; `2>/dev/null` hid the message but not
+    the status, and `set -e` killed the whole installer right after the
+    platform check. `--check-only` shares that pre-DEPS block, so it
+    reproduces the bug without installing anything.
+    """
+    fake_bin = tmp_path / 'bin'
+    fake_bin.mkdir()
+    for tool in _INFRA_TOOLS:
+        src = shutil.which(tool)
+        if src:
+            (fake_bin / tool).symlink_to(src)
+    # npm/node must NOT be resolvable — assert the curated PATH is clean.
+    fake_home = tmp_path / 'home'
+    fake_home.mkdir()
+
+    bash = shutil.which('bash')
+    assert bash, 'bash is required to run this test'
+
+    env = {'PATH': str(fake_bin), 'HOME': str(fake_home)}
+    assert shutil.which('npm', path=env['PATH']) is None
+    assert shutil.which('node', path=env['PATH']) is None
+
+    result = subprocess.run(
+        [bash, str(INSTALL_SH), '--check-only'],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode != 127, (
+        'install.sh aborted with 127 — the npm-missing set -e bug. '
+        f'stdout={result.stdout!r} stderr={result.stderr!r}'
+    )
+    # Positive signal that it ran past the crash point through the DEPS
+    # loop to the --check-only summary (rather than dying early some
+    # other way). With every dep missing it reports them and exits 1.
+    assert 'required tool' in combined, (
+        'install.sh did not reach the dependency-check summary; '
+        f'stdout={result.stdout!r} stderr={result.stderr!r}'
+    )


### PR DESCRIPTION
## Problem

`./install.sh --dev` — the README's from-source setup line — aborts with
**exit 127** right after the platform check on any machine without
Node/npm. That's every fresh machine, i.e. the exact scenario `--dev`
exists to bootstrap. `--check-only` (which `start.sh` runs) shares the
same block and fails the same way.

```
==> Vibe Seller — dev dependency check
[ok] Platform: macos (arm64)
<exit 127>
```

## Root cause (design, not symptom)

`main()` runs a *best-effort* PATH-augmentation block **before** the DEPS
loop that installs node/npm:

```bash
_npm_bin="$(npm config get prefix 2>/dev/null)/bin"
```

When npm doesn't exist yet, the command substitution exits 127.
`2>/dev/null` hides the message but **not** the exit status, so under
`set -euo pipefail` the bare assignment kills the whole installer. The
block is only meant to be optional PATH sugar for tools left by previous
runs — a missing npm should be a no-op, but the contract was never
enforced against that state.

## Fix

Probe npm's prefix only when npm is present (using the file's own
`_check` helper), and keep the `|| true` guard already used by
`fix_npm_permissions` so the lookup can never abort the script. The
downstream use is guarded with `-n "$_npm_bin"`. Nothing else in the
`--check-only`/`--dev` path before the DEPS loop invokes a
possibly-missing command unguarded.

## Test

Adds `tests/unit/test_install_sh.py` — runs `install.sh --check-only`
with a curated npm-free `PATH` and asserts it neither exits 127 nor dies
before reaching the dependency-check summary.

Verified: **fails (127) against the pre-fix script, passes after.**
`bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
