### PR TITLE
feat(frontend): mobile-responsive layout + unify accent to brand purple

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,9 +3,11 @@ import { useTranslation } from 'react-i18next'
 import { ProfileModal } from './components/ProfileModal'
 import { LoginPage } from './components/LoginPage'
 import { Sidebar } from './components/Sidebar'
+import { MobileMenuButton } from './components/MobileMenuButton'
 import { useWsFiles } from './hooks/useWsFiles'
 import { useUpdateCheck } from './hooks/useUpdateCheck'
 import { useIsMobile } from './hooks/useIsMobile'
+import { useMobileBackStack } from './hooks/useMobileBackStack'
 import { CreateTaskModal } from './components/CreateTaskModal'
 import { CreateScheduleModal } from './components/CreateScheduleModal'
 import { UpdateAvailableModal } from './components/UpdateAvailableModal'
@@ -15,14 +17,14 @@ import { WorkspaceAssistantView } from './views/WorkspaceAssistantView'
 import { SettingsView, type SettingsTab } from './views/SettingsView'
 import { useSSE } from './hooks/useSSE'
 import { api, AUTH_EXPIRED_EVENT } from './api'
-import { sendEvent, lengthBucket } from './lib/telemetry'
-import { FrontendEvent } from './lib/telemetryEvents'
 import { triggerSchedule as triggerScheduleHandler } from './handlers/triggerSchedule'
 import { replanSchedule as replanScheduleHandler } from './handlers/replanSchedule'
 import { selectSchedule as selectScheduleHandler } from './handlers/selectSchedule'
 import { submitCreateTask as submitCreateTaskHandler } from './handlers/submitCreateTask'
 import { retryTask as retryTaskHandler } from './handlers/retryTask'
 import { continueTask as continueTaskHandler } from './handlers/continueTask'
+import { deleteTask as deleteTaskHandler } from './handlers/deleteTask'
+import { sendChatMessage as sendChatMessageHandler } from './handlers/sendChatMessage'
 import type {
   Store, Task, TaskStep, AgentMessage, TodoItem, AuthUser, Profile,
   ServerPlatform,
@@ -191,40 +193,14 @@ export default function App() {
 
   const { updateCheck, dismissUpdateCheck } = useUpdateCheck(currentUser)
 
-  // ─── Mobile back-button integration ─────────────────
-  // On phones the layout is a drill-down stack (nav drawer → task list
-  // → task detail). Without this, the device/browser Back button leaves
-  // the site entirely. We add exactly one history entry whenever a
-  // "sub-screen" is open (drawer, or a selected task/schedule) and pop
-  // the top-most one on `popstate`, so Back means "up one level".
-  const mobileSubOpen =
-    isMobile && (navOpen || !!selectedTask || !!selectedSchedule)
-  const historyPushedRef = useRef(false)
-  useEffect(() => {
-    if (!isMobile) return
-    if (mobileSubOpen && !historyPushedRef.current) {
-      historyPushedRef.current = true
-      window.history.pushState({ vsSub: true }, '')
-    } else if (!mobileSubOpen && historyPushedRef.current) {
-      // Closed via in-app UI (the ← bar / scrim): drop our history
-      // entry so the next Back leaves the app as the user expects.
-      historyPushedRef.current = false
-      window.history.back()
-    }
-  }, [isMobile, mobileSubOpen])
-  useEffect(() => {
-    const onPop = () => {
-      if (!historyPushedRef.current) return
-      historyPushedRef.current = false
-      // Close only the top-most level. If a lower level is still open
-      // the push effect re-adds an entry for it, so each Back peels one.
-      if (navOpen) setNavOpen(false)
-      else if (selectedTask) setSelectedTask(null)
-      else if (selectedSchedule) setSelectedSchedule(null)
-    }
-    window.addEventListener('popstate', onPop)
-    return () => window.removeEventListener('popstate', onPop)
-  }, [navOpen, selectedTask, selectedSchedule])
+  // Device/browser Back pops the mobile drill-down instead of leaving.
+  useMobileBackStack({
+    isMobile, navOpen,
+    hasTask: !!selectedTask, hasSchedule: !!selectedSchedule,
+    closeNav: () => setNavOpen(false),
+    closeTask: () => setSelectedTask(null),
+    closeSchedule: () => setSelectedSchedule(null),
+  })
 
   const debugInitialized = useRef(false)
   useEffect(() => { if (!debugInitialized.current) { debugInitialized.current = true; return } if (currentUser) api.patch('/api/auth/me/debug-mode', { debug_mode: debugMode }).catch(() => {}) }, [debugMode])
@@ -523,81 +499,26 @@ export default function App() {
     })
   const continueTask = (taskId: string) =>
     continueTaskHandler(taskId, handlerDeps)
-  const deleteTask = async (taskId: string) => {
-    let childCount = 0
-    try {
-      const kids = await api.get(`/api/tasks?parent_task_id=${encodeURIComponent(taskId)}`) as Task[]
-      childCount = Array.isArray(kids) ? kids.length : 0
-    } catch { /* ignore — fall back to plain confirm */ }
-    const message = childCount > 0
-      ? t('tasks.deleteConfirmCascade', { count: childCount })
-      : t('tasks.deleteConfirm')
-    if (!confirm(message)) return
-    try {
-      await api.del(`/api/tasks/${taskId}`)
-      // Locally drop the deleted task plus any descendants we
-      // know about (cascade on the server won't push individual
-      // SSE deletes for each child).
-      const dropIds = new Set<string>([taskId])
-      let frontier = [taskId]
-      while (frontier.length) {
-        const next: string[] = []
-        for (const id of frontier) {
-          for (const t2 of tasks) if (t2.parent_task_id === id) next.push(t2.id)
-          for (const t2 of scheduleTasks) if (t2.parent_task_id === id) next.push(t2.id)
-        }
-        // Filter to unvisited BEFORE adding to dropIds — otherwise
-        // every BFS frontier collapses to [] after the first hop and
-        // we never reach grandchildren.
-        const unvisited = next.filter(id => !dropIds.has(id))
-        unvisited.forEach(id => dropIds.add(id))
-        frontier = unvisited
-      }
-      setTasks(prev => prev.filter(x => !dropIds.has(x.id)))
-      setScheduleTasks(prev => prev.filter(x => !dropIds.has(x.id)))
-      if (selectedTask && dropIds.has(selectedTask.id)) {
+  const deleteTask = (taskId: string) =>
+    deleteTaskHandler(taskId, {
+      api, tasks, scheduleTasks, selectedTask, setTasks, setScheduleTasks,
+      onSelectedCleared: () => {
         setSelectedTask(null)
         setSteps([]); setScreenshots({}); setLogs([]); setConversationItems([])
         setAgentMessages([]); setTodoItems([]); setPendingQuestions(null)
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      if (msg !== 'unauthorized') alert(msg)
-    }
-  }
+      },
+    })
   const selectAnswer = (questionText: string, answer: string) => { setSelectedAnswers(prev => ({ ...prev, [questionText]: answer })); setShowOtherInput(prev => ({ ...prev, [questionText]: false })); setOtherInputs(prev => ({ ...prev, [questionText]: '' })) }
   const toggleOtherInput = (questionText: string) => { setShowOtherInput(prev => { const show = !prev[questionText]; if (show) { setSelectedAnswers(p => { const n = { ...p }; delete n[questionText]; return n }) } else { setOtherInputs(p => ({ ...p, [questionText]: '' })); setSelectedAnswers(p => { const n = { ...p }; delete n[questionText]; return n }) } return { ...prev, [questionText]: show } }) }
   const setOtherAnswer = (questionText: string, text: string) => { setOtherInputs(prev => ({ ...prev, [questionText]: text })); if (text.trim()) { setSelectedAnswers(prev => ({ ...prev, [questionText]: text.trim() })) } else { setSelectedAnswers(prev => { const n = { ...prev }; delete n[questionText]; return n }) } }
   const submitAllAnswers = async (overrideAnswers?: Record<string, string>) => { if (!selectedTask || !pendingQuestions) return; const answers = overrideAnswers || selectedAnswers; await api.post(`/api/tasks/${selectedTask.id}/questions/answer`, { request_id: pendingQuestions.request_id, answers }); setPendingQuestions(null); setSelectedAnswers({}); setOtherInputs({}); setShowOtherInput({}) }
   const sendingRef = useRef(false)
-  const sendChatMessage = async () => {
-    if (!selectedTask || !chatInput.trim() || sendingRef.current) return
-    sendingRef.current = true
-    const content = chatInput.trim(); setChatInput('')
-    sendEvent(FrontendEvent.TASK_MESSAGE_SUBMITTED, {
-      length_bucket: lengthBucket(content.length),
-      task_status_at_send: selectedTask.status,
-      is_first_message_for_task: !conversationItems.some(c => c.type === 'user_message'),
+  const sendChatMessage = () =>
+    sendChatMessageHandler({
+      api, selectedTask, chatInput, profileId: selectedProfileId,
+      conversationItems, sendingRef,
+      setChatInput, setAgentMessages, setConversationItems, setSelectedTask, setTasks,
     })
-    // Optimistic add to both agentMessages (debug) and conversationItems
-    setAgentMessages(prev => [...prev, { role: 'user', content }])
-    setConversationItems(prev => [...prev, {
-      id: `user-opt-${Date.now()}`,
-      type: 'user_message',
-      timestamp: new Date().toISOString(),
-      message: { role: 'user', content },
-    }])
-    try {
-      const response = await api.post(`/api/tasks/${selectedTask.id}/messages`, { content, profile_id: selectedProfileId })
-      if (response.woken) {
-        setSelectedTask(prev => prev ? { ...prev, status: 'queued' } : prev)
-        setTasks(prev => prev.map(t2 => t2.id === selectedTask.id ? { ...t2, status: 'queued' } : t2))
-      }
-      if (response.profile_switched) {
-        setSelectedTask(prev => prev ? { ...prev, ai_profile_id: selectedProfileId } : prev)
-      }
-    } catch (err) { console.error('Failed to send message:', err) } finally { sendingRef.current = false }
-  }
 
   // ─── Profile helpers ───────────────────────────────
   const createProfile = async (profile: Omit<Profile, 'id'>) => { const newProfile = await api.post('/api/profiles', profile); setProfiles(prev => [...prev, newProfile]); return newProfile }
@@ -691,7 +612,7 @@ export default function App() {
   }
 
   return (
-    <div className="flex h-screen bg-gray-100 text-gray-900">
+    <div className="flex h-dvh bg-gray-100 text-gray-900">
       {/* Mobile drawer scrim — tap to close the slide-in sidebar. */}
       {isMobile && navOpen && (
         <div
@@ -767,13 +688,7 @@ export default function App() {
           {/* Mode toggle header */}
           <div className="px-4 py-2.5 bg-white border-b border-gray-100 flex items-center justify-end gap-2">
             {isMobile && (
-              <button
-                onClick={() => setNavOpen(true)}
-                className="mr-auto w-9 h-9 -ml-1 flex items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100"
-                aria-label={t('common.menu', 'Menu')}
-              >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" /></svg>
-              </button>
+              <MobileMenuButton onClick={() => setNavOpen(true)} label={t('common.menu', 'Menu')} className="mr-auto -ml-1" />
             )}
             <div className="inline-flex rounded-lg border border-gray-200 p-1 gap-1">
               <button
@@ -816,13 +731,7 @@ export default function App() {
         <div className="flex-1 flex flex-col min-w-0">
         {isMobile && (
           <div className="px-3 py-2 bg-white border-b border-gray-200 flex items-center">
-            <button
-              onClick={() => setNavOpen(true)}
-              className="w-9 h-9 -ml-1 flex items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100"
-              aria-label={t('common.menu', 'Menu')}
-            >
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" /></svg>
-            </button>
+            <MobileMenuButton onClick={() => setNavOpen(true)} label={t('common.menu', 'Menu')} className="-ml-1" />
             <span className="ml-1 font-semibold text-gray-800">{t('settings.title')}</span>
           </div>
         )}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { LoginPage } from './components/LoginPage'
 import { Sidebar } from './components/Sidebar'
 import { useWsFiles } from './hooks/useWsFiles'
 import { useUpdateCheck } from './hooks/useUpdateCheck'
+import { useIsMobile } from './hooks/useIsMobile'
 import { CreateTaskModal } from './components/CreateTaskModal'
 import { CreateScheduleModal } from './components/CreateScheduleModal'
 import { UpdateAvailableModal } from './components/UpdateAvailableModal'
@@ -42,6 +43,10 @@ export default function App() {
   const [loginError, setLoginError] = useState('')
 
   const [appView, setAppView] = useState<AppView>('tasks')
+  // Mobile: the sidebar collapses into a slide-in drawer toggled by a
+  // hamburger; desktop keeps it as a resident column.
+  const isMobile = useIsMobile()
+  const [navOpen, setNavOpen] = useState(false)
   const [stores, setStores] = useState<Store[]>([])
   const [selectedStore, setSelectedStore] = useState<Store | null>(null)
   const [showAllTasks, setShowAllTasks] = useState(true)
@@ -348,12 +353,14 @@ export default function App() {
   }
 
   const selectStore = async (store: Store) => {
+    setNavOpen(false)
     userActedRef.current = true; setSelectedStore(store); setShowAllTasks(false); setSelectedTask(null); setSteps([]); setScreenshots({}); setLogs([])
     setSelectedSchedule(null); setScheduleTasks([])
     setTasks(await api.get(`/api/tasks?store_id=${store.id}`))
     loadSchedules()
   }
   const selectAllTasks = async () => {
+    setNavOpen(false)
     userActedRef.current = true; setSelectedStore(null); setShowAllTasks(true); setSelectedTask(null); setSteps([]); setScreenshots({}); setLogs([])
     setSelectedSchedule(null); setScheduleTasks([])
     setTasks(await api.get('/api/tasks?store_id=__none__'))
@@ -650,7 +657,16 @@ export default function App() {
 
   return (
     <div className="flex h-screen bg-gray-100 text-gray-900">
+      {/* Mobile drawer scrim — tap to close the slide-in sidebar. */}
+      {isMobile && navOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40"
+          onClick={() => setNavOpen(false)}
+          aria-hidden
+        />
+      )}
       <Sidebar
+        isMobile={isMobile} navOpen={navOpen} closeNav={() => setNavOpen(false)}
         currentUser={currentUser} appView={appView} setAppView={setAppView} handleLogout={handleLogout} authRequired={authRequired}
         stores={stores} selectedStore={selectedStore} showAllTasks={showAllTasks}
         selectStore={selectStore} selectAllTasks={selectAllTasks}
@@ -684,6 +700,7 @@ export default function App() {
       {/* Main content area */}
       {appView === 'tasks' ? (
         <TasksView
+          isMobile={isMobile} onOpenNav={() => setNavOpen(true)}
           taskPanelActive={!!taskPanelActive} taskPanelTitle={taskPanelTitle}
           tasks={tasks} selectedTask={selectedTask} steps={steps} screenshots={screenshots} logs={logs}
           agentMessages={agentMessages} todoItems={todoItems} pendingQuestions={pendingQuestions}
@@ -711,9 +728,18 @@ export default function App() {
           stores={stores}
         />
       ) : appView === 'workspace' ? (
-        <div className="flex-1 flex flex-col">
+        <div className="flex-1 flex flex-col min-w-0">
           {/* Mode toggle header */}
-          <div className="px-4 py-2.5 bg-white border-b border-gray-100 flex justify-end">
+          <div className="px-4 py-2.5 bg-white border-b border-gray-100 flex items-center justify-end gap-2">
+            {isMobile && (
+              <button
+                onClick={() => setNavOpen(true)}
+                className="mr-auto w-9 h-9 -ml-1 flex items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100"
+                aria-label={t('common.menu', 'Menu')}
+              >
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" /></svg>
+              </button>
+            )}
             <div className="inline-flex rounded-lg border border-gray-200 p-1 gap-1">
               <button
                 onClick={() => setWsAssistantActive(false)}
@@ -724,7 +750,7 @@ export default function App() {
               </button>
               <button
                 onClick={() => setWsAssistantActive(true)}
-                className={`px-4 py-1.5 rounded-md transition-colors flex flex-col items-center ${wsAssistantActive ? 'bg-blue-50 text-blue-600' : 'text-gray-400 hover:text-gray-600 hover:bg-gray-50'}`}
+                className={`px-4 py-1.5 rounded-md transition-colors flex flex-col items-center ${wsAssistantActive ? 'bg-indigo-50 text-indigo-600' : 'text-gray-400 hover:text-gray-600 hover:bg-gray-50'}`}
               >
                 <span className="text-sm font-medium">{t('workspace.modeAI')}</span>
                 <span className="text-[10px] opacity-60">{t('workspace.modeAISub')}</span>
@@ -752,6 +778,19 @@ export default function App() {
           )}
         </div>
       ) : (
+        <div className="flex-1 flex flex-col min-w-0">
+        {isMobile && (
+          <div className="px-3 py-2 bg-white border-b border-gray-200 flex items-center">
+            <button
+              onClick={() => setNavOpen(true)}
+              className="w-9 h-9 -ml-1 flex items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100"
+              aria-label={t('common.menu', 'Menu')}
+            >
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" /></svg>
+            </button>
+            <span className="ml-1 font-semibold text-gray-800">{t('settings.title')}</span>
+          </div>
+        )}
         <SettingsView
           currentUser={currentUser} settingsTab={settingsTab} setSettingsTab={setSettingsTab}
           allUsers={allUsers} showAddUser={showAddUser} setShowAddUser={setShowAddUser}
@@ -762,6 +801,7 @@ export default function App() {
           stores={stores} loadStores={loadStores}
           authRequired={authRequired} setAuthRequired={setAuthRequired} loadUsers={loadUsers}
         />
+        </div>
       )}
 
       {/* Modals */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -191,6 +191,41 @@ export default function App() {
 
   const { updateCheck, dismissUpdateCheck } = useUpdateCheck(currentUser)
 
+  // ─── Mobile back-button integration ─────────────────
+  // On phones the layout is a drill-down stack (nav drawer → task list
+  // → task detail). Without this, the device/browser Back button leaves
+  // the site entirely. We add exactly one history entry whenever a
+  // "sub-screen" is open (drawer, or a selected task/schedule) and pop
+  // the top-most one on `popstate`, so Back means "up one level".
+  const mobileSubOpen =
+    isMobile && (navOpen || !!selectedTask || !!selectedSchedule)
+  const historyPushedRef = useRef(false)
+  useEffect(() => {
+    if (!isMobile) return
+    if (mobileSubOpen && !historyPushedRef.current) {
+      historyPushedRef.current = true
+      window.history.pushState({ vsSub: true }, '')
+    } else if (!mobileSubOpen && historyPushedRef.current) {
+      // Closed via in-app UI (the ← bar / scrim): drop our history
+      // entry so the next Back leaves the app as the user expects.
+      historyPushedRef.current = false
+      window.history.back()
+    }
+  }, [isMobile, mobileSubOpen])
+  useEffect(() => {
+    const onPop = () => {
+      if (!historyPushedRef.current) return
+      historyPushedRef.current = false
+      // Close only the top-most level. If a lower level is still open
+      // the push effect re-adds an entry for it, so each Back peels one.
+      if (navOpen) setNavOpen(false)
+      else if (selectedTask) setSelectedTask(null)
+      else if (selectedSchedule) setSelectedSchedule(null)
+    }
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+  }, [navOpen, selectedTask, selectedSchedule])
+
   const debugInitialized = useRef(false)
   useEffect(() => { if (!debugInitialized.current) { debugInitialized.current = true; return } if (currentUser) api.patch('/api/auth/me/debug-mode', { debug_mode: debugMode }).catch(() => {}) }, [debugMode])
   const userActedRef = useRef(false)  // Login default-select guard: flips true on any manual selectStore/selectAllTasks. A plain state ref wouldn't distinguish "clicked All Stores" from initial state (same values).

--- a/frontend/src/__tests__/allStoresTaskList.test.tsx
+++ b/frontend/src/__tests__/allStoresTaskList.test.tsx
@@ -86,7 +86,7 @@ describe('AllStoresTaskList', () => {
       })
 
       // Current store header is blue (not a button)
-      const blueHeader = container.querySelector('.bg-blue-50')
+      const blueHeader = container.querySelector('.bg-indigo-50')
       expect(blueHeader).toBeInTheDocument()
       expect(blueHeader?.textContent).toBe('Amazon US')
 
@@ -185,7 +185,7 @@ describe('AllStoresTaskList', () => {
       })
 
       // Blue header = current store (Zebra)
-      const blueHeader = container.querySelector('.bg-blue-50')
+      const blueHeader = container.querySelector('.bg-indigo-50')
       expect(blueHeader?.textContent).toBe('Zebra Store')
 
       // Other stores in alpha order: Alpha, Middle
@@ -221,7 +221,7 @@ describe('AllStoresTaskList', () => {
       expect(screen.queryByText('Task B')).not.toBeInTheDocument()
 
       // No blue highlight (no focused store)
-      expect(container.querySelector('.bg-blue-50')).not.toBeInTheDocument()
+      expect(container.querySelector('.bg-indigo-50')).not.toBeInTheDocument()
 
       // Headers are toggle buttons
       const toggleButtons = container.querySelectorAll('button[aria-expanded]')
@@ -287,7 +287,7 @@ describe('AllStoresTaskList', () => {
       })
 
       // No blue highlight — all-tasks mode doesn't focus a store
-      expect(container.querySelector('.bg-blue-50')).not.toBeInTheDocument()
+      expect(container.querySelector('.bg-indigo-50')).not.toBeInTheDocument()
 
       // Selected store sorts first
       const groupDivs = container.querySelectorAll('.bg-gray-50')
@@ -379,7 +379,7 @@ describe('AllStoresTaskList', () => {
     it('handles empty task list', () => {
       const { container } = renderList({ scheduleTasks: [], showAllTasks: true })
       expect(container.querySelector('.bg-gray-50')).not.toBeInTheDocument()
-      expect(container.querySelector('.bg-blue-50')).not.toBeInTheDocument()
+      expect(container.querySelector('.bg-indigo-50')).not.toBeInTheDocument()
     })
 
     it('handles tasks for a store not in the stores list', () => {

--- a/frontend/src/__tests__/scheduleDisplay.test.tsx
+++ b/frontend/src/__tests__/scheduleDisplay.test.tsx
@@ -84,7 +84,7 @@ describe('F10: showAllTasks=true → all schedule types visible', () => {
     const { container } = renderScheduleList({ schedules, showAllTasks: true })
 
     // Badge with purple bg
-    const badge = container.querySelector('.bg-purple-100')
+    const badge = container.querySelector('.bg-indigo-100')
     expect(badge).toBeInTheDocument()
     expect(badge?.textContent).toBe('All Stores')
   })

--- a/frontend/src/components/AllStoresTaskList.tsx
+++ b/frontend/src/components/AllStoresTaskList.tsx
@@ -76,7 +76,7 @@ export function AllStoresTaskList({
         return (
           <div key={storeKey}>
             {isStoreFocused && isCurrent ? (
-              <div className="px-2 py-1 text-xs font-medium text-blue-600 bg-blue-50 rounded">{storeName}</div>
+              <div className="px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded">{storeName}</div>
             ) : (
               <button
                 type="button"

--- a/frontend/src/components/CreateScheduleModal.tsx
+++ b/frontend/src/components/CreateScheduleModal.tsx
@@ -110,13 +110,13 @@ export function CreateScheduleModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
       onClick={e => {
         if (e.target === e.currentTarget) onClose()
       }}
     >
       <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-lg mx-4"
+        className="bg-white rounded-t-2xl sm:rounded-xl shadow-2xl w-full sm:max-w-lg sm:mx-4 max-h-[92vh] overflow-y-auto"
         onClick={e => e.stopPropagation()}
       >
         <div className="px-6 py-4 border-b border-gray-200">
@@ -181,7 +181,7 @@ export function CreateScheduleModal({
           <button
             onClick={handleSubmit}
             disabled={!form.title.trim() || creating}
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             {creating ? t('common.loading') : t('common.create')}
           </button>

--- a/frontend/src/components/CreateTaskModal.tsx
+++ b/frontend/src/components/CreateTaskModal.tsx
@@ -87,11 +87,11 @@ export function CreateTaskModal({ showAllTasks, storeName, selectedStore, onClos
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
       onClick={(e) => { if (e.target === e.currentTarget) handleClose() }}
       onPaste={handlePaste}
     >
-      <div className="bg-white rounded-xl shadow-2xl w-full max-w-lg mx-4" onClick={e => e.stopPropagation()}>
+      <div className="bg-white rounded-t-2xl sm:rounded-xl shadow-2xl w-full sm:max-w-lg sm:mx-4 max-h-[92vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
         <div className="px-6 py-4 border-b border-gray-200">
           <h3 className="text-lg font-semibold">
             {showAllTasks ? t('tasks.newTask') : t('tasks.newTaskFor', { storeName })}
@@ -110,7 +110,7 @@ export function CreateTaskModal({ showAllTasks, storeName, selectedStore, onClos
               onChange={e => setModalTitle(e.target.value)}
               onKeyDown={e => { if (e.key === 'Escape') handleClose() }}
               placeholder={showAllTasks ? 'e.g. Process billing files' : 'e.g. Navigate to google.com'}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
               autoFocus
             />
           </div>
@@ -123,7 +123,7 @@ export function CreateTaskModal({ showAllTasks, storeName, selectedStore, onClos
               onKeyDown={e => { if (e.key === 'Escape') handleClose() }}
               placeholder={t('tasks.descriptionPlaceholder')}
               rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent resize-none"
             />
           </div>
           {selectedStore && selectedStore.platform_countries && Object.keys(selectedStore.platform_countries).length > 0 && (
@@ -166,7 +166,7 @@ export function CreateTaskModal({ showAllTasks, storeName, selectedStore, onClos
               onDrop={handleDrop}
               onClick={() => fileInputRef.current?.click()}
               className={`border-2 border-dashed rounded-lg p-4 text-center cursor-pointer transition-colors ${
-                dragOver ? 'border-blue-500 bg-blue-50' : 'border-gray-300 hover:border-gray-400'
+                dragOver ? 'border-indigo-500 bg-indigo-50' : 'border-gray-300 hover:border-gray-400'
               }`}
             >
               <p className="text-sm text-gray-500">Drop images here, paste, or click to browse</p>
@@ -214,7 +214,7 @@ export function CreateTaskModal({ showAllTasks, storeName, selectedStore, onClos
           <button
             onClick={handleSubmit}
             disabled={!modalTitle.trim() || modalCreating}
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             {modalCreating ? t('common.loading') : showAllTasks ? t('common.create') : 'Create & Run'}
           </button>

--- a/frontend/src/components/EditScheduleModal.tsx
+++ b/frontend/src/components/EditScheduleModal.tsx
@@ -81,13 +81,13 @@ export function EditScheduleModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
       onClick={e => {
         if (e.target === e.currentTarget) onClose()
       }}
     >
       <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-lg mx-4"
+        className="bg-white rounded-t-2xl sm:rounded-xl shadow-2xl w-full sm:max-w-lg sm:mx-4 max-h-[92vh] overflow-y-auto"
         onClick={e => e.stopPropagation()}
       >
         <div className="px-6 py-4 border-b border-gray-200">
@@ -106,7 +106,7 @@ export function EditScheduleModal({
           <button
             onClick={handleSubmit}
             disabled={!form.title.trim() || saving}
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             {saving ? t('common.loading') : t('common.save')}
           </button>

--- a/frontend/src/components/ExternalConfigOverrideModal.tsx
+++ b/frontend/src/components/ExternalConfigOverrideModal.tsx
@@ -69,7 +69,7 @@ export function ExternalConfigOverrideModal({
           {onUseDefault && (
             <button
               onClick={onUseDefault}
-              className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
+              className="rounded bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700"
             >
               {t('errors.externalConfigOverride.useDefault')}
             </button>

--- a/frontend/src/components/FileViewers.tsx
+++ b/frontend/src/components/FileViewers.tsx
@@ -156,7 +156,7 @@ export function BinaryDownload({ path }: { path: string }) {
   return (
     <div className="flex-1 flex flex-col items-center justify-center gap-3 text-gray-400">
       <div className="text-4xl opacity-40">&#128230;</div>
-      <a href={rawUrl(path)} download className="px-4 py-2 text-xs font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+      <a href={rawUrl(path)} download className="px-4 py-2 text-xs font-medium bg-indigo-600 text-white rounded-lg hover:bg-indigo-700">
         {t('workspace.download')} {path.split('/').pop()}
       </a>
     </div>

--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -21,16 +21,16 @@ export function LoginPage({ loginIdentifier, setLoginIdentifier, loginPassword, 
         <input
           value={loginIdentifier} onChange={e => setLoginIdentifier(e.target.value)}
           placeholder={t('auth.identifierPlaceholder')} type="text" autoFocus
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm mb-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm mb-3 focus:outline-none focus:ring-2 focus:ring-indigo-500"
           onKeyDown={e => e.key === 'Enter' && onLogin()}
         />
         <input
           value={loginPassword} onChange={e => setLoginPassword(e.target.value)}
           placeholder={t('auth.passwordPlaceholder')} type="password"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm mb-4 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm mb-4 focus:outline-none focus:ring-2 focus:ring-indigo-500"
           onKeyDown={e => e.key === 'Enter' && onLogin()}
         />
-        <button onClick={onLogin} className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700">
+        <button onClick={onLogin} className="w-full px-4 py-2 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700">
           {t('auth.signIn')}
         </button>
         {/* Language switcher on login page */}

--- a/frontend/src/components/MobileMenuButton.tsx
+++ b/frontend/src/components/MobileMenuButton.tsx
@@ -1,0 +1,19 @@
+/** Hamburger that opens the mobile nav drawer. Shared by the tasks,
+ *  workspace and settings headers so the icon markup lives in one place. */
+export function MobileMenuButton({ onClick, label, className = '' }: {
+  onClick: () => void
+  label: string
+  className?: string
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-9 h-9 flex items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 flex-shrink-0 ${className}`}
+      aria-label={label}
+    >
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    </button>
+  )
+}

--- a/frontend/src/components/ProfileModal.tsx
+++ b/frontend/src/components/ProfileModal.tsx
@@ -32,7 +32,7 @@ export function ProfileModal({
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50 sm:p-4">
       <ProfileForm
         key={editingProfile?.id ?? '__new__'}
         editingProfile={editingProfile}
@@ -140,7 +140,7 @@ function ProfileForm({
   }
 
   return (
-    <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+    <div className="bg-white rounded-t-2xl sm:rounded-lg shadow-xl w-full sm:max-w-2xl max-h-[90vh] overflow-y-auto">
       <div className="p-6">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-xl font-semibold">
@@ -178,7 +178,7 @@ function ProfileForm({
                     onClick={() => applyPreset(id)}
                     className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                       selectedPreset === id
-                        ? 'bg-blue-600 text-white'
+                        ? 'bg-indigo-600 text-white'
                         : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                     }`}
                   >
@@ -194,7 +194,7 @@ function ProfileForm({
                   }}
                   className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                     selectedPreset === 'custom'
-                      ? 'bg-blue-600 text-white'
+                      ? 'bg-indigo-600 text-white'
                       : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                   }`}
                 >
@@ -213,7 +213,7 @@ function ProfileForm({
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
               placeholder={t('profiles.namePlaceholder')}
             />
           </div>
@@ -227,7 +227,7 @@ function ProfileForm({
                 onChange={(e) => setLoadGlobalMcp(e.target.checked)}
                 className="sr-only peer"
               />
-              <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-blue-600" />
+              <div className="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-indigo-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-indigo-600" />
             </label>
             <div>
               <span className="text-sm font-medium text-gray-700">
@@ -247,7 +247,7 @@ function ProfileForm({
               </h4>
               <button
                 onClick={addEnvVar}
-                className="text-sm text-blue-600 hover:text-blue-700 font-medium"
+                className="text-sm text-indigo-600 hover:text-indigo-700 font-medium"
               >
                 + {t('profiles.addVariable')}
               </button>
@@ -266,14 +266,14 @@ function ProfileForm({
                       placeholder="KEY"
                       value={env.key}
                       onChange={(e) => updateEnvKey(idx, e.target.value)}
-                      className="flex-1 px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      className="flex-1 px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
                     />
                     <input
                       type="text"
                       placeholder="value"
                       value={env.value}
                       onChange={(e) => updateEnvValue(idx, e.target.value)}
-                      className="flex-[2] px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      className="flex-[2] px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
                     />
                     <button
                       onClick={() => removeEnv(idx)}
@@ -298,7 +298,7 @@ function ProfileForm({
             </button>
             <button
               onClick={handleSave}
-              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
+              className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg transition-colors"
             >
               {editingProfile
                 ? t('common.save')

--- a/frontend/src/components/QuestionBanner.tsx
+++ b/frontend/src/components/QuestionBanner.tsx
@@ -79,10 +79,10 @@ export function QuestionBanner({
                       <button
                         key={oi}
                         onClick={() => onSelectAnswer(q.question, opt.label)}
-                        className={`px-3 py-1.5 text-xs border rounded-lg transition-all ${
+                        className={`px-3 py-2.5 text-sm sm:py-1.5 sm:text-xs border rounded-lg transition-all ${
                           selectedAnswers[q.question] === opt.label && !isOther
-                            ? 'bg-blue-50 border-blue-400 text-blue-700 font-medium shadow-sm'
-                            : 'bg-white border-gray-200 text-gray-600 hover:bg-blue-50 hover:border-blue-300 hover:text-blue-600'
+                            ? 'bg-indigo-50 border-indigo-400 text-indigo-700 font-medium shadow-sm'
+                            : 'bg-white border-gray-200 text-gray-600 hover:bg-indigo-50 hover:border-indigo-300 hover:text-indigo-600'
                         }`}
                         title={opt.description || ''}
                       >
@@ -91,10 +91,10 @@ export function QuestionBanner({
                     ))}
                     <button
                       onClick={() => onToggleOther(q.question)}
-                      className={`px-3 py-1.5 text-xs border rounded-lg transition-all ${
+                      className={`px-3 py-2.5 text-sm sm:py-1.5 sm:text-xs border rounded-lg transition-all ${
                         isOther
-                          ? 'bg-blue-50 border-blue-400 text-blue-700 font-medium shadow-sm'
-                          : 'bg-white border-gray-200 text-gray-600 hover:bg-blue-50 hover:border-blue-300 hover:text-blue-600'
+                          ? 'bg-indigo-50 border-indigo-400 text-indigo-700 font-medium shadow-sm'
+                          : 'bg-white border-gray-200 text-gray-600 hover:bg-indigo-50 hover:border-indigo-300 hover:text-indigo-600'
                       }`}
                     >
                       {t('tasks.other')}
@@ -109,7 +109,7 @@ export function QuestionBanner({
                       onChange={e => onSetOtherAnswer(q.question, e.target.value)}
                       onKeyDown={e => { if (e.key === 'Escape') onToggleOther(q.question) }}
                       placeholder={t('tasks.typeAnswer')}
-                      className="w-full px-3 py-1.5 text-xs border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-blue-400 bg-white"
+                      className="w-full px-3 py-2.5 text-sm sm:py-1.5 sm:text-xs border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400 bg-white"
                       autoFocus
                     />
                   )}
@@ -133,7 +133,7 @@ export function QuestionBanner({
             }}
             placeholder={t('tasks.freeTextPlaceholder')}
             aria-label={t('tasks.freeTextPlaceholder')}
-            className="min-h-[80px] w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-blue-400 bg-white resize-y"
+            className="min-h-[80px] w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400 bg-white resize-y"
           />
         </div>
       )}
@@ -142,13 +142,13 @@ export function QuestionBanner({
           <button
             onClick={() => freeTextMode ? onSubmitAll({ _free_text: freeTextInput.trim() }) : onSubmitAll()}
             disabled={freeTextMode ? !freeTextInput.trim() : Object.keys(selectedAnswers).length < questions.length}
-            className="px-5 py-2 text-xs font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors shadow-sm"
+            className="px-5 py-2 text-xs font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors shadow-sm"
           >
             {t('tasks.submitAnswers')}
           </button>
           <button
             type="button"
-            className="text-xs text-blue-600 hover:underline cursor-pointer"
+            className="text-xs text-indigo-600 hover:underline cursor-pointer"
             onClick={() => setFreeTextMode(prev => !prev)}
             aria-pressed={freeTextMode}
           >

--- a/frontend/src/components/ScheduleDetailView.tsx
+++ b/frontend/src/components/ScheduleDetailView.tsx
@@ -63,7 +63,7 @@ export function ScheduleDetailView({
           <h2 className="text-lg font-semibold">{schedule.title}</h2>
           <div className="flex items-center gap-2">
             {schedule.is_system && (
-              <span className="px-2 py-1 text-xs rounded-full font-medium bg-blue-100 text-blue-700">
+              <span className="px-2 py-1 text-xs rounded-full font-medium bg-indigo-100 text-indigo-700">
                 {t('schedules.system')}
               </span>
             )}
@@ -126,7 +126,7 @@ export function ScheduleDetailView({
             onClick={() => triggerSchedule(schedule.id)}
             disabled={triggerDisabled}
             title={triggerTitle}
-            className={`px-3 py-1.5 text-xs rounded font-medium ${triggerDisabled ? 'bg-gray-200 text-gray-400 cursor-not-allowed' : 'bg-blue-600 text-white hover:bg-blue-700'}`}
+            className={`px-3 py-1.5 text-xs rounded font-medium ${triggerDisabled ? 'bg-gray-200 text-gray-400 cursor-not-allowed' : 'bg-indigo-600 text-white hover:bg-indigo-700'}`}
           >
             {t('schedules.trigger')}
           </button>

--- a/frontend/src/components/ScheduleForm.tsx
+++ b/frontend/src/components/ScheduleForm.tsx
@@ -69,7 +69,7 @@ export function ScheduleForm({
             value={value.title}
             onChange={e => set('title', e.target.value)}
             placeholder={t('tasks.titlePlaceholder')}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
             autoFocus
           />
         </div>
@@ -86,7 +86,7 @@ export function ScheduleForm({
           onChange={e => set('description', e.target.value)}
           rows={2}
           placeholder={t('tasks.descriptionPlaceholder')}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm resize-none focus:outline-none focus:ring-2 focus:ring-indigo-500"
         />
       </div>
 

--- a/frontend/src/components/ScheduleList.tsx
+++ b/frontend/src/components/ScheduleList.tsx
@@ -39,17 +39,17 @@ function ScheduleItem({ schedule, badge, storeName, isSelected, onClick, getSche
   return (
     <button
       onClick={onClick}
-      className={`w-full text-left px-4 py-3 hover:bg-gray-50 border-b border-gray-100 ${isSelected ? 'bg-blue-50' : ''}`}
+      className={`w-full text-left px-4 py-3 hover:bg-gray-50 border-b border-gray-100 ${isSelected ? 'bg-indigo-50' : ''}`}
     >
       <div className="flex items-center gap-2">
         <span className="font-medium text-sm truncate flex-1">{schedule.title}</span>
         {badge && (
-          <span className="px-1.5 py-0.5 text-[10px] rounded-full font-medium bg-purple-100 text-purple-700 shrink-0">{badge}</span>
+          <span className="px-1.5 py-0.5 text-[10px] rounded-full font-medium bg-indigo-100 text-indigo-700 shrink-0">{badge}</span>
         )}
       </div>
       <div className="flex items-center gap-2 mt-1 flex-wrap">
         {schedule.is_system && (
-          <span className="px-1.5 py-0.5 text-[10px] rounded-full font-medium bg-blue-100 text-blue-700">{t('schedules.system')}</span>
+          <span className="px-1.5 py-0.5 text-[10px] rounded-full font-medium bg-indigo-100 text-indigo-700">{t('schedules.system')}</span>
         )}
         <span className={`px-1.5 py-0.5 text-[10px] rounded-full font-medium ${schedule.is_active ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>
           {schedule.is_active ? t('schedules.active') : t('schedules.paused')}
@@ -120,7 +120,7 @@ export function ScheduleList({
           <p className="text-xs text-gray-400 mb-3">{t('schedules.createFirstSchedule')}</p>
           <button
             onClick={() => setShowCreateSchedule(true)}
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700"
+            className="px-4 py-2 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700"
           >
             + {t('schedules.newSchedule')}
           </button>

--- a/frontend/src/components/SchedulePlanPanel.tsx
+++ b/frontend/src/components/SchedulePlanPanel.tsx
@@ -35,7 +35,7 @@ interface Props {
 
 const STATE_ACCENT: Record<SchedulePlanStatus, string> = {
   ready: 'border-l-green-500 bg-green-50/40',
-  planning: 'border-l-blue-500 bg-blue-50/40',
+  planning: 'border-l-indigo-500 bg-indigo-50/40',
   stale: 'border-l-orange-500 bg-orange-50/40',
   failed: 'border-l-red-500 bg-red-50/40',
   none: 'border-l-amber-500 bg-amber-50/40',
@@ -43,7 +43,7 @@ const STATE_ACCENT: Record<SchedulePlanStatus, string> = {
 
 const STATUS_PILL: Record<SchedulePlanStatus, string> = {
   ready: 'bg-green-100 text-green-800',
-  planning: 'bg-blue-100 text-blue-800',
+  planning: 'bg-indigo-100 text-indigo-800',
   stale: 'bg-orange-100 text-orange-800',
   failed: 'bg-red-100 text-red-800',
   none: 'bg-amber-100 text-amber-800',
@@ -302,7 +302,7 @@ function renderCta({
     return (
       <button
         onClick={() => onOpenTask(planningTaskId)}
-        className="px-3 py-1.5 text-xs rounded font-medium bg-blue-600 text-white hover:bg-blue-700"
+        className="px-3 py-1.5 text-xs rounded font-medium bg-indigo-600 text-white hover:bg-indigo-700"
         data-testid="plan-open-planning-task"
       >
         {t('schedules.plan.openPlanningTask')}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -8,6 +8,10 @@ import { FrontendEvent } from '../lib/telemetryEvents'
 import type { Store, AuthUser, AppView, ServerPlatform, WsStructured, WsSkill, ZiniaoAccount, ZiniaoBrowserProfile } from '../types'
 
 interface SidebarProps {
+  // Mobile drawer control (desktop leaves these at defaults)
+  isMobile: boolean
+  navOpen: boolean
+  closeNav: () => void
   currentUser: AuthUser
   appView: AppView
   setAppView: (v: AppView) => void
@@ -83,6 +87,7 @@ interface SidebarProps {
 export function Sidebar(props: SidebarProps) {
   const { t } = useTranslation()
   const {
+    isMobile, navOpen, closeNav,
     currentUser, appView, setAppView, handleLogout, authRequired,
     stores, selectedStore, showAllTasks, selectStore, selectAllTasks,
     showCreateStore, setShowCreateStore, createStore,
@@ -127,13 +132,29 @@ export function Sidebar(props: SidebarProps) {
     window.addEventListener('mouseup', onUp)
   }
 
+  // Mobile: fixed slide-in drawer (off-canvas when closed). Desktop:
+  // resident, resizable column. Width/resize-handle apply to desktop only.
+  const rootClass = isMobile
+    ? `fixed inset-y-0 left-0 z-50 w-[86%] max-w-xs bg-white border-r border-gray-200 flex flex-col transform transition-transform duration-200 ${navOpen ? 'translate-x-0' : '-translate-x-full'}`
+    : 'relative bg-white border-r border-gray-200 flex flex-col flex-shrink-0'
   return (
-    <div className="relative bg-white border-r border-gray-200 flex flex-col flex-shrink-0" style={{ width: sidebarWidth }}>
-      <div
-        onMouseDown={startSidebarResize}
-        className="absolute top-0 right-0 w-1.5 h-full cursor-col-resize z-10 hover:bg-blue-200/60 active:bg-blue-300/60"
-        title="drag to resize"
-      />
+    <div className={rootClass} style={isMobile ? undefined : { width: sidebarWidth }}>
+      {!isMobile && (
+        <div
+          onMouseDown={startSidebarResize}
+          className="absolute top-0 right-0 w-1.5 h-full cursor-col-resize z-10 hover:bg-indigo-200/60 active:bg-indigo-300/60"
+          title="drag to resize"
+        />
+      )}
+      {isMobile && (
+        <button
+          onClick={closeNav}
+          className="absolute top-3 right-3 z-10 w-8 h-8 flex items-center justify-center rounded-lg text-gray-400 hover:bg-gray-100"
+          aria-label={t('common.close', 'Close')}
+        >
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+        </button>
+      )}
       <div className="p-4 border-b border-gray-200">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-baseline gap-1"><h1 className="text-lg font-bold leading-tight">Vibe Seller</h1>{serverVersion && <span className="text-[10px] text-gray-400" title={`Server: ${serverVersion}`}>v{serverVersion.slice(0, 14)}</span>}</div>
@@ -156,7 +177,7 @@ export function Sidebar(props: SidebarProps) {
           {(['tasks', 'workspace'] as const).map(v => (
             <button
               key={v}
-              onClick={() => { sendEvent(FrontendEvent.VIEW_CHANGED, { view: v }); setAppView(v) }}
+              onClick={() => { sendEvent(FrontendEvent.VIEW_CHANGED, { view: v }); setAppView(v); closeNav() }}
               className={`flex-1 px-2 py-1 text-xs font-medium rounded-md transition-colors ${appView === v ? 'bg-white shadow text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
             >
               {t(`navigation.${v}`)}
@@ -170,7 +191,7 @@ export function Sidebar(props: SidebarProps) {
           <div className="p-3">
             <button
               onClick={() => setShowCreateStore(true)}
-              className="w-full px-3 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700"
+              className="w-full px-3 py-2 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700"
             >
               + {t('settings.newStore')}
             </button>
@@ -204,7 +225,7 @@ export function Sidebar(props: SidebarProps) {
               <button
                 key={store.id}
                 onClick={() => { sendEvent(FrontendEvent.STORE_SWITCHED, { is_all_stores: false, backend: store.browser_backend }); selectStore(store) }}
-                className={`w-full text-left px-4 py-3 hover:bg-gray-50 border-b border-gray-100 ${selectedStore?.id === store.id && !showAllTasks ? 'bg-blue-50 border-l-4 border-l-blue-600' : ''}`}
+                className={`w-full text-left px-4 py-3 hover:bg-gray-50 border-b border-gray-100 ${selectedStore?.id === store.id && !showAllTasks ? 'bg-indigo-50 border-l-4 border-l-indigo-600' : ''}`}
               >
                 <div className="font-medium text-sm">{store.name}</div>
                 <div className="text-xs text-gray-500">{store.browser_backend}</div>
@@ -215,7 +236,7 @@ export function Sidebar(props: SidebarProps) {
             )}
             <button
               onClick={() => { sendEvent(FrontendEvent.STORE_SWITCHED, { is_all_stores: true }); selectAllTasks() }}
-              className={`w-full text-left px-4 py-3 hover:bg-gray-50 border-b border-gray-100 ${showAllTasks ? 'bg-purple-50 border-l-4 border-l-purple-600' : ''}`}
+              className={`w-full text-left px-4 py-3 hover:bg-gray-50 border-b border-gray-100 ${showAllTasks ? 'bg-indigo-50 border-l-4 border-l-indigo-600' : ''}`}
             >
               <div className="font-medium text-sm">{t('tasks.allStores')}</div>
               <div className="text-xs text-gray-500">{t('tasks.noStore')}</div>
@@ -387,7 +408,7 @@ function ZiniaoSection(props: {
             <button onClick={() => { if (confirm(t('settings.deleteAccountConfirm'))) p.deleteZiniaoAccount(p.selectedZiniaoAccountId) }} className="flex-shrink-0 w-7 h-7 flex items-center justify-center text-sm text-red-500 hover:bg-red-50 rounded border border-gray-300" title={t('common.delete')}>&times;</button>
           </>
         )}
-        <button onClick={() => { p.setEditingAccountId(''); p.setNewAccount({ name: '', company: '', username: '', password: '' }); p.setShowAddAccount(!p.showAddAccount) }} className="flex-shrink-0 w-7 h-7 flex items-center justify-center text-sm text-blue-600 hover:bg-blue-50 rounded border border-gray-300" title="Add account">+</button>
+        <button onClick={() => { p.setEditingAccountId(''); p.setNewAccount({ name: '', company: '', username: '', password: '' }); p.setShowAddAccount(!p.showAddAccount) }} className="flex-shrink-0 w-7 h-7 flex items-center justify-center text-sm text-indigo-600 hover:bg-indigo-50 rounded border border-gray-300" title="Add account">+</button>
       </div>
       {p.showAddAccount && (
         <div className="space-y-1 p-2 bg-gray-50 rounded border border-gray-200">
@@ -401,7 +422,7 @@ function ZiniaoSection(props: {
             </button>
           </div>
           <div className="flex gap-1">
-            <button onClick={p.editingAccountId ? p.updateZiniaoAccount : p.createZiniaoAccount} className="px-2 py-1 bg-blue-600 text-white rounded text-xs">{t('common.save')}</button>
+            <button onClick={p.editingAccountId ? p.updateZiniaoAccount : p.createZiniaoAccount} className="px-2 py-1 bg-indigo-600 text-white rounded text-xs">{t('common.save')}</button>
             <button onClick={() => { p.setShowAddAccount(false); p.setEditingAccountId(''); p.setShowAccountPassword(false) }} className="px-2 py-1 bg-gray-200 rounded text-xs">{t('common.cancel')}</button>
           </div>
           <p className="text-[10px] text-gray-400">Credentials stored in local SQLite, not in the cloud.</p>
@@ -420,9 +441,9 @@ function ZiniaoSection(props: {
         const editSelected = () => { const a = p.ziniaoAccounts.find(x => x.id === p.selectedZiniaoAccountId); if (a) { p.setNewAccount({ name: a.name, company: a.company, username: a.username, password: '' }); p.setEditingAccountId(a.id); p.setShowAddAccount(true) } }
 
         return p.fetchingBrowsers ? (
-          <div className="flex flex-col items-center justify-center py-6 px-4 bg-blue-50 rounded-lg border border-blue-200">
-            <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin mb-3"></div>
-            <p className="text-sm font-medium text-blue-700">{t('settings.ziniaoLoading')}</p>
+          <div className="flex flex-col items-center justify-center py-6 px-4 bg-indigo-50 rounded-lg border border-indigo-200">
+            <div className="w-6 h-6 border-2 border-indigo-500 border-t-transparent rounded-full animate-spin mb-3"></div>
+            <p className="text-sm font-medium text-indigo-700">{t('settings.ziniaoLoading')}</p>
           </div>
         ) : zs?.status === 'running_normal' && (isMac || isWsl || isWindows) ? (
           // Mac/Windows/WSL: Ziniao running in normal mode
@@ -439,7 +460,7 @@ function ZiniaoSection(props: {
           <div className="flex flex-col items-center justify-center py-6 px-4 bg-red-50 rounded-lg border border-red-200">
             {zs.message ? <p className="text-sm font-medium text-red-700 mb-3 break-all">{zs.message}</p> : <><p className="text-sm font-medium text-red-700 mb-2">{t('settings.ziniaoNoPermission')}</p><p className="text-xs text-red-600 mb-3">{t('settings.ziniaoNoPermissionHint')}</p></>}
             <div className="flex gap-2">
-              {!zs.message && <a href="https://open.ziniao.com/docSupport?docId=99" target="_blank" rel="noopener noreferrer" className="px-3 py-1 bg-blue-600 text-white rounded text-xs hover:bg-blue-700">{t('settings.ziniaoEnableWebDriver')}</a>}
+              {!zs.message && <a href="https://open.ziniao.com/docSupport?docId=99" target="_blank" rel="noopener noreferrer" className="px-3 py-1 bg-indigo-600 text-white rounded text-xs hover:bg-indigo-700">{t('settings.ziniaoEnableWebDriver')}</a>}
               <button onClick={() => p.fetchBrowserProfiles(p.selectedZiniaoAccountId)} className="px-3 py-1 bg-red-600 text-white rounded text-xs hover:bg-red-700">{t('common.refresh')}</button>
             </div>
           </div>
@@ -448,7 +469,7 @@ function ZiniaoSection(props: {
           <div className="flex flex-col items-center justify-center py-6 px-4 bg-red-50 rounded-lg border border-red-200">
             <p className="text-sm font-medium text-red-700 mb-3 break-all">{t('settings.ziniaoCredentialsError')}</p>
             <div className="flex gap-2">
-              <button onClick={editSelected} className="px-3 py-1 bg-blue-600 text-white rounded text-xs hover:bg-blue-700">{t('settings.editZiniaoAccount')}</button>
+              <button onClick={editSelected} className="px-3 py-1 bg-indigo-600 text-white rounded text-xs hover:bg-indigo-700">{t('settings.editZiniaoAccount')}</button>
               <button onClick={() => p.fetchBrowserProfiles(p.selectedZiniaoAccountId)} className="px-3 py-1 bg-red-600 text-white rounded text-xs hover:bg-red-700">{t('common.refresh')}</button>
             </div>
           </div>
@@ -458,7 +479,7 @@ function ZiniaoSection(props: {
             <p className="text-sm font-medium text-red-700 mb-2">{t('settings.ziniaoNotInstalled')}</p>
             <p className="text-xs text-red-600 mb-3">{t('settings.ziniaoNotInstalledHint')}</p>
             <div className="flex gap-2">
-              <a href="https://www.ziniao.com/download" target="_blank" rel="noopener noreferrer" className="px-3 py-1 bg-blue-600 text-white rounded text-xs hover:bg-blue-700">{t('settings.ziniaoDownloadZiniao')}</a>
+              <a href="https://www.ziniao.com/download" target="_blank" rel="noopener noreferrer" className="px-3 py-1 bg-indigo-600 text-white rounded text-xs hover:bg-indigo-700">{t('settings.ziniaoDownloadZiniao')}</a>
               <button onClick={() => p.fetchBrowserProfiles(p.selectedZiniaoAccountId)} className="px-3 py-1 bg-red-600 text-white rounded text-xs hover:bg-red-700">{t('common.refresh')}</button>
             </div>
           </div>
@@ -474,8 +495,8 @@ function ZiniaoSection(props: {
             <p className="text-sm font-medium text-red-700 mb-2">{isMac ? t('settings.ziniaoConnectErrorMac') : t('settings.ziniaoConnectError')}</p>
             {isWsl && <p className="text-xs text-red-600 mb-3">{t('settings.ziniaoLaunchHint')}</p>}
             <div className="flex gap-2">
-              {isWsl && <a href="/api/ziniao/launcher" download className="px-3 py-1 bg-blue-600 text-white rounded text-xs hover:bg-blue-700">{t('settings.ziniaoDownloadLauncher')}</a>}
-              <button onClick={editSelected} className="px-3 py-1 bg-blue-600 text-white rounded text-xs hover:bg-blue-700">{t('settings.editZiniaoAccount')}</button>
+              {isWsl && <a href="/api/ziniao/launcher" download className="px-3 py-1 bg-indigo-600 text-white rounded text-xs hover:bg-indigo-700">{t('settings.ziniaoDownloadLauncher')}</a>}
+              <button onClick={editSelected} className="px-3 py-1 bg-indigo-600 text-white rounded text-xs hover:bg-indigo-700">{t('settings.editZiniaoAccount')}</button>
               <button onClick={() => p.fetchBrowserProfiles(p.selectedZiniaoAccountId)} className="px-3 py-1 bg-red-600 text-white rounded text-xs hover:bg-red-700">{t('common.refresh')}</button>
             </div>
           </div>
@@ -603,11 +624,11 @@ function WorkspaceSidebar(props: {
           <div className="flex items-center gap-0">
             <button
               onClick={() => setSkillsTab('builtin')}
-              className={`px-2 py-0.5 text-xs font-semibold uppercase tracking-wider border-b-2 transition-colors ${skillsTab === 'builtin' ? 'text-blue-600 border-blue-600' : 'text-gray-400 border-transparent hover:text-gray-600'}`}
+              className={`px-2 py-0.5 text-xs font-semibold uppercase tracking-wider border-b-2 transition-colors ${skillsTab === 'builtin' ? 'text-indigo-600 border-indigo-600' : 'text-gray-400 border-transparent hover:text-gray-600'}`}
             >{t('workspace.builtinTab')}</button>
             <button
               onClick={() => setSkillsTab('myskills')}
-              className={`px-2 py-0.5 text-xs font-semibold uppercase tracking-wider border-b-2 transition-colors ${skillsTab === 'myskills' ? 'text-blue-600 border-blue-600' : 'text-gray-400 border-transparent hover:text-gray-600'}`}
+              className={`px-2 py-0.5 text-xs font-semibold uppercase tracking-wider border-b-2 transition-colors ${skillsTab === 'myskills' ? 'text-indigo-600 border-indigo-600' : 'text-gray-400 border-transparent hover:text-gray-600'}`}
             >{t('workspace.mySkillsTab')}</button>
           </div>
           <div className="flex items-center gap-1">
@@ -615,14 +636,14 @@ function WorkspaceSidebar(props: {
               <button
                 onClick={p.syncBuiltinSkills}
                 disabled={p.wsSkillsSyncing}
-                className={`text-gray-400 hover:text-blue-600 text-[10px] leading-none ${p.wsSkillsSyncing ? 'animate-spin' : ''}`}
+                className={`text-gray-400 hover:text-indigo-600 text-[10px] leading-none ${p.wsSkillsSyncing ? 'animate-spin' : ''}`}
                 title={t('workspace.syncSkills')}
               >&#8635;</button>
             )}
             {skillsTab === 'myskills' && (
               <button
                 onClick={() => p.setWsNewFileSection(p.wsNewFileSection === '_skill_create' ? null : '_skill_create')}
-                className="text-gray-400 hover:text-blue-600 text-sm leading-none"
+                className="text-gray-400 hover:text-indigo-600 text-sm leading-none"
                 title={t('workspace.createSkill')}
               >+</button>
             )}
@@ -637,7 +658,7 @@ function WorkspaceSidebar(props: {
               <SkillItem
                 key={skill.slug + skill.source}
                 skill={skill}
-                badge={<span className="text-[9px] bg-blue-100 text-blue-700 px-1.5 py-0.5 rounded-full flex-shrink-0">{t('workspace.builtinBadge')}</span>}
+                badge={<span className="text-[9px] bg-indigo-100 text-indigo-700 px-1.5 py-0.5 rounded-full flex-shrink-0">{t('workspace.builtinBadge')}</span>}
                 expanded={p.wsExpandedSkills.has(skill.slug)}
                 toggleExpanded={() => p.toggleSkillExpanded(skill.slug)}
                 wsSelectedFile={p.wsSelectedFile}
@@ -700,7 +721,7 @@ function WorkspaceSidebar(props: {
               <SkillItem
                 key={skill.slug + skill.source}
                 skill={skill}
-                badge={<span className="text-[9px] bg-purple-100 text-purple-700 px-1.5 py-0.5 rounded-full flex-shrink-0">{getOriginDomain(skill.origin_url)}</span>}
+                badge={<span className="text-[9px] bg-indigo-100 text-indigo-700 px-1.5 py-0.5 rounded-full flex-shrink-0">{getOriginDomain(skill.origin_url)}</span>}
                 expanded={p.wsExpandedSkills.has(skill.slug)}
                 toggleExpanded={() => p.toggleSkillExpanded(skill.slug)}
                 wsSelectedFile={p.wsSelectedFile}
@@ -723,7 +744,7 @@ function WorkspaceSidebar(props: {
           <button
             onClick={p.syncProjectKnowledge}
             disabled={p.wsSyncing}
-            className={`text-gray-400 hover:text-blue-600 text-[10px] leading-none ${p.wsSyncing ? 'animate-spin' : ''}`}
+            className={`text-gray-400 hover:text-indigo-600 text-[10px] leading-none ${p.wsSyncing ? 'animate-spin' : ''}`}
             title={p.wsSyncing ? t('workspace.syncing') : t('workspace.syncKnowledge')}
           >&#8635;</button>
         </div>
@@ -754,7 +775,7 @@ function WorkspaceSidebar(props: {
           <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">{t('workspace.localKnowledge')}</p>
           <button
             onClick={() => p.setWsNewFileSection(p.wsNewFileSection === 'knowledge' ? null : 'knowledge')}
-            className="text-gray-400 hover:text-blue-600 text-sm leading-none"
+            className="text-gray-400 hover:text-indigo-600 text-sm leading-none"
             title={t('workspace.addKnowledgeFile')}
           >+</button>
         </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LanguageSwitcher, WsFileItem } from './ui'
+import { SkillItem } from './SkillItem'
 import { StoreFilesSection } from './WorkspaceStoreSections'
 import { api } from '../api'
 import { sendEvent } from '../lib/telemetry'
 import { FrontendEvent } from '../lib/telemetryEvents'
-import type { Store, AuthUser, AppView, ServerPlatform, WsStructured, WsSkill, ZiniaoAccount, ZiniaoBrowserProfile } from '../types'
+import type { Store, AuthUser, AppView, ServerPlatform, WsStructured, ZiniaoAccount, ZiniaoBrowserProfile } from '../types'
 
 interface SidebarProps {
   // Mobile drawer control (desktop leaves these at defaults)
@@ -257,10 +258,10 @@ export function Sidebar(props: SidebarProps) {
           syncBuiltinSkills={syncBuiltinSkills} wsSkillsSyncing={wsSkillsSyncing}
         />
       ) : (
-        <div className="flex-1 overflow-y-auto p-4">
-          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">{t('settings.title')}</p>
-          <button onClick={() => setAppView('settings')} className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded">{t('settings.userManagement')}</button>
-        </div>
+        // Settings navigates via the top tabs in the main panel; the
+        // sidebar body stays empty here (the old lone "user management"
+        // link was a vestige of the pre-tab layout).
+        <div className="flex-1 overflow-y-auto" />
       )}
     </div>
   )
@@ -532,57 +533,6 @@ function ZiniaoSection(props: {
 }
 
 // ─── Reusable skill item renderer ─────────────────────
-function SkillItem(props: {
-  skill: WsSkill
-  badge: React.ReactNode
-  expanded: boolean
-  toggleExpanded: () => void
-  wsSelectedFile: string | null
-  openWsFile: (path: string) => void
-  deleteWsFile: (path: string) => void
-  onDelete?: (slug: string) => void
-}) {
-  const { t } = useTranslation()
-  const { skill, badge, expanded, toggleExpanded, wsSelectedFile, openWsFile, deleteWsFile, onDelete } = props
-  return (
-    <div className="border-b border-gray-50">
-      <div className="flex items-center px-3">
-        <button
-          onClick={toggleExpanded}
-          className="flex-1 text-left py-1.5 flex items-center gap-2 hover:bg-gray-50 text-sm"
-        >
-          <span className={`text-[10px] text-gray-400 transition-transform ${expanded ? 'rotate-90' : ''}`}>&#9654;</span>
-          <span className="font-medium text-gray-700 text-xs">{skill.slug}</span>
-          {badge}
-          <span className="text-[10px] text-gray-400 ml-auto">{skill.file_count}</span>
-        </button>
-        {onDelete && (
-          <button
-            type="button"
-            onClick={() => onDelete(skill.slug)}
-            className="text-gray-300 hover:text-red-500 cursor-pointer ml-1 text-xs"
-            title={t('workspace.uninstallSkill')}
-            aria-label={t('workspace.uninstallSkill')}
-          >&times;</button>
-        )}
-      </div>
-      {skill.description && !expanded && (
-        <p className="px-3 pb-1 ml-5 text-[10px] text-gray-400 leading-tight truncate">{skill.description}</p>
-      )}
-      {expanded && (
-        <div className="ml-3">
-          {skill.files.map(f => (
-            <WsFileItem key={f.path} file={f} selected={wsSelectedFile === f.path} onSelect={openWsFile} onDelete={deleteWsFile} />
-          ))}
-          {skill.files.length === 0 && (
-            <div className="px-4 py-1 text-[10px] text-gray-400 italic">{t('common.noData')}</div>
-          )}
-        </div>
-      )}
-    </div>
-  )
-}
-
 // ─── Workspace sidebar tree ──────────────────────────
 function WorkspaceSidebar(props: {
   wsStructured: WsStructured | null; wsSelectedFile: string | null

--- a/frontend/src/components/SkillItem.tsx
+++ b/frontend/src/components/SkillItem.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next'
+import { WsFileItem } from './ui'
+import type { WsSkill } from '../types'
+
+/** One skill row in the workspace sidebar tree (expandable file list). */
+export function SkillItem(props: {
+  skill: WsSkill
+  badge: React.ReactNode
+  expanded: boolean
+  toggleExpanded: () => void
+  wsSelectedFile: string | null
+  openWsFile: (path: string) => void
+  deleteWsFile: (path: string) => void
+  onDelete?: (slug: string) => void
+}) {
+  const { t } = useTranslation()
+  const { skill, badge, expanded, toggleExpanded, wsSelectedFile, openWsFile, deleteWsFile, onDelete } = props
+  return (
+    <div className="border-b border-gray-50">
+      <div className="flex items-center px-3">
+        <button
+          onClick={toggleExpanded}
+          className="flex-1 text-left py-1.5 flex items-center gap-2 hover:bg-gray-50 text-sm"
+        >
+          <span className={`text-[10px] text-gray-400 transition-transform ${expanded ? 'rotate-90' : ''}`}>&#9654;</span>
+          <span className="font-medium text-gray-700 text-xs">{skill.slug}</span>
+          {badge}
+          <span className="text-[10px] text-gray-400 ml-auto">{skill.file_count}</span>
+        </button>
+        {onDelete && (
+          <button
+            type="button"
+            onClick={() => onDelete(skill.slug)}
+            className="text-gray-300 hover:text-red-500 cursor-pointer ml-1 text-xs"
+            title={t('workspace.uninstallSkill')}
+            aria-label={t('workspace.uninstallSkill')}
+          >&times;</button>
+        )}
+      </div>
+      {skill.description && !expanded && (
+        <p className="px-3 pb-1 ml-5 text-[10px] text-gray-400 leading-tight truncate">{skill.description}</p>
+      )}
+      {expanded && (
+        <div className="ml-3">
+          {skill.files.map(f => (
+            <WsFileItem key={f.path} file={f} selected={wsSelectedFile === f.path} onSelect={openWsFile} onDelete={deleteWsFile} />
+          ))}
+          {skill.files.length === 0 && (
+            <div className="px-4 py-1 text-[10px] text-gray-400 italic">{t('common.noData')}</div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/StoreForm.tsx
+++ b/frontend/src/components/StoreForm.tsx
@@ -153,7 +153,7 @@ export function StoreForm({ mode, initialValues, onSubmit, onCancel, ...ziniaoPr
         <button
           onClick={handleSubmit}
           disabled={nameEmpty}
-          className={`px-4 py-2 rounded-lg text-sm font-medium ${nameEmpty ? 'bg-gray-300 text-gray-500 cursor-not-allowed' : 'bg-blue-600 text-white hover:bg-blue-700'}`}
+          className={`px-4 py-2 rounded-lg text-sm font-medium ${nameEmpty ? 'bg-gray-300 text-gray-500 cursor-not-allowed' : 'bg-indigo-600 text-white hover:bg-indigo-700'}`}
         >
           {mode === 'create' ? t('common.create') : t('common.save')}
         </button>

--- a/frontend/src/components/SubtaskList.tsx
+++ b/frontend/src/components/SubtaskList.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { api } from '../api'
+import { StatusBadge } from './ui'
+import type { Task, Store } from '../types'
+
+/** Child tasks of a parent, polled every 10s (no second SSE stream). */
+export function SubtaskList({ parentTaskId, onSelect, stores }: {
+  parentTaskId: string
+  onSelect: (t: Task) => void
+  stores: Store[]
+}) {
+  const { t } = useTranslation()
+  const [children, setChildren] = useState<Task[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    const fetchChildren = () => {
+      api.get(`/api/tasks?parent_task_id=${encodeURIComponent(parentTaskId)}`).then((data: Task[]) => {
+        if (!cancelled) setChildren(data)
+      }).catch(() => {})
+    }
+    fetchChildren()
+    // Poll every 10s for status updates instead of opening a second SSE
+    const interval = setInterval(fetchChildren, 10000)
+    return () => { cancelled = true; clearInterval(interval) }
+  }, [parentTaskId])
+
+  if (children.length === 0) return null
+
+  const storeName = (sid: string | null) => {
+    if (!sid) return ''
+    return stores.find(s => s.id === sid)?.name || sid.slice(0, 8)
+  }
+
+  return (
+    <div className="mt-2">
+      <div className="text-xs font-medium text-gray-500 mb-1">{t('tasks.subtasks', 'Subtasks')} ({children.length})</div>
+      <div className="space-y-1">
+        {children.map(child => (
+          <button
+            key={child.id}
+            onClick={() => onSelect(child)}
+            className="w-full text-left px-2 py-1.5 text-xs rounded border border-gray-200 hover:bg-gray-50 flex items-center gap-2"
+          >
+            <StatusBadge status={child.status} />
+            <span className="truncate flex-1">{child.title}</span>
+            {child.store_id && <span className="text-gray-400 text-[10px]">{storeName(child.store_id)}</span>}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/UpdateAvailableModal.tsx
+++ b/frontend/src/components/UpdateAvailableModal.tsx
@@ -67,7 +67,7 @@ export function UpdateAvailableModal({ result, onClose }: Props) {
                 href={result.download_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="mt-2 inline-block rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
+                className="mt-2 inline-block rounded bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700"
               >
                 {t('updateCheck.downloadButton')}
               </a>

--- a/frontend/src/components/WeComBotSection.tsx
+++ b/frontend/src/components/WeComBotSection.tsx
@@ -125,7 +125,7 @@ export function WeComBotSection() {
           <button
             data-testid="wecom-bot-add"
             onClick={startCreate}
-            className="px-3 py-1.5 text-sm rounded font-medium bg-blue-600 text-white hover:bg-blue-700"
+            className="px-3 py-1.5 text-sm rounded font-medium bg-indigo-600 text-white hover:bg-indigo-700"
           >
             {t('integrations.wecom_bot.add')}
           </button>
@@ -164,7 +164,7 @@ export function WeComBotSection() {
               data-testid="wecom-bot-save"
               onClick={save}
               disabled={saving}
-              className="px-3 py-1.5 text-sm rounded font-medium bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-40"
+              className="px-3 py-1.5 text-sm rounded font-medium bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-40"
             >
               {saving ? '…' : t('integrations.wecom_bot.save')}
             </button>

--- a/frontend/src/components/WorkspaceStoreSections.tsx
+++ b/frontend/src/components/WorkspaceStoreSections.tsx
@@ -91,7 +91,7 @@ export function StoreFilesSection(p: StoreSectionsProps) {
           >
             <span className={`text-[10px] text-gray-400 transition-transform ${p.wsExpandedStores.has(store.slug) ? 'rotate-90' : ''}`}>&#9654;</span>
             <span className="font-medium text-gray-700 text-xs">{store.slug}</span>
-            {store.has_content && <span className="w-1.5 h-1.5 rounded-full bg-blue-400 flex-shrink-0" title={t('workspace.hasContent')} />}
+            {store.has_content && <span className="w-1.5 h-1.5 rounded-full bg-indigo-400 flex-shrink-0" title={t('workspace.hasContent')} />}
             <span className="text-[10px] text-gray-400 ml-auto">{store.file_count + store.data_file_count}</span>
           </button>
           {p.wsExpandedStores.has(store.slug) && (
@@ -99,7 +99,7 @@ export function StoreFilesSection(p: StoreSectionsProps) {
               <div className="flex items-center px-3 py-0.5">
                 <button
                   onClick={() => p.setWsNewFileSection(p.wsNewFileSection === store.path ? null : store.path)}
-                  className="text-[10px] text-gray-400 hover:text-blue-600"
+                  className="text-[10px] text-gray-400 hover:text-indigo-600"
                 >+ {t('workspace.newFile')}</button>
               </div>
               {p.wsNewFileSection === store.path && (

--- a/frontend/src/components/conversation/ConversationStream.tsx
+++ b/frontend/src/components/conversation/ConversationStream.tsx
@@ -179,13 +179,13 @@ function FileTreeItem({ node, taskId, depth }: { node: FileTreeNode; taskId: str
     <a
       href={`/api/tasks/${taskId}/files/${encodedPath}`}
       download={node.name}
-      className="flex items-center gap-1.5 px-2 py-1 text-xs hover:bg-blue-50 rounded transition-colors"
+      className="flex items-center gap-1.5 px-2 py-1 text-xs hover:bg-indigo-50 rounded transition-colors"
       style={{ paddingLeft: `${(depth) * 16 + 8 + 12 + 6}px` }}
     >
       <span className="text-gray-400 text-[10px]">
         {node.type?.includes('pdf') ? '\uD83D\uDCC4' : '\uD83D\uDCCE'}
       </span>
-      <span className="text-blue-600 font-medium truncate">{node.name}</span>
+      <span className="text-indigo-600 font-medium truncate">{node.name}</span>
       <span className="text-gray-400 ml-auto whitespace-nowrap">
         {node.size != null ? formatSize(node.size) : ''}
       </span>
@@ -219,7 +219,7 @@ function TaskFiles({ taskId }: { taskId: string }) {
         <a
           href={`/api/tasks/${taskId}/files-zip`}
           download
-          className="text-[10px] text-blue-600 hover:underline cursor-pointer"
+          className="text-[10px] text-indigo-600 hover:underline cursor-pointer"
         >
           {t('tasks.downloadZip', 'Download All (ZIP)')}
         </a>
@@ -295,13 +295,13 @@ export function ConversationStream({
       {/* Review plan toggle in stream when applicable */}
 
       {items.length === 0 && isActive && (
-        <div className="flex items-center gap-3 px-4 py-4 bg-blue-50 rounded-lg border border-blue-200">
-          <div className="w-5 h-5 rounded-full border-2 border-blue-500 border-t-transparent animate-spin shrink-0" />
+        <div className="flex items-center gap-3 px-4 py-4 bg-indigo-50 rounded-lg border border-indigo-200">
+          <div className="w-5 h-5 rounded-full border-2 border-indigo-500 border-t-transparent animate-spin shrink-0" />
           <div>
-            <div className="text-sm font-medium text-blue-700">
+            <div className="text-sm font-medium text-indigo-700">
               {task.status === 'designing' ? t('tasks.designing') : t('tasks.running')}
             </div>
-            <div className="text-xs text-blue-500">{t('tasks.agentStarting')}</div>
+            <div className="text-xs text-indigo-500">{t('tasks.agentStarting')}</div>
           </div>
         </div>
       )}
@@ -477,7 +477,7 @@ export function ConversationStream({
               <div className="flex items-center gap-2 mb-3">
                 <span className="text-amber-600 text-lg">&#9203;</span>
                 <h3 className="text-sm font-semibold text-amber-800">{t('status.waiting')}</h3>
-                <span className={`px-1.5 py-0.5 text-[10px] rounded-full font-medium ${strategy === 'email' ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600'}`}>
+                <span className={`px-1.5 py-0.5 text-[10px] rounded-full font-medium ${strategy === 'email' ? 'bg-indigo-100 text-indigo-700' : 'bg-gray-100 text-gray-600'}`}>
                   {strategy === 'email' ? t('waiting.autoEmail') : t('waiting.manual')}
                 </span>
               </div>

--- a/frontend/src/components/conversation/PlanCard.tsx
+++ b/frontend/src/components/conversation/PlanCard.tsx
@@ -169,18 +169,18 @@ export function PlanCard({ plan, allVersions, todoItems, taskStatus, planMode, s
                 const isActive = ti.status === 'in_progress'
                 return (
                   <div key={idx} className={`flex gap-3 p-2 rounded-lg transition-all duration-300 ${
-                    isActive ? 'bg-blue-50 border border-blue-200 shadow-sm' :
+                    isActive ? 'bg-indigo-50 border border-indigo-200 shadow-sm' :
                     isDone ? 'bg-green-50/50 border border-green-100' :
                     'bg-gray-50 border border-transparent'
                   }`}>
                     <div className={`flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${
                       isDone ? 'bg-green-500 text-white' :
-                      isActive ? 'bg-blue-500 text-white animate-pulse' :
+                      isActive ? 'bg-indigo-500 text-white animate-pulse' :
                       'bg-gray-200 text-gray-500'
                     }`}>
                       {isDone ? '\u2713' : idx + 1}
                     </div>
-                    <div className={`flex-1 text-sm ${isDone ? 'text-gray-400 line-through' : isActive ? 'text-blue-800 font-medium' : 'text-gray-700'}`}>
+                    <div className={`flex-1 text-sm ${isDone ? 'text-gray-400 line-through' : isActive ? 'text-indigo-800 font-medium' : 'text-gray-700'}`}>
                       {ti.content}
                     </div>
                   </div>

--- a/frontend/src/components/conversation/ThinkingBlock.tsx
+++ b/frontend/src/components/conversation/ThinkingBlock.tsx
@@ -16,7 +16,7 @@ export function ThinkingBlock({ content, isStreaming }: ThinkingBlockProps) {
     const preview = lines.slice(-3).join('\n')
     return (
       <div className="py-0.5">
-        <div className="flex items-center gap-1.5 text-[13px] text-purple-500">
+        <div className="flex items-center gap-1.5 text-[13px] text-indigo-500">
           <span className="animate-pulse">💭</span>
           <span>{t('tasks.thinking', 'Thinking...')}</span>
         </div>
@@ -33,7 +33,7 @@ export function ThinkingBlock({ content, isStreaming }: ThinkingBlockProps) {
   return (
     <div className="py-0.5">
       <button
-        className="flex items-center gap-1.5 text-[13px] text-gray-400 hover:text-purple-500"
+        className="flex items-center gap-1.5 text-[13px] text-gray-400 hover:text-indigo-500"
         onClick={() => setExpanded(e => !e)}
       >
         <span>💭</span>

--- a/frontend/src/components/settings/AccountPanel.tsx
+++ b/frontend/src/components/settings/AccountPanel.tsx
@@ -134,7 +134,7 @@ export function AccountPanel({
             </div>
             <button
               onClick={() => handleToggleAuth(!authRequired)}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${authRequired ? 'bg-blue-600' : 'bg-gray-300'}`}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${authRequired ? 'bg-indigo-600' : 'bg-gray-300'}`}
             >
               <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${authRequired ? 'translate-x-6' : 'translate-x-1'}`} />
             </button>
@@ -156,7 +156,7 @@ export function AccountPanel({
             <input value={profileEmail} onChange={e => setProfileEmail(e.target.value)} type="email" className="w-full px-3 py-2 border border-gray-300 rounded text-sm" placeholder={t('auth.emailPlaceholder')} />
           </div>
           {profileMsg && <p className={`text-xs ${profileMsgIsError ? 'text-red-600' : 'text-green-600'}`}>{profileMsg}</p>}
-          <button onClick={handleUpdateProfile} className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700">{t('common.save')}</button>
+          <button onClick={handleUpdateProfile} className="px-3 py-1.5 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700">{t('common.save')}</button>
         </div>
       </div>
 
@@ -170,7 +170,7 @@ export function AccountPanel({
           <input value={newPassword} onChange={e => setNewPassword(e.target.value)} placeholder={t('settings.newPassword')} type="password" className="w-full px-3 py-2 border border-gray-300 rounded text-sm" />
           <input value={confirmPassword} onChange={e => setConfirmPassword(e.target.value)} placeholder={t('settings.confirmPassword')} type="password" className="w-full px-3 py-2 border border-gray-300 rounded text-sm" />
           {pwMsg && <p className={`text-xs ${pwMsg === t('settings.passwordChanged') ? 'text-green-600' : 'text-red-600'}`}>{pwMsg}</p>}
-          <button onClick={handleChangePassword} className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700">{t('settings.changePassword')}</button>
+          <button onClick={handleChangePassword} className="px-3 py-1.5 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700">{t('settings.changePassword')}</button>
         </div>
       </div>
 
@@ -179,7 +179,7 @@ export function AccountPanel({
         <div className="bg-white rounded-lg border border-gray-200 p-4">
           <div className="flex items-center justify-between mb-4">
             <h3 className="font-semibold text-sm">{t('settings.users')}</h3>
-            <button onClick={() => setShowAddUser(true)} className="px-3 py-1.5 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700">+ {t('settings.newUser')}</button>
+            <button onClick={() => setShowAddUser(true)} className="px-3 py-1.5 bg-indigo-600 text-white rounded-lg text-sm hover:bg-indigo-700">+ {t('settings.newUser')}</button>
           </div>
           {showAddUser && (
             <div className="mb-4 p-3 bg-gray-50 rounded-lg border border-gray-200 space-y-2">
@@ -209,10 +209,10 @@ export function AccountPanel({
                 <React.Fragment key={u.id}>
                   <tr className="border-b border-gray-100">
                     <td className="py-2">{u.username}</td>
-                    <td className="py-2"><span className={`px-2 py-0.5 rounded-full text-xs ${u.role === 'admin' ? 'bg-purple-100 text-purple-700' : u.role === 'ai_bot' ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-700'}`}>{u.role}</span></td>
+                    <td className="py-2"><span className={`px-2 py-0.5 rounded-full text-xs ${u.role === 'admin' ? 'bg-indigo-100 text-indigo-700' : u.role === 'ai_bot' ? 'bg-indigo-100 text-indigo-700' : 'bg-gray-100 text-gray-700'}`}>{u.role}</span></td>
                     <td className="py-2 text-right space-x-2">
                       {u.role !== 'ai_bot' && u.id !== currentUser.id && (<>
-                        <button onClick={() => editingUserId === u.id ? setEditingUserId(null) : startEditUser(u)} className="text-xs text-blue-600 hover:text-blue-800">
+                        <button onClick={() => editingUserId === u.id ? setEditingUserId(null) : startEditUser(u)} className="text-xs text-indigo-600 hover:text-indigo-800">
                           {editingUserId === u.id ? t('common.cancel') : t('common.edit')}
                         </button>
                         <button onClick={() => deleteUser(u.id, u.username)} className="text-xs text-gray-500 hover:text-red-600">
@@ -236,7 +236,7 @@ export function AccountPanel({
                               <option value="admin">{t('settings.admin')}</option>
                             </select>
                           </div>
-                          <button onClick={handleSaveUser} className="px-3 py-1 bg-blue-600 text-white rounded text-sm hover:bg-blue-700">{t('common.save')}</button>
+                          <button onClick={handleSaveUser} className="px-3 py-1 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700">{t('common.save')}</button>
                         </div>
                       </td>
                     </tr>

--- a/frontend/src/components/settings/Dida365Panel.tsx
+++ b/frontend/src/components/settings/Dida365Panel.tsx
@@ -195,7 +195,7 @@ export function Dida365Panel() {
             <button
               onClick={handleSave}
               disabled={saving}
-              className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50"
+              className="px-3 py-1.5 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700 disabled:opacity-50"
             >
               {saving ? t('common.loading') : t('settings.dida365SaveConfig')}
             </button>
@@ -212,7 +212,7 @@ export function Dida365Panel() {
         <div className="space-y-4">
           {/* Step 1: Choose service */}
           <div className="flex items-start gap-3">
-            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-blue-100 text-blue-700 text-xs font-bold flex items-center justify-center mt-0.5">1</span>
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-indigo-100 text-indigo-700 text-xs font-bold flex items-center justify-center mt-0.5">1</span>
             <div className="flex-1">
               <p className="text-sm font-medium text-gray-700 mb-1">{t('settings.dida365GuideStep1')}</p>
               <div className="flex gap-4">
@@ -242,12 +242,12 @@ export function Dida365Panel() {
 
           {/* Step 2: Register app on developer portal */}
           <div className="flex items-start gap-3">
-            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-blue-100 text-blue-700 text-xs font-bold flex items-center justify-center mt-0.5">2</span>
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-indigo-100 text-indigo-700 text-xs font-bold flex items-center justify-center mt-0.5">2</span>
             <div className="flex-1">
               <p className="text-sm font-medium text-gray-700 mb-1">{t('settings.dida365GuideStep2')}</p>
               <p className="text-xs text-gray-500 mb-2">{t('settings.dida365GuideStep2Hint')}</p>
               <a href={devPortalUrl} target="_blank" rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 px-3 py-1.5 bg-gray-100 hover:bg-gray-200 text-sm text-blue-600 rounded border border-gray-200 transition-colors">
+                className="inline-flex items-center gap-1 px-3 py-1.5 bg-gray-100 hover:bg-gray-200 text-sm text-indigo-600 rounded border border-gray-200 transition-colors">
                 {serviceType === 'dida365' ? 'developer.dida365.com' : 'developer.ticktick.com'} &rarr;
               </a>
             </div>
@@ -255,7 +255,7 @@ export function Dida365Panel() {
 
           {/* Step 3: Set callback URL */}
           <div className="flex items-start gap-3">
-            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-blue-100 text-blue-700 text-xs font-bold flex items-center justify-center mt-0.5">3</span>
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-indigo-100 text-indigo-700 text-xs font-bold flex items-center justify-center mt-0.5">3</span>
             <div className="flex-1">
               <p className="text-sm font-medium text-gray-700 mb-1">{t('settings.dida365GuideStep3')}</p>
               <p className="text-xs text-gray-500 mb-1">{t('settings.dida365GuideStep3Hint')}</p>
@@ -274,7 +274,7 @@ export function Dida365Panel() {
 
           {/* Step 4: Paste credentials */}
           <div className="flex items-start gap-3">
-            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-blue-100 text-blue-700 text-xs font-bold flex items-center justify-center mt-0.5">4</span>
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-indigo-100 text-indigo-700 text-xs font-bold flex items-center justify-center mt-0.5">4</span>
             <div className="flex-1">
               <p className="text-sm font-medium text-gray-700 mb-2">{t('settings.dida365GuideStep4')}</p>
               <div className="space-y-2">
@@ -303,17 +303,17 @@ export function Dida365Panel() {
 
           {/* Step 5: Connect */}
           <div className="flex items-start gap-3">
-            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-blue-100 text-blue-700 text-xs font-bold flex items-center justify-center mt-0.5">5</span>
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-indigo-100 text-indigo-700 text-xs font-bold flex items-center justify-center mt-0.5">5</span>
             <div className="flex-1">
               <p className="text-sm font-medium text-gray-700 mb-1">{t('settings.dida365GuideStep5')}</p>
               <p className="text-xs text-gray-400 mb-2">{t('settings.dida365PopupHint')}</p>
               {installing ? (
-                <div className="flex items-center gap-2 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-                  <svg className="animate-spin h-4 w-4 text-blue-600" viewBox="0 0 24 24">
+                <div className="flex items-center gap-2 p-3 bg-indigo-50 border border-indigo-200 rounded-lg">
+                  <svg className="animate-spin h-4 w-4 text-indigo-600" viewBox="0 0 24 24">
                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                   </svg>
-                  <span className="text-sm text-blue-700">{t('settings.dida365Installing')}</span>
+                  <span className="text-sm text-indigo-700">{t('settings.dida365Installing')}</span>
                 </div>
               ) : polling ? (
                 <div className="space-y-2">
@@ -342,7 +342,7 @@ export function Dida365Panel() {
                 <button
                   onClick={handleConnect}
                   disabled={connecting || !clientId || !clientSecret}
-                  className="px-4 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50"
+                  className="px-4 py-2 bg-indigo-600 text-white rounded text-sm hover:bg-indigo-700 disabled:opacity-50"
                 >
                   {t('settings.dida365Connect')}
                 </button>

--- a/frontend/src/components/settings/EmailAccountsPanel.tsx
+++ b/frontend/src/components/settings/EmailAccountsPanel.tsx
@@ -140,7 +140,7 @@ export function EmailAccountsPanel({ emailAccounts, loadEmailAccounts, stores }:
         <h3 className="font-semibold">{t('email.accounts')}</h3>
         <button
           onClick={() => setShowAddEmail(!showAddEmail)}
-          className="px-3 py-1.5 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700"
+          className="px-3 py-1.5 bg-indigo-600 text-white rounded-lg text-sm hover:bg-indigo-700"
         >
           + {t('email.addAccount')}
         </button>
@@ -278,11 +278,11 @@ export function EmailAccountsPanel({ emailAccounts, loadEmailAccounts, stores }:
                   {links.length > 0 && (
                     <div className="flex flex-wrap gap-1.5 mb-2">
                       {links.map(link => (
-                        <span key={link.link_id} className="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-50 text-blue-700 rounded-full text-xs">
+                        <span key={link.link_id} className="inline-flex items-center gap-1 px-2 py-0.5 bg-indigo-50 text-indigo-700 rounded-full text-xs">
                           {link.store_name}
                           <button
                             onClick={() => unlinkStore(link.store_id, link.link_id)}
-                            className="text-blue-400 hover:text-red-500 ml-0.5"
+                            className="text-indigo-400 hover:text-red-500 ml-0.5"
                             title={t('email.disconnect')}
                           >
                             &times;
@@ -306,7 +306,7 @@ export function EmailAccountsPanel({ emailAccounts, loadEmailAccounts, stores }:
                       <button
                         onClick={() => linkStore(acct.id, linkingStore[acct.id] || '')}
                         disabled={!linkingStore[acct.id]}
-                        className="text-xs px-2 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                        className="text-xs px-2 py-1 bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:opacity-50"
                       >
                         {t('email.linkToStore')}
                       </button>

--- a/frontend/src/components/settings/GeneralPanel.tsx
+++ b/frontend/src/components/settings/GeneralPanel.tsx
@@ -267,7 +267,7 @@ export function GeneralPanel({ currentUser, setCurrentUser }: GeneralPanelProps)
               checked={browserHeadless}
               onChange={e => saveBrowserHeadless(e.target.checked)}
             />
-            <span className="w-10 h-5 bg-gray-300 rounded-full relative transition-colors peer-checked:bg-blue-600">
+            <span className="w-10 h-5 bg-gray-300 rounded-full relative transition-colors peer-checked:bg-indigo-600">
               <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${browserHeadless ? 'translate-x-5' : ''}`}></span>
             </span>
           </label>
@@ -290,7 +290,7 @@ export function GeneralPanel({ currentUser, setCurrentUser }: GeneralPanelProps)
               onChange={e => saveSkillsAutoSync(e.target.checked)}
               aria-label={t('settings.skillsAutoSyncTitle')}
             />
-            <span className="w-10 h-5 bg-gray-300 rounded-full relative transition-colors peer-checked:bg-blue-600">
+            <span className="w-10 h-5 bg-gray-300 rounded-full relative transition-colors peer-checked:bg-indigo-600">
               <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${skillsAutoSync ? 'translate-x-5' : ''}`}></span>
             </span>
           </label>
@@ -312,7 +312,7 @@ export function GeneralPanel({ currentUser, setCurrentUser }: GeneralPanelProps)
               checked={telemetryEnabled}
               onChange={e => saveTelemetry(e.target.checked)}
             />
-            <span className="w-10 h-5 bg-gray-300 rounded-full relative transition-colors peer-checked:bg-blue-600">
+            <span className="w-10 h-5 bg-gray-300 rounded-full relative transition-colors peer-checked:bg-indigo-600">
               <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${telemetryEnabled ? 'translate-x-5' : ''}`}></span>
             </span>
           </label>

--- a/frontend/src/components/settings/IntegrationsPanel.tsx
+++ b/frontend/src/components/settings/IntegrationsPanel.tsx
@@ -97,7 +97,7 @@ export function IntegrationsPanel() {
                 className={`px-3 py-1.5 text-sm rounded font-medium transition-colors ${
                   status.enabled
                     ? 'bg-gray-200 text-gray-800 hover:bg-gray-300'
-                    : 'bg-blue-600 text-white hover:bg-blue-700'
+                    : 'bg-indigo-600 text-white hover:bg-indigo-700'
                 } disabled:opacity-40 disabled:cursor-not-allowed`}
               >
                 {busy
@@ -154,7 +154,7 @@ export function IntegrationsPanel() {
                   href="https://github.com/googleworkspace/cli/releases"
                   target="_blank"
                   rel="noreferrer"
-                  className="text-blue-600 hover:underline"
+                  className="text-indigo-600 hover:underline"
                 >
                   github.com/googleworkspace/cli
                 </a>
@@ -166,7 +166,7 @@ export function IntegrationsPanel() {
               </p>
             )}
             {busy && !status.enabled && (
-              <p className="text-xs text-blue-600">
+              <p className="text-xs text-indigo-600">
                 {t('integrations.gws.installing')}
               </p>
             )}

--- a/frontend/src/components/settings/StoresPanel.tsx
+++ b/frontend/src/components/settings/StoresPanel.tsx
@@ -107,7 +107,7 @@ export function StoresPanel({ stores, loadStores, emailAccounts, loadEmailAccoun
 
         if (editingStore?.id === store.id) {
           return (
-            <div key={store.id} className="bg-white rounded-lg border border-blue-300 p-4">
+            <div key={store.id} className="bg-white rounded-lg border border-indigo-300 p-4">
               <h4 className="font-semibold mb-3">{t('settings.editStore')}</h4>
               <StoreForm
                 mode="edit"
@@ -127,8 +127,8 @@ export function StoresPanel({ stores, loadStores, emailAccounts, loadEmailAccoun
                   <h4 className="font-semibold text-sm">{store.name}</h4>
                   <span className={`px-2 py-0.5 rounded-full text-[10px] font-medium ${
                     store.browser_backend === 'chrome'
-                      ? 'bg-blue-100 text-blue-700'
-                      : 'bg-purple-100 text-purple-700'
+                      ? 'bg-indigo-100 text-indigo-700'
+                      : 'bg-indigo-100 text-indigo-700'
                   }`}>
                     {store.browser_backend === 'chrome' ? 'Chrome' : t('tasks.ziniao')}
                   </span>
@@ -171,11 +171,11 @@ export function StoresPanel({ stores, loadStores, emailAccounts, loadEmailAccoun
               {links.length > 0 && (
                 <div className="flex flex-wrap gap-1.5 mb-2">
                   {links.map(link => (
-                    <span key={link.id} className="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-50 text-blue-700 rounded-full text-xs">
+                    <span key={link.id} className="inline-flex items-center gap-1 px-2 py-0.5 bg-indigo-50 text-indigo-700 rounded-full text-xs">
                       {link.email}
                       <button
                         onClick={() => unlinkEmail(store.id, link.id)}
-                        className="text-blue-400 hover:text-red-500 ml-0.5"
+                        className="text-indigo-400 hover:text-red-500 ml-0.5"
                         title={t('email.disconnect')}
                       >
                         &times;
@@ -199,7 +199,7 @@ export function StoresPanel({ stores, loadStores, emailAccounts, loadEmailAccoun
                   <button
                     onClick={() => linkEmail(store.id, linkingEmail[store.id] || '')}
                     disabled={!linkingEmail[store.id]}
-                    className="text-xs px-2 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                    className="text-xs px-2 py-1 bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:opacity-50"
                   >
                     {t('stores.linkEmail')}
                   </button>

--- a/frontend/src/components/ui/EventStatusBadge.tsx
+++ b/frontend/src/components/ui/EventStatusBadge.tsx
@@ -4,7 +4,7 @@ export function EventStatusBadge({ status }: { status: string }) {
   const { t } = useTranslation()
   const colors: Record<string, string> = {
     draft: 'bg-gray-200 text-gray-700',
-    open: 'bg-blue-100 text-blue-700',
+    open: 'bg-indigo-100 text-indigo-700',
     in_progress: 'bg-indigo-100 text-indigo-700',
     waiting: 'bg-amber-100 text-amber-700',
     resolved: 'bg-green-100 text-green-700',

--- a/frontend/src/components/ui/StatusBadge.tsx
+++ b/frontend/src/components/ui/StatusBadge.tsx
@@ -4,9 +4,9 @@ export function StatusBadge({ status }: { status: string }) {
   const { t } = useTranslation()
   const colors: Record<string, string> = {
     pending: 'bg-gray-200 text-gray-700',
-    designing: 'bg-purple-100 text-purple-700',
+    designing: 'bg-indigo-100 text-indigo-700',
     planned: 'bg-indigo-100 text-indigo-700',
-    running: 'bg-blue-100 text-blue-700',
+    running: 'bg-indigo-100 text-indigo-700',
     completed: 'bg-green-100 text-green-700',
     failed: 'bg-red-100 text-red-700',
     queued: 'bg-yellow-100 text-yellow-700',

--- a/frontend/src/components/ui/StepIcon.tsx
+++ b/frontend/src/components/ui/StepIcon.tsx
@@ -1,6 +1,6 @@
 export function StepIcon({ status }: { status: string }) {
   if (status === 'completed') return <span className="text-green-500 text-lg">&#10003;</span>
-  if (status === 'running') return <span className="text-blue-500 animate-spin inline-block">&#9696;</span>
+  if (status === 'running') return <span className="text-indigo-500 animate-spin inline-block">&#9696;</span>
   if (status === 'failed') return <span className="text-red-500 text-lg">&#10007;</span>
   return <span className="text-gray-300 text-lg">&#9675;</span>
 }

--- a/frontend/src/components/ui/WsFileItem.tsx
+++ b/frontend/src/components/ui/WsFileItem.tsx
@@ -18,7 +18,7 @@ export function WsFileItem({ file, selected, onSelect, onDelete, displayPrefix }
     : file.name
   return (
     <div
-      className={`group px-3 py-1.5 cursor-pointer text-xs ${selected ? 'bg-blue-50 text-blue-700' : 'text-gray-600 hover:bg-gray-50'}`}
+      className={`group px-3 py-1.5 cursor-pointer text-xs ${selected ? 'bg-indigo-50 text-indigo-700' : 'text-gray-600 hover:bg-gray-50'}`}
       onClick={() => onSelect(file.path)}
     >
       <div className="flex items-center">
@@ -35,7 +35,7 @@ export function WsFileItem({ file, selected, onSelect, onDelete, displayPrefix }
           title={t('common.delete')}
         >&#10005;</button>
       </div>
-      {hintKey && <p className={`mt-0.5 text-[10px] leading-tight ml-5 ${selected ? 'text-blue-400' : 'text-gray-400'}`}>{t(hintKey)}</p>}
+      {hintKey && <p className={`mt-0.5 text-[10px] leading-tight ml-5 ${selected ? 'text-indigo-400' : 'text-gray-400'}`}>{t(hintKey)}</p>}
     </div>
   )
 }

--- a/frontend/src/handlers/deleteTask.ts
+++ b/frontend/src/handlers/deleteTask.ts
@@ -1,0 +1,66 @@
+import i18n from '../i18n'
+import type { Task } from '../types'
+
+export interface DeleteTaskApi {
+  get(url: string): Promise<Task[]>
+  del(url: string): Promise<unknown>
+}
+
+export interface DeleteTaskDeps {
+  api: DeleteTaskApi
+  tasks: Task[]
+  scheduleTasks: Task[]
+  selectedTask: Task | null
+  setTasks: React.Dispatch<React.SetStateAction<Task[]>>
+  setScheduleTasks: React.Dispatch<React.SetStateAction<Task[]>>
+  onSelectedCleared: () => void
+}
+
+/**
+ * Delete a task and locally drop it plus any descendants (the server
+ * cascade-deletes children but doesn't push an SSE delete for each), so
+ * the tree disappears immediately without a refetch.
+ */
+export async function deleteTask(
+  taskId: string,
+  deps: DeleteTaskDeps,
+): Promise<void> {
+  let childCount = 0
+  try {
+    const kids = await deps.api.get(
+      `/api/tasks?parent_task_id=${encodeURIComponent(taskId)}`,
+    )
+    childCount = Array.isArray(kids) ? kids.length : 0
+  } catch { /* ignore — fall back to plain confirm */ }
+  const message = childCount > 0
+    ? i18n.t('tasks.deleteConfirmCascade', { count: childCount })
+    : i18n.t('tasks.deleteConfirm')
+  if (!confirm(message)) return
+  try {
+    await deps.api.del(`/api/tasks/${taskId}`)
+    // BFS over known tasks to collect the deleted node + descendants.
+    const dropIds = new Set<string>([taskId])
+    let frontier = [taskId]
+    while (frontier.length) {
+      const next: string[] = []
+      for (const id of frontier) {
+        for (const t2 of deps.tasks) if (t2.parent_task_id === id) next.push(t2.id)
+        for (const t2 of deps.scheduleTasks) if (t2.parent_task_id === id) next.push(t2.id)
+      }
+      // Filter to unvisited BEFORE adding to dropIds — otherwise every
+      // BFS frontier collapses to [] after the first hop and we never
+      // reach grandchildren.
+      const unvisited = next.filter(id => !dropIds.has(id))
+      unvisited.forEach(id => dropIds.add(id))
+      frontier = unvisited
+    }
+    deps.setTasks(prev => prev.filter(x => !dropIds.has(x.id)))
+    deps.setScheduleTasks(prev => prev.filter(x => !dropIds.has(x.id)))
+    if (deps.selectedTask && dropIds.has(deps.selectedTask.id)) {
+      deps.onSelectedCleared()
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (msg !== 'unauthorized') alert(msg)
+  }
+}

--- a/frontend/src/handlers/sendChatMessage.ts
+++ b/frontend/src/handlers/sendChatMessage.ts
@@ -1,0 +1,57 @@
+import { sendEvent, lengthBucket } from '../lib/telemetry'
+import { FrontendEvent } from '../lib/telemetryEvents'
+import type { Task, AgentMessage, ConversationItem } from '../types'
+
+export interface SendChatApi {
+  post(url: string, body: unknown): Promise<{ woken?: boolean; profile_switched?: boolean }>
+}
+
+export interface SendChatDeps {
+  api: SendChatApi
+  selectedTask: Task | null
+  chatInput: string
+  profileId: string
+  conversationItems: ConversationItem[]
+  sendingRef: React.MutableRefObject<boolean>
+  setChatInput: (v: string) => void
+  setAgentMessages: React.Dispatch<React.SetStateAction<AgentMessage[]>>
+  setConversationItems: React.Dispatch<React.SetStateAction<ConversationItem[]>>
+  setSelectedTask: React.Dispatch<React.SetStateAction<Task | null>>
+  setTasks: React.Dispatch<React.SetStateAction<Task[]>>
+}
+
+/**
+ * Send a follow-up message on the selected task. Optimistically appends
+ * the user turn, POSTs it, and reconciles woken / profile-switch status
+ * from the response. `sendingRef` de-dupes rapid double-submits.
+ */
+export async function sendChatMessage(deps: SendChatDeps): Promise<void> {
+  const { selectedTask } = deps
+  if (!selectedTask || !deps.chatInput.trim() || deps.sendingRef.current) return
+  deps.sendingRef.current = true
+  const content = deps.chatInput.trim()
+  deps.setChatInput('')
+  sendEvent(FrontendEvent.TASK_MESSAGE_SUBMITTED, {
+    length_bucket: lengthBucket(content.length),
+    task_status_at_send: selectedTask.status,
+    is_first_message_for_task: !deps.conversationItems.some(c => c.type === 'user_message'),
+  })
+  // Optimistic add to both agentMessages (debug) and conversationItems
+  deps.setAgentMessages(prev => [...prev, { role: 'user', content }])
+  deps.setConversationItems(prev => [...prev, {
+    id: `user-opt-${Date.now()}`,
+    type: 'user_message',
+    timestamp: new Date().toISOString(),
+    message: { role: 'user', content },
+  }])
+  try {
+    const response = await deps.api.post(`/api/tasks/${selectedTask.id}/messages`, { content, profile_id: deps.profileId })
+    if (response.woken) {
+      deps.setSelectedTask(prev => prev ? { ...prev, status: 'queued' } : prev)
+      deps.setTasks(prev => prev.map(t2 => t2.id === selectedTask.id ? { ...t2, status: 'queued' } : t2))
+    }
+    if (response.profile_switched) {
+      deps.setSelectedTask(prev => prev ? { ...prev, ai_profile_id: deps.profileId } : prev)
+    }
+  } catch (err) { console.error('Failed to send message:', err) } finally { deps.sendingRef.current = false }
+}

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react'
+
+// Single source of truth for the mobile breakpoint. Matches Tailwind's
+// `md` (>=768px = desktop three-pane; <768px = mobile drill-down stack).
+const MOBILE_QUERY = '(max-width: 767px)'
+
+/**
+ * True when the viewport is phone-width. Drives the layout switch
+ * between the desktop three-pane view and the mobile navigation stack.
+ * Structural (which pane is mounted) decisions use this; purely visual
+ * tweaks should prefer Tailwind `md:` classes so they stay in CSS.
+ */
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia(MOBILE_QUERY).matches,
+  )
+
+  useEffect(() => {
+    const mq = window.matchMedia(MOBILE_QUERY)
+    const onChange = () => setIsMobile(mq.matches)
+    mq.addEventListener('change', onChange)
+    // Sync once in case the query changed between render and effect.
+    onChange()
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+
+  return isMobile
+}

--- a/frontend/src/hooks/useMobileBackStack.ts
+++ b/frontend/src/hooks/useMobileBackStack.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react'
+
+interface Args {
+  isMobile: boolean
+  navOpen: boolean
+  hasTask: boolean
+  hasSchedule: boolean
+  closeNav: () => void
+  closeTask: () => void
+  closeSchedule: () => void
+}
+
+/**
+ * Make the device/browser Back button pop the mobile drill-down stack
+ * (nav drawer → task list → task detail) instead of leaving the site.
+ *
+ * We add exactly one history entry whenever a "sub-screen" is open and
+ * pop the top-most level on `popstate`, so Back means "up one level".
+ * Closing via in-app UI (the ← bar / scrim) drops our entry so a later
+ * Back still leaves the app as the user expects. No-op on desktop.
+ */
+export function useMobileBackStack({
+  isMobile, navOpen, hasTask, hasSchedule, closeNav, closeTask, closeSchedule,
+}: Args) {
+  const subOpen = isMobile && (navOpen || hasTask || hasSchedule)
+  const pushedRef = useRef(false)
+
+  useEffect(() => {
+    if (!isMobile) return
+    if (subOpen && !pushedRef.current) {
+      pushedRef.current = true
+      window.history.pushState({ vsSub: true }, '')
+    } else if (!subOpen && pushedRef.current) {
+      pushedRef.current = false
+      window.history.back()
+    }
+  }, [isMobile, subOpen])
+
+  useEffect(() => {
+    const onPop = () => {
+      if (!pushedRef.current) return
+      pushedRef.current = false
+      // Close only the top-most level. If a lower level is still open the
+      // push effect re-adds an entry for it, so each Back peels one.
+      if (navOpen) closeNav()
+      else if (hasTask) closeTask()
+      else if (hasSchedule) closeSchedule()
+    }
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+  }, [navOpen, hasTask, hasSchedule, closeNav, closeTask, closeSchedule])
+}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -6,6 +6,7 @@
     "delete": "Delete",
     "edit": "Edit",
     "close": "Close",
+    "menu": "Menu",
     "loading": "Loading...",
     "error": "Error",
     "success": "Success",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -6,6 +6,7 @@
     "delete": "删除",
     "edit": "编辑",
     "close": "关闭",
+    "menu": "菜单",
     "loading": "加载中...",
     "error": "错误",
     "success": "成功",

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -95,7 +95,7 @@ export function SettingsView({
   return (
     <div className="flex-1 flex flex-col bg-gray-50 p-4 sm:p-6 overflow-y-auto">
       <h2 className="text-lg font-bold mb-4">{t('settings.title')}</h2>
-      <div className="flex gap-2 mb-4 border-b border-gray-200 overflow-x-auto">
+      <div className="flex flex-wrap gap-x-2 gap-y-1 mb-4 border-b border-gray-200">
         {tabs.map(tab => (
           <button
             key={tab}

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -93,16 +93,16 @@ export function SettingsView({
   }
 
   return (
-    <div className="flex-1 flex flex-col bg-gray-50 p-6 overflow-y-auto">
+    <div className="flex-1 flex flex-col bg-gray-50 p-4 sm:p-6 overflow-y-auto">
       <h2 className="text-lg font-bold mb-4">{t('settings.title')}</h2>
-      <div className="flex gap-2 mb-4 border-b border-gray-200">
+      <div className="flex gap-2 mb-4 border-b border-gray-200 overflow-x-auto">
         {tabs.map(tab => (
           <button
             key={tab}
             onClick={() => setSettingsTab(tab)}
-            className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+            className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors whitespace-nowrap flex-shrink-0 ${
               settingsTab === tab
-                ? 'border-blue-600 text-blue-600'
+                ? 'border-indigo-600 text-indigo-600'
                 : 'border-transparent text-gray-500 hover:text-gray-700'
             }`}
           >
@@ -156,7 +156,7 @@ export function SettingsView({
               <h3 className="font-semibold text-sm">{t('settings.aiProfiles')}</h3>
               <button
                 onClick={() => { setEditingProfile(undefined); setShowProfileModal(true) }}
-                className="px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700"
+                className="px-3 py-1 bg-indigo-600 text-white text-sm rounded hover:bg-indigo-700"
               >
                 {t('profiles.create')}
               </button>
@@ -164,10 +164,10 @@ export function SettingsView({
             <p className="text-xs text-gray-500 mb-3">{t('profiles.description')}</p>
 
             {/* Default Profile */}
-            <div className={`border rounded-lg p-3 mb-2 ${currentUser?.default_profile_id === 'default' ? 'border-blue-300 bg-blue-50/30' : 'border-gray-200'}`}>
+            <div className={`border rounded-lg p-3 mb-2 ${currentUser?.default_profile_id === 'default' ? 'border-indigo-300 bg-indigo-50/30' : 'border-gray-200'}`}>
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="font-medium text-sm">{t('profiles.default')}{currentUser?.default_profile_id === 'default' && <span className="ml-1.5 text-xs text-blue-600">★ {t('profiles.isDefault')}</span>}</p>
+                  <p className="font-medium text-sm">{t('profiles.default')}{currentUser?.default_profile_id === 'default' && <span className="ml-1.5 text-xs text-indigo-600">★ {t('profiles.isDefault')}</span>}</p>
                   <p className="text-xs text-gray-500">{t('profiles.defaultDescription')}</p>
                 </div>
                 <div className="flex gap-2 items-center">
@@ -180,7 +180,7 @@ export function SettingsView({
                           setSelectedProfileId('default')
                         } catch (err) { if (!handleProfileApiError(err)) { /* swallow other errors */ } }
                       }}
-                      className="px-2 py-1 text-xs border border-blue-300 text-blue-600 rounded hover:bg-blue-50"
+                      className="px-2 py-1 text-xs border border-indigo-300 text-indigo-600 rounded hover:bg-indigo-50"
                     >
                       {t('profiles.setDefault')}
                     </button>
@@ -192,10 +192,10 @@ export function SettingsView({
 
             {/* Custom Profiles */}
             {profiles.filter(p => p.id !== 'default').map(profile => (
-              <div key={profile.id} className={`border rounded-lg p-3 mb-2 ${currentUser?.default_profile_id === profile.id ? 'border-blue-300 bg-blue-50/30' : 'border-gray-200'}`}>
+              <div key={profile.id} className={`border rounded-lg p-3 mb-2 ${currentUser?.default_profile_id === profile.id ? 'border-indigo-300 bg-indigo-50/30' : 'border-gray-200'}`}>
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="font-medium text-sm">{profile.name}{currentUser?.default_profile_id === profile.id && <span className="ml-1.5 text-xs text-blue-600">★ {t('profiles.isDefault')}</span>}</p>
+                    <p className="font-medium text-sm">{profile.name}{currentUser?.default_profile_id === profile.id && <span className="ml-1.5 text-xs text-indigo-600">★ {t('profiles.isDefault')}</span>}</p>
                     <p className="text-xs text-gray-500">{profile.description || t('profiles.noDescription')}</p>
                     {profile.env && Object.keys(profile.env).length > 0 && (
                       <p className="text-xs text-gray-400 mt-1">
@@ -213,7 +213,7 @@ export function SettingsView({
                             setSelectedProfileId(profile.id)
                           } catch (err) { if (!handleProfileApiError(err)) { /* swallow other errors */ } }
                         }}
-                        className="px-2 py-1 text-xs border border-blue-300 text-blue-600 rounded hover:bg-blue-50"
+                        className="px-2 py-1 text-xs border border-indigo-300 text-indigo-600 rounded hover:bg-indigo-50"
                       >
                         {t('profiles.setDefault')}
                       </button>

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -383,7 +383,7 @@ export function TasksView({
       </div>
 
       {/* Right: Task detail or Schedule detail */}
-      <div className={`${isMobile && !mobileShowDetail ? 'hidden ' : 'flex '}flex-1 flex-col bg-gray-50`}>
+      <div className={`${isMobile && !mobileShowDetail ? 'hidden ' : 'flex '}flex-1 min-w-0 flex-col bg-gray-50`}>
         {/* Mobile: a slim back bar returns to the list (or schedule). */}
         {isMobile && mobileShowDetail && (
           <button
@@ -424,20 +424,20 @@ export function TasksView({
                     <span>&larr;</span> {t('schedules.backToSchedule')}: {selectedSchedule.title}
                   </button>
                 )}
-                <div className="flex items-center gap-3">
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 min-w-0">
                   <StatusBadge status={selectedTask.status} />
                   {selectedTask.description ? (
                     <button
                       type="button"
                       aria-expanded={descExpanded}
-                      className="flex items-center gap-1.5 hover:text-indigo-600"
+                      className="flex items-center gap-1.5 hover:text-indigo-600 min-w-0 text-left"
                       onClick={() => setDescExpanded(e => !e)}
                     >
                       <span className={`text-[10px] text-gray-400 transition-transform ${descExpanded ? 'rotate-90' : ''}`}>▶</span>
-                      <h2 className="font-semibold">{selectedTask.title}</h2>
+                      <h2 className="font-semibold break-words min-w-0">{selectedTask.title}</h2>
                     </button>
                   ) : (
-                    <h2 className="font-semibold">{selectedTask.title}</h2>
+                    <h2 className="font-semibold break-words min-w-0">{selectedTask.title}</h2>
                   )}
                   {selectedTask.store_id && (
                     <span className="text-xs text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded">{stores.find(s => s.id === selectedTask.store_id)?.name || selectedTask.store_id.slice(0, 8)}</span>
@@ -548,7 +548,7 @@ export function TasksView({
                 const el = scrollContainerRef.current
                 if (el) userNearBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 100
               }}
-              className="flex-1 overflow-y-auto px-6 py-6"
+              className="flex-1 overflow-y-auto px-4 sm:px-6 py-6"
             >
               <div className="w-full">
               {debugMode ? (
@@ -634,10 +634,10 @@ export function TasksView({
             </div>
 
             {/* Fixed footer */}
-            <div className="bg-white border-t border-gray-200 px-6 py-3">
+            <div className="bg-white border-t border-gray-200 px-4 sm:px-6 py-3">
               <div className="w-full space-y-2">
               {/* Profile selector + Debug toggle row */}
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2">
                 <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-gray-50 border border-gray-200 rounded-lg">
                   <svg className="w-3.5 h-3.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" /></svg>
                   <select

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -10,6 +10,8 @@ import { ScheduleList } from '../components/ScheduleList'
 import { ScheduleDetailView } from '../components/ScheduleDetailView'
 import { EditScheduleModal } from '../components/EditScheduleModal'
 import { ExternalConfigOverrideErrorCard } from '../components/ExternalConfigOverrideErrorCard'
+import { SubtaskList } from '../components/SubtaskList'
+import { MobileMenuButton } from '../components/MobileMenuButton'
 import { getUI, hasProgressingTask } from '../taskStates'
 import type { Task, TaskStep, AgentMessage, TodoItem, AuthUser, Profile, Schedule, Store, ConversationItem } from '../types'
 
@@ -81,54 +83,6 @@ interface TasksViewProps {
   onScheduleUpdated: (schedule: Schedule) => void
   selectedStore: Store | null
   stores: Store[]
-}
-
-function SubtaskList({ parentTaskId, onSelect, stores }: {
-  parentTaskId: string
-  onSelect: (t: Task) => void
-  stores: Store[]
-}) {
-  const { t } = useTranslation()
-  const [children, setChildren] = useState<Task[]>([])
-
-  useEffect(() => {
-    let cancelled = false
-    const fetchChildren = () => {
-      api.get(`/api/tasks?parent_task_id=${encodeURIComponent(parentTaskId)}`).then((data: Task[]) => {
-        if (!cancelled) setChildren(data)
-      }).catch(() => {})
-    }
-    fetchChildren()
-    // Poll every 10s for status updates instead of opening a second SSE
-    const interval = setInterval(fetchChildren, 10000)
-    return () => { cancelled = true; clearInterval(interval) }
-  }, [parentTaskId])
-
-  if (children.length === 0) return null
-
-  const storeName = (sid: string | null) => {
-    if (!sid) return ''
-    return stores.find(s => s.id === sid)?.name || sid.slice(0, 8)
-  }
-
-  return (
-    <div className="mt-2">
-      <div className="text-xs font-medium text-gray-500 mb-1">{t('tasks.subtasks', 'Subtasks')} ({children.length})</div>
-      <div className="space-y-1">
-        {children.map(child => (
-          <button
-            key={child.id}
-            onClick={() => onSelect(child)}
-            className="w-full text-left px-2 py-1.5 text-xs rounded border border-gray-200 hover:bg-gray-50 flex items-center gap-2"
-          >
-            <StatusBadge status={child.status} />
-            <span className="truncate flex-1">{child.title}</span>
-            {child.store_id && <span className="text-gray-400 text-[10px]">{storeName(child.store_id)}</span>}
-          </button>
-        ))}
-      </div>
-    </div>
-  )
 }
 
 export function TasksView({
@@ -273,13 +227,7 @@ export function TasksView({
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-2 min-w-0">
                   {isMobile && (
-                    <button
-                      onClick={onOpenNav}
-                      className="w-9 h-9 -ml-1.5 flex items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 flex-shrink-0"
-                      aria-label={t('common.menu', 'Menu')}
-                    >
-                      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" /></svg>
-                    </button>
+                    <MobileMenuButton onClick={onOpenNav} label={t('common.menu', 'Menu')} className="-ml-1.5" />
                   )}
                   <h2 className="font-semibold truncate">{taskPanelTitle}</h2>
                 </div>

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -21,6 +21,8 @@ function formatDate(dateStr: string): string {
 }
 
 interface TasksViewProps {
+  isMobile: boolean
+  onOpenNav: () => void
   taskPanelActive: boolean
   taskPanelTitle: string
   tasks: Task[]
@@ -130,6 +132,8 @@ function SubtaskList({ parentTaskId, onSelect, stores }: {
 }
 
 export function TasksView({
+  isMobile,
+  onOpenNav,
   taskPanelActive,
   taskPanelTitle,
   tasks,
@@ -250,20 +254,38 @@ export function TasksView({
 
   const onetimeTasks = tasks.filter(task => !task.schedule_id)
 
+  // Mobile drill-down: the list and detail are separate full-screen
+  // steps. Show detail (task or schedule) full-width and hide the list
+  // once something is selected; otherwise the list fills the screen.
+  const mobileShowDetail = isMobile && (!!selectedTask || !!selectedSchedule)
+  const onMobileBack = () => {
+    if (selectedTask) setSelectedTask(null)
+    else setSelectedSchedule(null)
+  }
+
   return (
     <>
       {/* Middle: Task list */}
-      <div className="w-80 bg-white border-r border-gray-200 flex flex-col">
+      <div className={`${mobileShowDetail ? 'hidden ' : 'flex '}${isMobile ? 'w-full' : 'w-80'} bg-white border-r border-gray-200 flex-col`}>
         {taskPanelActive ? (
           <>
             <div className="p-4 pb-0 border-b border-gray-200">
               <div className="flex items-center justify-between mb-2">
-                <div>
-                  <h2 className="font-semibold">{taskPanelTitle}</h2>
+                <div className="flex items-center gap-2 min-w-0">
+                  {isMobile && (
+                    <button
+                      onClick={onOpenNav}
+                      className="w-9 h-9 -ml-1.5 flex items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 flex-shrink-0"
+                      aria-label={t('common.menu', 'Menu')}
+                    >
+                      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" /></svg>
+                    </button>
+                  )}
+                  <h2 className="font-semibold truncate">{taskPanelTitle}</h2>
                 </div>
                 <button
                   onClick={taskSubTab === 'onetime' ? openCreateModal : () => setShowCreateSchedule(true)}
-                  className="px-3 py-1.5 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 flex items-center gap-1"
+                  className="px-3 py-1.5 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700 flex items-center gap-1"
                 >
                   <span className="text-base leading-none">+</span> {taskSubTab === 'onetime' ? t('tasks.newTask') : t('schedules.newSchedule')}
                 </button>
@@ -303,7 +325,7 @@ export function TasksView({
                         })
                         selectTask(task); setSelectedSchedule(null)
                       }}
-                      className={`w-full text-left px-4 py-3 hover:bg-gray-50 border-b border-gray-100 ${selectedTask?.id === task.id && !selectedSchedule ? 'bg-blue-50' : ''} ${task.status === 'waiting' ? 'border-l-3 border-l-amber-400' : ''}`}
+                      className={`w-full text-left px-4 py-3 hover:bg-gray-50 border-b border-gray-100 ${selectedTask?.id === task.id && !selectedSchedule ? 'bg-indigo-50' : ''} ${task.status === 'waiting' ? 'border-l-3 border-l-amber-400' : ''}`}
                     >
                       <div className="font-medium text-sm truncate">{task.title}</div>
                       {task.description && <div className="text-xs text-gray-400 truncate">{task.description}</div>}
@@ -314,7 +336,7 @@ export function TasksView({
                             const cond = JSON.parse(task.wait_condition)
                             const strategy = cond.check_strategy || 'manual'
                             return (
-                              <span className={`text-[10px] px-1 py-0.5 rounded whitespace-nowrap shrink-0 ${strategy === 'email' ? 'bg-blue-50 text-blue-600' : 'bg-gray-100 text-gray-500'}`}>
+                              <span className={`text-[10px] px-1 py-0.5 rounded whitespace-nowrap shrink-0 ${strategy === 'email' ? 'bg-indigo-50 text-indigo-600' : 'bg-gray-100 text-gray-500'}`}>
                                 {strategy === 'email' ? t('waiting.autoEmail') : t('waiting.manual')}
                               </span>
                             )
@@ -331,7 +353,7 @@ export function TasksView({
                       <p className="text-sm text-gray-500 mb-3">{t('tasks.noTasks')}</p>
                       <button
                         onClick={openCreateModal}
-                        className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700"
+                        className="px-4 py-2 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700"
                       >
                         + {t('tasks.createFirstTask')}
                       </button>
@@ -361,7 +383,17 @@ export function TasksView({
       </div>
 
       {/* Right: Task detail or Schedule detail */}
-      <div className="flex-1 flex flex-col bg-gray-50">
+      <div className={`${isMobile && !mobileShowDetail ? 'hidden ' : 'flex '}flex-1 flex-col bg-gray-50`}>
+        {/* Mobile: a slim back bar returns to the list (or schedule). */}
+        {isMobile && mobileShowDetail && (
+          <button
+            onClick={onMobileBack}
+            className="flex items-center gap-1.5 px-3 py-2 border-b border-gray-200 bg-white text-sm text-gray-600 hover:bg-gray-50"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg>
+            {t('common.back', 'Back')}
+          </button>
+        )}
         {selectedSchedule && !selectedTask ? (
           <ScheduleDetailView
             schedule={selectedSchedule}
@@ -387,7 +419,7 @@ export function TasksView({
                 {selectedSchedule && (
                   <button
                     onClick={() => { setSelectedTask(null) }}
-                    className="text-xs text-blue-600 hover:text-blue-800 mb-2 flex items-center gap-1"
+                    className="text-xs text-indigo-600 hover:text-indigo-800 mb-2 flex items-center gap-1"
                   >
                     <span>&larr;</span> {t('schedules.backToSchedule')}: {selectedSchedule.title}
                   </button>
@@ -426,7 +458,7 @@ export function TasksView({
                       {todoItems.map((ti, i) => (
                         <div key={i} className={`w-1.5 h-1.5 rounded-full ${
                           ti.status === 'completed' ? 'bg-green-500' :
-                          ti.status === 'in_progress' ? 'bg-blue-500 animate-pulse' :
+                          ti.status === 'in_progress' ? 'bg-indigo-500 animate-pulse' :
                           'bg-gray-300'
                         }`} />
                       ))}
@@ -454,7 +486,7 @@ export function TasksView({
                       ? t(`tasks.error_${selectedTask.error_category}`, selectedTask.error)
                       : selectedTask.error}
                     {selectedTask.error.includes('/api/ziniao/launcher') && (
-                      <a href="/api/ziniao/launcher" download className="ml-2 inline-block px-2 py-0.5 bg-blue-600 text-white rounded text-xs hover:bg-blue-700">{t('settings.ziniaoDownloadLauncher')}</a>
+                      <a href="/api/ziniao/launcher" download className="ml-2 inline-block px-2 py-0.5 bg-indigo-600 text-white rounded text-xs hover:bg-indigo-700">{t('settings.ziniaoDownloadLauncher')}</a>
                     )}
                   </div>
                     )
@@ -462,7 +494,7 @@ export function TasksView({
                 <SubtaskList parentTaskId={selectedTask.id} onSelect={selectTask} stores={stores} />
                 <div className="mt-2 flex gap-2 flex-wrap">
                   {getUI(selectedTask.status).isActive && (
-                    <span className="text-xs text-blue-600 animate-pulse self-center">
+                    <span className="text-xs text-indigo-600 animate-pulse self-center">
                       {selectedTask.status === 'designing' ? t('tasks.designing') : t('tasks.running')}
                     </span>
                   )}
@@ -543,8 +575,8 @@ export function TasksView({
                         <div key={i} className="text-xs font-mono min-w-0">
                           <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-bold mr-1.5 ${
                             msg.role === 'assistant' || msg.role === 'result' ? 'bg-green-900 text-green-300' :
-                            msg.role === 'user' ? 'bg-blue-900 text-blue-300' :
-                            msg.role === 'tool_use' ? 'bg-purple-900 text-purple-300' :
+                            msg.role === 'user' ? 'bg-indigo-900 text-indigo-300' :
+                            msg.role === 'tool_use' ? 'bg-indigo-900 text-indigo-300' :
                             msg.role === 'system' ? 'bg-red-900 text-red-300' :
                             'bg-gray-700 text-gray-400'
                           }`}>{msg.role}</span>
@@ -555,9 +587,9 @@ export function TasksView({
                       </div>
                     </div>
                   ) : isActive ? (
-                    <div className="flex items-center gap-3 px-4 py-4 bg-blue-50 rounded-lg border border-blue-200">
-                      <div className="w-5 h-5 rounded-full border-2 border-blue-500 border-t-transparent animate-spin shrink-0" />
-                      <div className="text-sm font-medium text-blue-700">{t('tasks.agentStarting')}</div>
+                    <div className="flex items-center gap-3 px-4 py-4 bg-indigo-50 rounded-lg border border-indigo-200">
+                      <div className="w-5 h-5 rounded-full border-2 border-indigo-500 border-t-transparent animate-spin shrink-0" />
+                      <div className="text-sm font-medium text-indigo-700">{t('tasks.agentStarting')}</div>
                     </div>
                   ) : null}
                 </div>
@@ -636,7 +668,7 @@ export function TasksView({
                 })()}
                 <button
                   onClick={() => { setEditingProfile(undefined); setShowProfileModal(true) }}
-                  className="text-xs text-gray-400 hover:text-blue-600"
+                  className="text-xs text-gray-400 hover:text-indigo-600"
                   title={t('chat.manageProfiles')}
                 >
                   <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
@@ -697,7 +729,7 @@ export function TasksView({
                   aria-checked={debugMode}
                 >
                   <span className="text-xs text-gray-400">{t('tasks.debugMode')}</span>
-                  <div className={`relative w-8 h-4 rounded-full transition-colors ${debugMode ? 'bg-blue-500' : 'bg-gray-300'}`}>
+                  <div className={`relative w-8 h-4 rounded-full transition-colors ${debugMode ? 'bg-indigo-500' : 'bg-gray-300'}`}>
                     <div className={`absolute top-0.5 left-0.5 w-3 h-3 bg-white rounded-full transition-transform pointer-events-none ${debugMode ? 'translate-x-4' : ''}`} />
                   </div>
                 </div>
@@ -735,7 +767,7 @@ export function TasksView({
                   }}
                   placeholder={getPlaceholder()}
                   disabled={!canSend && !isActive}
-                  className="flex-1 px-3 py-2 text-sm leading-5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-40 disabled:cursor-not-allowed resize-none overflow-y-auto"
+                  className="flex-1 px-3 py-2 text-sm leading-5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed resize-none overflow-y-auto"
                 />
                 {canSend && hasText ? (
                   <button

--- a/frontend/src/views/WorkspaceAssistantView.tsx
+++ b/frontend/src/views/WorkspaceAssistantView.tsx
@@ -73,7 +73,7 @@ export function WorkspaceAssistantView({
             className="flex items-center gap-1.5 px-2 py-1 rounded-full bg-white/80 backdrop-blur border border-gray-200 shadow-sm hover:bg-gray-50 transition-colors"
           >
             <span className="text-[11px] text-gray-400">{t('tasks.debugMode')}</span>
-            <div className={`relative w-7 h-3.5 rounded-full transition-colors ${debugMode ? 'bg-blue-500' : 'bg-gray-300'}`}>
+            <div className={`relative w-7 h-3.5 rounded-full transition-colors ${debugMode ? 'bg-indigo-500' : 'bg-gray-300'}`}>
               <div className={`absolute top-0.5 left-0.5 w-2.5 h-2.5 bg-white rounded-full transition-transform pointer-events-none ${debugMode ? 'translate-x-3.5' : ''}`} />
             </div>
           </button>
@@ -93,7 +93,7 @@ export function WorkspaceAssistantView({
                 <button
                   key={i}
                   onClick={() => { if (inputRef.current) { inputRef.current.value = ex; inputRef.current.focus() } }}
-                  className="text-left px-4 py-3 bg-white border border-gray-200 rounded-lg text-sm text-gray-700 hover:bg-blue-50 hover:border-blue-300 transition-colors"
+                  className="text-left px-4 py-3 bg-white border border-gray-200 rounded-lg text-sm text-gray-700 hover:bg-indigo-50 hover:border-indigo-300 transition-colors"
                 >
                   {ex}
                 </button>
@@ -106,8 +106,8 @@ export function WorkspaceAssistantView({
               <div key={i} className="text-xs font-mono min-w-0">
                 <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-bold mr-1.5 ${
                   msg.role === 'assistant' || msg.role === 'result' ? 'bg-green-900 text-green-300' :
-                  msg.role === 'user' ? 'bg-blue-900 text-blue-300' :
-                  msg.role === 'tool_use' ? 'bg-purple-900 text-purple-300' :
+                  msg.role === 'user' ? 'bg-indigo-900 text-indigo-300' :
+                  msg.role === 'tool_use' ? 'bg-indigo-900 text-indigo-300' :
                   msg.role === 'system' ? 'bg-red-900 text-red-300' :
                   msg.role === 'agent_event' ? 'bg-yellow-900 text-yellow-300' :
                   'bg-gray-700 text-gray-400'
@@ -123,7 +123,7 @@ export function WorkspaceAssistantView({
               if (msg.role === 'user') {
                 return (
                   <div key={i} className="flex justify-end">
-                    <div className="bg-blue-500 text-white px-4 py-2 rounded-2xl rounded-br-md max-w-[80%] text-sm whitespace-pre-wrap">
+                    <div className="bg-indigo-500 text-white px-4 py-2 rounded-2xl rounded-br-md max-w-[80%] text-sm whitespace-pre-wrap">
                       {msg.content}
                     </div>
                   </div>
@@ -136,7 +136,7 @@ export function WorkspaceAssistantView({
                     {msg.role === '_streaming' ? (
                       <div className="prose prose-sm max-w-none">
                         <ReactMarkdown>{msg.content}</ReactMarkdown>
-                        <span className="inline-block w-1.5 h-4 bg-blue-400 animate-pulse ml-0.5 align-text-bottom" />
+                        <span className="inline-block w-1.5 h-4 bg-indigo-400 animate-pulse ml-0.5 align-text-bottom" />
                       </div>
                     ) : (
                       <div className="prose prose-sm max-w-none">
@@ -151,9 +151,9 @@ export function WorkspaceAssistantView({
               <div className="flex justify-start">
                 <div className="px-4 py-3 rounded-2xl rounded-bl-md bg-white border border-gray-200 text-sm text-gray-400 flex items-center gap-2">
                   <span className="flex gap-1">
-                    <span className="w-1.5 h-1.5 bg-blue-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
-                    <span className="w-1.5 h-1.5 bg-blue-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
-                    <span className="w-1.5 h-1.5 bg-blue-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+                    <span className="w-1.5 h-1.5 bg-indigo-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+                    <span className="w-1.5 h-1.5 bg-indigo-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+                    <span className="w-1.5 h-1.5 bg-indigo-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
                   </span>
                   {t('workspace.assistantThinking')}
                 </div>
@@ -171,7 +171,7 @@ export function WorkspaceAssistantView({
             ref={inputRef}
             onKeyDown={handleKeyDown}
             placeholder={t('workspace.assistantPlaceholder')}
-            className="flex-1 px-4 py-2 border border-gray-300 rounded-xl text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-transparent"
+            className="flex-1 px-4 py-2 border border-gray-300 rounded-xl text-sm resize-none focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-transparent"
             rows={1}
             disabled={false}
           />
@@ -185,7 +185,7 @@ export function WorkspaceAssistantView({
           ) : (
             <button
               onClick={handleSubmit}
-              className="px-4 py-2 bg-blue-500 text-white rounded-xl text-sm font-medium hover:bg-blue-600 transition-colors flex-shrink-0"
+              className="px-4 py-2 bg-indigo-500 text-white rounded-xl text-sm font-medium hover:bg-indigo-600 transition-colors flex-shrink-0"
             >
               {t('tasks.send')}
             </button>

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -116,7 +116,7 @@ export function WorkspaceView({
               <button
                 onClick={saveWsFile}
                 disabled={!wsEditorDirty || wsSaving}
-                className="px-4 py-1.5 text-xs font-medium bg-blue-600 text-white rounded-lg disabled:opacity-40 disabled:cursor-not-allowed hover:bg-blue-700 transition-colors"
+                className="px-4 py-1.5 text-xs font-medium bg-indigo-600 text-white rounded-lg disabled:opacity-40 disabled:cursor-not-allowed hover:bg-indigo-700 transition-colors"
               >
                 {wsSaving ? t('common.loading') : t('common.save')}
               </button>
@@ -125,12 +125,12 @@ export function WorkspaceView({
         </div>
       </div>
       {isBuiltinSkill && (
-        <div className="px-4 py-2 bg-blue-50 border-b border-blue-200">
-          <p className="text-xs text-blue-700">{t('workspace.builtinSkillHint')}</p>
+        <div className="px-4 py-2 bg-indigo-50 border-b border-indigo-200">
+          <p className="text-xs text-indigo-700">{t('workspace.builtinSkillHint')}</p>
         </div>
       )}
       {isImportedSkill && (
-        <div className="px-4 py-2 bg-purple-50 border-b border-purple-200 text-xs text-purple-700">
+        <div className="px-4 py-2 bg-indigo-50 border-b border-indigo-200 text-xs text-indigo-700">
           {t('workspace.importedSkillHint')}
         </div>
       )}
@@ -154,11 +154,11 @@ export function WorkspaceView({
               wsFileHistory.map((c, i) => (
                 <div
                   key={c.sha}
-                  className={`px-3 py-2 border-b border-gray-100 cursor-pointer hover:bg-blue-50 transition-colors ${wsPreviewCommit === c.sha ? 'bg-blue-50 border-l-2 border-l-blue-500' : ''}`}
+                  className={`px-3 py-2 border-b border-gray-100 cursor-pointer hover:bg-indigo-50 transition-colors ${wsPreviewCommit === c.sha ? 'bg-indigo-50 border-l-2 border-l-indigo-500' : ''}`}
                   onClick={() => previewVersion(wsSelectedFile!, c.sha)}
                 >
                   <div className="flex items-center justify-between">
-                    <code className="text-[10px] text-blue-600 font-mono">{c.sha}</code>
+                    <code className="text-[10px] text-indigo-600 font-mono">{c.sha}</code>
                     {i === 0 && <span className="text-[9px] bg-green-100 text-green-700 px-1.5 py-0.5 rounded">{t('workspace.current')}</span>}
                   </div>
                   <p className="text-xs text-gray-700 mt-0.5 line-clamp-2">{c.message}</p>
@@ -172,7 +172,7 @@ export function WorkspaceView({
             {wsPreviewCommit ? (
               <>
                 <div className="px-4 py-2 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
-                  <span className="text-xs text-gray-500">{t('workspace.preview')}: <code className="font-mono text-blue-600">{wsPreviewCommit}</code></span>
+                  <span className="text-xs text-gray-500">{t('workspace.preview')}: <code className="font-mono text-indigo-600">{wsPreviewCommit}</code></span>
                   {wsFileHistory[0]?.sha !== wsPreviewCommit && (
                     <button
                       onClick={() => resetFileToVersion(wsSelectedFile!, wsPreviewCommit!)}


### PR DESCRIPTION
## What

Two changes, both spanning **PC and mobile**, reviewed as artifacts before building.

### 1. Mobile responsive (`<768px`)
The desktop three-pane layout (sidebar / list / detail) can't fit a phone, so below `768px` it becomes a **drill-down stack**, driven by a new `useIsMobile()` (`matchMedia`). Desktop (`≥768px`) is unchanged by construction.

- **Sidebar → slide-in drawer** with scrim; a hamburger toggles it; picking a store/view closes it.
- **TasksView → one screen at a time**: list full-width → tap a task → full-width detail with a back bar (schedule detail too).
- **Hamburger** in tasks / workspace / settings headers so nav is always reachable.
- **Modals → bottom sheets** on mobile (new task, schedules, AI profile): `items-end` + `rounded-t-2xl` + `max-h/scroll`; centered on desktop.
- **Settings tabs → horizontally scrollable**; padding tightens.
- **AI question banner → ≥44px tap targets** on mobile.
- i18n: add `common.menu` (en/zh).

### 2. Unify accent to the brand purple
The app icon (`vibe-seller.svg`) is `#6366F1`, but buttons were `blue-600` (`#2563eb`) and the send button `indigo-600` — three competing accents. Collapsed **all `blue-*` / `purple-*` accent classes to the indigo scale**: button `#4f46e5` (indigo-600), tint `indigo-50`, brand `#6366F1` (indigo-500). Semantic colors (green / red / amber) untouched. Two tests asserting `.bg-blue-50` / `.bg-purple-100` updated in sync with their components.

## Coverage
Task flow, settings (6 tabs), AI config + profile editor, create + bind store (Ziniao), email config, and the AI question/select banner — all adapted.

## Verification
- `npm run build` clean (tsc + vite).
- **336/336** frontend tests pass.
- Authenticated mobile views verified against the approved design artifact — I couldn't auto-screenshot them (local server requires login), so please eyeball on a phone / narrow window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)