### PR TITLE
fix(install): start.sh resolves uv via install.sh --print-path (check-context == run-context)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,7 @@ set -euo pipefail
 DEV=false
 CHECK_ONLY=false
 HELP=false
+PRINT_PATH=false
 TEST_PYPI=false
 VERSION=""
 # `while + shift` so we can take an argument after --version. Other
@@ -37,6 +38,7 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --dev)         DEV=true ;;
         --check-only)  CHECK_ONLY=true; DEV=true ;;  # check-only is dev-only
+        --print-path)  PRINT_PATH=true ;;  # emit the tool PATH, for start.sh
         --test-pypi)   TEST_PYPI=true ;;
         --version)     VERSION="${2:-}"; shift ;;
         --version=*)   VERSION="${1#*=}" ;;
@@ -125,6 +127,39 @@ _success() { printf "%s[ok]%s %s\n" "$_G" "$_Z" "$*"; }
 _warn()    { printf "%s[!]%s %s\n" "$_Y" "$_Z" "$*" >&2; }
 _error()   { printf "%s[error]%s %s\n" "$_R" "$_Z" "$*" >&2; }
 _check()   { command -v "$1" > /dev/null 2>&1; }
+
+# Canonical set of user-local bin dirs where our installers drop
+# binaries: uv → ~/.local/bin or ~/.cargo/bin; node/pnpm → the npm
+# prefix's bin. Prints a PATH value with these prepended.
+#
+# SINGLE SOURCE OF TRUTH: main()'s dependency checks AND start.sh (via
+# `install.sh --print-path`) prepend the *same* dirs. Without this, a
+# passing `--check-only` would not guarantee the tools are runnable
+# where they are used — install.sh finds uv only because it bootstraps
+# this PATH internally, and that export dies with the subprocess, so a
+# login shell (or start.sh) that lacks ~/.local/bin can't run uv.
+_compute_bootstrap_path() {
+    local p="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+    # Only probe npm's prefix if npm resolves under the augmented PATH.
+    # A command substitution of a missing command exits 127, which
+    # `2>/dev/null` silences but does NOT neutralize under `set -e`;
+    # guarding with the `if` keeps a missing npm a no-op.
+    local npm_bin=''
+    if PATH="$p" command -v npm >/dev/null 2>&1; then
+        npm_bin="$(PATH="$p" npm config get prefix 2>/dev/null || true)/bin"
+    fi
+    if [[ -n "$npm_bin" && -d "$npm_bin" && ":$p:" != *":$npm_bin:"* ]]; then
+        p="$npm_bin:$p"
+    fi
+    printf '%s' "$p"
+}
+
+# `--print-path` is a pure query used by start.sh: emit the tool PATH
+# and exit before any install side effect (no clone, no sudo, no deps).
+if [[ "$PRINT_PATH" == true ]]; then
+    _compute_bootstrap_path
+    exit 0
+fi
 
 # -- Platform detection --
 OS="unknown"
@@ -283,6 +318,10 @@ Other flags:
                     Combine with --test-pypi to test a release candidate.
   --check-only      Check dev-mode dependencies without installing.
                     Used by start.sh during local development.
+  --print-path      Print the PATH (user-local tool dirs prepended)
+                    and exit, without installing anything. start.sh
+                    uses this so it resolves uv/pnpm exactly as the
+                    dependency check did.
   --help, -h        Show this help.
 EOF
 }
@@ -761,24 +800,12 @@ main() {
         require_sudo
     fi
 
-    # Bootstrap PATH with common user-local binary dirs so check_* functions
-    # find tools installed by previous runs even in non-interactive shells
-    # (e.g. SSH sessions, WSL launched from Windows, CI runners).
-    export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
-    # npm may not exist yet on a fresh machine — the DEPS loop below is
-    # what installs node/npm. Only probe npm's prefix if npm is present:
-    # a command substitution of a missing command exits 127, which
-    # `2>/dev/null` silences but does NOT neutralize, so under `set -e`
-    # the bare assignment aborts the whole installer (observed as an
-    # instant exit 127 right after the platform check on a clean macOS).
-    # This block is best-effort PATH sugar; a missing npm must be a no-op.
-    local _npm_bin=""
-    if _check npm; then
-        _npm_bin="$(npm config get prefix 2>/dev/null || true)/bin"
-    fi
-    if [[ -n "$_npm_bin" && -d "$_npm_bin" && ":$PATH:" != *":$_npm_bin:"* ]]; then
-        export PATH="$_npm_bin:$PATH"
-    fi
+    # Bootstrap PATH with common user-local binary dirs so check_*
+    # functions find tools installed by previous runs even in
+    # non-interactive shells (SSH sessions, WSL launched from Windows,
+    # CI runners). start.sh applies the IDENTICAL set via `--print-path`
+    # so a passing check guarantees the tools are runnable there too.
+    export PATH="$(_compute_bootstrap_path)"
     # In GitHub Actions, PATH exports inside a script don't persist to
     # subsequent steps. When we find tools via the bootstrap above and skip
     # their installers (which would normally write to $GITHUB_PATH), register
@@ -786,7 +813,11 @@ main() {
     if [[ -n "${GITHUB_PATH:-}" ]]; then
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        [[ -d "$_npm_bin" ]] && echo "$_npm_bin" >> "$GITHUB_PATH"
+        local _npm_bin=""
+        if _check npm; then
+            _npm_bin="$(npm config get prefix 2>/dev/null || true)/bin"
+        fi
+        [[ -n "$_npm_bin" && -d "$_npm_bin" ]] && echo "$_npm_bin" >> "$GITHUB_PATH"
     fi
 
     # Required dependencies

--- a/start.sh
+++ b/start.sh
@@ -19,6 +19,18 @@ fi
 _info()  { printf "%s==>%s %s%s\n" "$_B$_W" "$_Z$_W" "$*" "$_Z"; }
 _error() { printf "%sError%s: %s\n" "$_R$_W" "$_Z" "$*" >&2; }
 
+# -- Make installed tools resolvable in THIS shell --
+# install.sh drops uv in ~/.local/bin (and node/pnpm under the npm
+# prefix); a login shell may not have those dirs on PATH, so `uv` would
+# be missing even though the dependency check below — which bootstraps
+# the same dirs internally — passes. Ask the installer for its canonical
+# PATH so the check-context and the run-context are identical. Without
+# this, `env … uv run …` at launch fails with "env: uv: No such file".
+if _bootstrap_path="$("$SCRIPT_DIR/install.sh" --print-path 2>/dev/null)" \
+        && [ -n "$_bootstrap_path" ]; then
+    export PATH="$_bootstrap_path"
+fi
+
 # -- Prerequisite checks (delegates to install.sh) --
 if ! "$SCRIPT_DIR/install.sh" --check-only; then
     echo "" >&2

--- a/tests/unit/test_install_sh.py
+++ b/tests/unit/test_install_sh.py
@@ -69,3 +69,116 @@ def test_check_only_survives_missing_npm(tmp_path):
         'install.sh did not reach the dependency-check summary; '
         f'stdout={result.stdout!r} stderr={result.stderr!r}'
     )
+
+
+def _run_print_path(tmp_path, extra_bin_files=()):
+    """Run `install.sh --print-path` with a curated, uv-free PATH.
+
+    Returns (result, fake_home, emitted_path). `extra_bin_files` is a
+    list of (relative_path_under_home, contents) executables to seed —
+    e.g. ('.local/bin/uv', '') to place a uv the caller's PATH lacks.
+    """
+    fake_bin = tmp_path / 'bin'
+    fake_bin.mkdir()
+    for tool in _INFRA_TOOLS:
+        src = shutil.which(tool)
+        if src:
+            (fake_bin / tool).symlink_to(src)
+    fake_home = tmp_path / 'home'
+    fake_home.mkdir()
+    for rel, contents in extra_bin_files:
+        dest = fake_home / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(contents or '#!/bin/sh\n')
+        dest.chmod(0o755)
+
+    bash = shutil.which('bash')
+    assert bash, 'bash is required to run this test'
+    env = {'PATH': str(fake_bin), 'HOME': str(fake_home)}
+    # uv must NOT be on the caller's PATH — that is the whole point.
+    assert shutil.which('uv', path=env['PATH']) is None
+
+    result = subprocess.run(
+        [bash, str(INSTALL_SH), '--print-path'],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return result, fake_home, result.stdout
+
+
+@pytest.mark.unit
+def test_print_path_makes_local_uv_resolvable(tmp_path):
+    """`--print-path` must emit a PATH on which a ~/.local/bin uv resolves.
+
+    Regression (izz-mac): uv installs to ~/.local/bin, which a login
+    shell may not have on PATH. `install.sh --check-only` passed anyway
+    because it bootstraps that dir into its *own* process; that export
+    died with the subprocess, so start.sh's `env … uv run …` failed with
+    `env: uv: No such file`. The fix makes install.sh the single source
+    of truth via `--print-path`, and start.sh adopts it — so the PATH
+    the check validated and the PATH the launch uses are identical.
+    """
+    result, fake_home, emitted = _run_print_path(
+        tmp_path, extra_bin_files=[('.local/bin/uv', '#!/bin/sh\n')]
+    )
+
+    assert result.returncode == 0, (
+        f'--print-path failed: stdout={result.stdout!r} '
+        f'stderr={result.stderr!r}'
+    )
+    emitted_path = emitted.strip()
+    assert emitted_path, 'nothing printed'
+    # The decisive assertion: uv is now findable on the emitted PATH,
+    # resolving to the one under the fake HOME's ~/.local/bin.
+    resolved = shutil.which('uv', path=emitted_path)
+    assert resolved == str(fake_home / '.local' / 'bin' / 'uv'), (
+        f'uv not resolvable on emitted PATH; resolved={resolved!r} '
+        f'emitted={emitted_path!r}'
+    )
+
+
+@pytest.mark.unit
+def test_print_path_has_no_install_side_effects(tmp_path):
+    """`--print-path` is a pure query: one PATH line, no install output.
+
+    It must exit before the clone bootstrap, sudo, and dependency
+    install — so it prints exactly the PATH and none of the installer's
+    `==>`/`[ok]` chatter (which would corrupt the value start.sh
+    captures via command substitution).
+    """
+    result, _fake_home, emitted = _run_print_path(tmp_path)
+
+    assert result.returncode == 0, (
+        f'--print-path failed: stderr={result.stderr!r}'
+    )
+    combined = result.stdout + result.stderr
+    for noise in ('[ok]', '==>', '[error]', 'sudo'):
+        assert noise not in combined, (
+            f'--print-path leaked installer output ({noise!r}): {combined!r}'
+        )
+    # A PATH is a single line — no trailing newline chatter beyond it.
+    assert emitted.strip().count('\n') == 0, (
+        f'--print-path emitted more than one line: {emitted!r}'
+    )
+
+
+@pytest.mark.unit
+def test_start_sh_derives_path_from_install_print_path():
+    """start.sh must resolve tools via `install.sh --print-path`.
+
+    Static guard: the wiring that closes the check-vs-run PATH gap must
+    run before start.sh invokes uv, and must not be silently dropped.
+    """
+    start_sh = (REPO_ROOT / 'start.sh').read_text()
+    assert '--print-path' in start_sh, (
+        'start.sh no longer asks install.sh for its canonical PATH'
+    )
+    bootstrap_at = start_sh.index('--print-path')
+    # `uv run python` is the actual server launch; plain `uv run` also
+    # appears in the bootstrap comment, so match the launch specifically.
+    launch_at = start_sh.index('uv run python')
+    assert bootstrap_at < launch_at, (
+        'start.sh must set PATH via --print-path *before* it runs uv'
+    )


### PR DESCRIPTION
## Problem

`./start.sh --dev` (and `./restart.sh --dev`) failed on a fresh Mac with:

```
ERROR: Server did not become healthy on :7777.
env: uv: No such file or directory
```

…even though the dependency check right above it printed `[ok] uv 0.10.4`.

## Root cause — design gap, not symptom

`install.sh` validates `uv` against a PATH it bootstraps **inside its own process** (`~/.local/bin`, `~/.cargo/bin`, npm prefix). That `export` dies with the subprocess, and `start.sh` never re-created it. So the dependency **check** and the server **launch** resolved `uv` in *different PATH contexts*:

- `install.sh --check-only` → passes (uv visible in its bootstrapped PATH)
- `nohup env … uv run … uvicorn` in `start.sh` → `env: uv: No such file` (caller's login shell lacks `~/.local/bin`)

The invariant *"after `install.sh` passes, `start.sh` works"* was never actually enforced.

## Fix — make `install.sh` the single source of truth for the tool PATH

- **`install.sh`**: extract the PATH bootstrap into `_compute_bootstrap_path()` (now used by `main()` itself) and add a pure `--print-path` query that emits that PATH and exits **before any install side effect** (no clone, no sudo, no deps).
- **`start.sh`**: before touching `uv`, `export PATH="$("$SCRIPT_DIR/install.sh" --print-path)"`. The PATH the check validated is now exactly the PATH the launch runs in — they can't drift. The daemon inherits it too, so runtime `uv venv` / `uv pip install` spawns resolve as well.

This makes the bug class impossible to recreate from this surface.

## PyPI installs unaffected

`vibe-seller start` launches uvicorn via `sys.executable -m uvicorn` (never `uv run`), and the `vibe-seller` command itself lives in `~/.local/bin` — so a user who can invoke it already has `uv` on PATH. The daemon's runtime `uv` spawns inherit that PATH.

## Verification

- **Live on izz-mac**: plain `./restart.sh --dev` through a login shell, with `uv` confirmed absent from that shell's PATH, boots healthy (`{"status":"ok",...}`) with **zero** `uv: No such file` errors. (Before the fix, same shell → server never came up.)
- **New unit tests** (`tests/unit/test_install_sh.py`, 4 pass, ruff/pre-commit clean):
  - `--print-path` emits a PATH on which a `~/.local/bin` uv resolves (the exact izz-mac scenario)
  - `--print-path` is a pure query: single line, no installer chatter
  - `start.sh` derives PATH from `--print-path` *before* it launches uv

🤖 Generated with [Claude Code](https://claude.com/claude-code)