### PR TITLE
fix(amazon-listing): support Amazon's unified flat-file template + upload from the browser-readable downloads dir

### DIFF
--- a/app/skills_v2/MANIFEST.txt
+++ b/app/skills_v2/MANIFEST.txt
@@ -22,6 +22,7 @@ amazon-listing/references/template-round-trip.md
 amazon-listing/references/1688-sourcing.md
 amazon-listing/scripts/listing_bulk.py
 amazon-listing/scripts/marketplace_ids.py
+amazon-listing/scripts/listing_schema.py
 amazon-listing/scripts/ocr_1688.py
 amazon-listing/requirements.txt
 amazon-invoice/SKILL.md

--- a/app/skills_v2/amazon-ads/references/bulk-operations.md
+++ b/app/skills_v2/amazon-ads/references/bulk-operations.md
@@ -127,12 +127,9 @@ row and sheet name from the export you fed it (see locale note below).
 
 ### 3. Import (Upload campaigns)
 
-> **The upload file must be under `~/.vibe-seller/downloads/<slug>/`, not
-> `/tmp`** — the browser reads it to attach it and Ziniao's Chrome can't
-> read `/tmp` (see `browser-harness` § "Uploading a file"). That's why the
-> `--out` paths above target the downloads dir.
-
-Bulk Operations → **Upload campaigns** → pick the output file. The job
+Bulk Operations → **Upload campaigns** → pick the output file (from the
+downloads dir the `--out` paths above target — the browser must read it to
+attach it; see `browser-harness` § "Uploading a file"). The job
 runs asynchronously; the history table shows `Success` / `Failed` /
 `File not uploaded` (these status strings are **English regardless of
 console language**). When a row fails, **download its result report**

--- a/app/skills_v2/amazon-ads/references/bulk-operations.md
+++ b/app/skills_v2/amazon-ads/references/bulk-operations.md
@@ -60,18 +60,18 @@ $PY "$S" clone-campaign "$EXPORT" \
     --new "acme widgets 006 manual keyword US" \
     --sku WIDGET-006-Blue-M --asin B0EXAMPLE1 \
     --daily-budget 10 --default-bid 0.75 \
-    --out /tmp/<slug>/bulk_create.xlsx
+    --out ~/.vibe-seller/downloads/<slug>/bulk_create.xlsx
 
 # BID UPDATE: re-bid every keyword in a campaign (scale or set).
 $PY "$S" bid-update "$EXPORT" \
     --campaign "acme widgets 004 manual keyword US" --scale 0.85 \
-    --out /tmp/<slug>/bulk_bid_update.xlsx
+    --out ~/.vibe-seller/downloads/<slug>/bulk_bid_update.xlsx
 
 # ARCHIVE (disable + clean up) a campaign — needs only its Campaign Id,
 # read from the export.
 $PY "$S" archive-campaign "$EXPORT" \
     --campaign "acme widgets 006 manual keyword US" \
-    --out /tmp/<slug>/bulk_archive.xlsx
+    --out ~/.vibe-seller/downloads/<slug>/bulk_archive.xlsx
 
 # CLONE an AUTO campaign — same command; it detects auto from the source
 # (which has product-targeting rows, not keywords) and copies those match
@@ -79,14 +79,14 @@ $PY "$S" archive-campaign "$EXPORT" \
 # NOT hand-write auto-target tokens; clone from a working auto campaign.
 $PY "$S" clone-campaign "$EXPORT" \
     --src "acme widgets 004 auto US" --new "acme widgets 006 auto US" \
-    --sku WIDGET-006-Blue-M --daily-budget 10 --out /tmp/<slug>/bulk_auto.xlsx
+    --sku WIDGET-006-Blue-M --daily-budget 10 --out ~/.vibe-seller/downloads/<slug>/bulk_auto.xlsx
 
 # NEGATE zero-sales keywords on a campaign (bulk — NOT by scraping the
 # on-screen grid). Campaign-level by default; --level adgroup for ad-group.
 $PY "$S" negate "$EXPORT" \
     --campaign "acme widgets 006 manual keyword US" \
     --keywords "generic term a,generic term b" --match negativePhrase \
-    --out /tmp/<slug>/bulk_negate.xlsx
+    --out ~/.vibe-seller/downloads/<slug>/bulk_negate.xlsx
 ```
 
 > **Negation is a bulk op, never a grid scrape.** The on-screen keyword /
@@ -126,6 +126,11 @@ row and sheet name from the export you fed it (see locale note below).
 > + terminated export to confirm.
 
 ### 3. Import (Upload campaigns)
+
+> **The upload file must be under `~/.vibe-seller/downloads/<slug>/`, not
+> `/tmp`** — the browser reads it to attach it and Ziniao's Chrome can't
+> read `/tmp` (see `browser-harness` § "Uploading a file"). That's why the
+> `--out` paths above target the downloads dir.
 
 Bulk Operations → **Upload campaigns** → pick the output file. The job
 runs asynchronously; the history table shows `Success` / `Failed` /

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -192,6 +192,18 @@ a family that the parent shows **"Variations (N)"**.
   a long-title item. That is **NOT done**: fix the exact field the report
   names (Item Highlight is optional — clear it; the colour belongs in
   `color_name`) and re-upload. Only 18320 is a legit deferral.
+- **When the image IS the only remaining error, say so — never call it
+  "live".** A SUCCESS (OTHER) whose sole error is the missing main image
+  ("submit a compliant image to lift the suppression") means the SKU is
+  **created + priced + stocked but SEARCH-SUPPRESSED** — it is NOT buyable
+  or discoverable until the seller adds an image. That is the accepted
+  deferred done-state, but the final result MUST report it precisely:
+  "N children created, linked, priced, stocked — **SUPPRESSED pending main
+  image** (seller adds the image to go live)". Do **not** write "live",
+  "done", "全部完成", or imply the listings are sellable. The Manage
+  Inventory row will read "Search suppressed" / "No image available" and
+  the upload feed will read 0/N successful — that is expected for this
+  state, not a failure to re-upload over.
 - **A buyable child that `8560`s ("doesn't match any ASINs … include
   standard_product_id")** — Amazon is refusing to *mint a new ASIN* for
   it. Two cases, decided by whether that child's ASIN already exists:

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -133,11 +133,9 @@ a family that the parent shows **"Variations (N)"**.
   `.txt` next to the `.xlsm` for you — upload that. An openpyxl-saved
   `.xlsm` triggers a **90502 FATAL** ("worksheet template type not
   supported for Excel upload").
-- **Write the file under `~/.vibe-seller/downloads/<slug>/`, NOT `/tmp`**
-  (`fill --out` there). The browser reads the file to attach it and
-  Ziniao's Chrome can't read `/tmp`, so a `/tmp` file silently fails to
-  upload (Submit never enables). This was the sole cause of failed child
-  uploads.
+- **`fill --out` into the store downloads dir**
+  (`~/.vibe-seller/downloads/<slug>/`), not `/tmp` — the browser must read
+  the file to attach it (see `browser-harness` § "Uploading a file").
 - **Submit is TWO clicks; the "network error" banner is a red herring.**
   On the unified upload page the 1st **Submit products** only fires
   `introspect-feed` (file-type detection → "Automatically detected"

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -153,6 +153,17 @@ a family that the parent shows **"Variations (N)"**.
   its category asks for (e.g. `item_name`, `target_gender`,
   `age_range_description`, and any compound-attribute sub-fields), plus
   its differentiator + offer — not just `parent_sku` + colour.
+- **"Required" is a guide, not an absolute — fill what you can, defer what
+  you can't.** For each required-field error the report names, supply a
+  sensible value: pick from the template's valid set (material, weave,
+  size type, package dimension/weight units), set `list_price` = your
+  price, `model_name` = the SKU/title. For a **new ASIN** with no GTIN, set
+  the product-id **type** to `GTIN Exempt` (unified) / leave the id blank
+  + set brand (legacy) if the brand is exempt. A few are genuinely
+  deferrable — a real **main image** you don't have (18320) is added later
+  and does NOT block creation. Don't stall the whole family on one
+  attribute you can't provide; create with what you have and let the
+  seller finish image/GTIN afterwards.
 - **Enum case is exact** (`UAE/KSA`, not `uae/ksa`). `fill` canonicalises
   a value to the template's own casing when the field has a valid set.
 - **Compound attributes come as a set** — e.g. Apparel Size needs

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -133,6 +133,11 @@ a family that the parent shows **"Variations (N)"**.
   `.txt` next to the `.xlsm` for you — upload that. An openpyxl-saved
   `.xlsm` triggers a **90502 FATAL** ("worksheet template type not
   supported for Excel upload").
+- **Write the file under `~/.vibe-seller/downloads/<slug>/`, NOT `/tmp`**
+  (`fill --out` there). The browser reads the file to attach it and
+  Ziniao's Chrome can't read `/tmp`, so a `/tmp` file silently fails to
+  upload (Submit never enables). This was the sole cause of failed child
+  uploads.
 - **Submit is TWO clicks; the "network error" banner is a red herring.**
   On the unified upload page the 1st **Submit products** only fires
   `introspect-feed` (file-type detection → "Automatically detected"

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -133,6 +133,17 @@ a family that the parent shows **"Variations (N)"**.
   `.txt` next to the `.xlsm` for you — upload that. An openpyxl-saved
   `.xlsm` triggers a **90502 FATAL** ("worksheet template type not
   supported for Excel upload").
+- **Submit is TWO clicks; the "network error" banner is a red herring.**
+  On the unified upload page the 1st **Submit products** only fires
+  `introspect-feed` (file-type detection → "Automatically detected"
+  banner); a 2nd click actually posts the feed (URL gains
+  `reference_id=`). The red "Sorry! There's a network error" toast shows
+  even when introspect returned 200 — do NOT re-upload on it. See
+  `references/template-round-trip.md` § 4.
+- **"1/N — parent created, children failed" is a CONTENT rejection, not a
+  browser bug.** The file uploaded fine (it reached validation); download
+  the Processing Summary and `parse-feedback` it for the per-child reason,
+  then fix + re-upload the children. Never thrash on the upload widget.
 - **Children are NOT minimal.** Each child needs the full required set
   its category asks for (e.g. `item_name`, `target_gender`,
   `age_range_description`, and any compound-attribute sub-fields), plus
@@ -203,13 +214,25 @@ PY=<project-venv>/bin/python3     # needs openpyxl + rapidocr-onnxruntime
 ```
 
 - **`listing_bulk.py`** — deterministic template writer. It keys every
-  field by its **field API name** (the row that contains `item_sku`),
+  field by its **field API name** (the row carrying the SKU column),
   which is identical in every console language, so it is locale-robust
-  the same way `amazon-ads/ads_bulk.py` is.
-  - `inspect TEMPLATE.xlsm [--field NAME]` — dump the field set, which
-    fields are Required, the accepted enum tokens, and the variation
-    cluster. **Run this first on every fresh template** — the column
-    set and valid values differ per product type.
+  the same way `amazon-ads/ads_bulk.py` is. It **auto-detects both
+  template dialects** — legacy `fptcustom` (`item_sku`, `update_delete`,
+  header row 3) and the current unified NGS "Beta Product Spreadsheet"
+  (`contribution_sku#1.value`, `::record_action`, marketplace-scoped
+  parentage/offer, header row 5) — and resolves the friendly spec keys to
+  each dialect's columns, so the SAME spec drives either. **Always drive
+  the upload file through `fill` — never hand-roll it**: a hand-rolled
+  file skips `fill`'s guard that clears the unified template's prefilled
+  example/instruction rows, and uploading those as SKUs is what produced a
+  live **"1/8 successful"** (parent only, all children failed). See
+  `references/template-round-trip.md` § 0.
+  - `inspect TEMPLATE.xlsm [--field NAME]` — dump the dialect, the field
+    set, which fields are Required, the accepted enum tokens, and the
+    resolved friendly roles (which column each of sku / operation /
+    parentage / parent_sku / variation_theme / brand / offer maps to for
+    THIS template). **Run this first on every fresh template** — the
+    column set, dialect, and valid values differ per product type.
   - `fill TEMPLATE.xlsm --spec SPEC.json --out OUT.xlsm` — write
     parent/child rows, set the operation column per row, validate enums
     and required fields against the template's own metadata sheets, and

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -8,8 +8,12 @@ review:
     - Every attempted SKU is ACTUALLY LIVE, not just "uploaded": on
       Manage Inventory the parent shows Variations(N) and each child has
       a real ASIN (not "-"), with title / bullets / images matching the
-      request. The processing report parsed to 0 BLOCKING errors (a
-      missing-image 18320 is not blocking).
+      request. The LATEST processing report for EVERY batch parsed
+      (`parse-feedback`) to zero errors of ANY severity EXCEPT a
+      missing-image 18320. This includes non-fatal "SUCCESS (OTHER) /
+      Action required" errors (e.g. 100476 Item Highlight): the SKU is in
+      inventory yet the error is unresolved -- that is NOT done. Presence
+      in inventory alone never satisfies this.
     - For a delete, the SKU no longer appears in Manage Inventory.
     - No partial family (parent live but a child missing) is called done.
   evidence:
@@ -19,8 +23,10 @@ review:
   verify_by: |
     Open Manage Inventory (skucentral?mSku=<sku>, no &condition=New) for
     each attempted SKU and confirm it exists with the intended content
-    and a real ASIN; open the downloaded processing report and confirm 0
-    blocking errors. For a delete, confirm the SKU is gone.
+    and a real ASIN; download the LATEST processing report for EVERY
+    batch you uploaded and `parse-feedback` it -- confirm zero errors except
+    18320. Do NOT accept a batch shown "Action required / SUCCESS (OTHER)"
+    (e.g. 100476) as done. For a delete, confirm the SKU is gone.
 ---
 
 # Amazon — Listing CRUD (flat-file upload)
@@ -177,7 +183,15 @@ a family that the parent shows **"Variations (N)"**.
   ("main image is missing") error is *expected noise*, not a blocker;
   don't chase it, and don't hotlink a supplier CDN URL into
   `main_image_url` (Amazon can't fetch a referer-protected 1688/alibaba
-  URL anyway). "Done" = every error resolved **except** the image one.
+  URL anyway). "Done" = every error resolved **except** the image one —
+  and that means **`parse-feedback` the report, not eyeball inventory**. A
+  record can post as **SUCCESS (OTHER)** ("Action required", 0 successful):
+  it *appears* in inventory but carries an unresolved, fixable error —
+  e.g. **100476** ("Provide an Item Name ≤75 chars to use Item
+  Highlights") when `title_differentiation` (Item Highlight) was filled on
+  a long-title item. That is **NOT done**: fix the exact field the report
+  names (Item Highlight is optional — clear it; the colour belongs in
+  `color_name`) and re-upload. Only 18320 is a legit deferral.
 - **A buyable child that `8560`s ("doesn't match any ASINs … include
   standard_product_id")** — Amazon is refusing to *mint a new ASIN* for
   it. Two cases, decided by whether that child's ASIN already exists:

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -341,7 +341,9 @@ detection → green "Product Spreadsheet File (Automatically detected)"); the
 2nd posts the feed (URL gains `reference_id=`). Confirm staging by
 Submit-enabled / the detected banner — the widget's "File upload was
 unsuccessful" shadow text and any red "network error" toast are stale and
-lie. Then read the report (downloaded to the same dir):
+lie. If `click_at_xy` on **Submit products** doesn't register (the button
+sits low on the page), fire it with a JS `.click()` on the `kat-button`
+instead. Then read the report (downloaded to the same dir):
 
 ```bash
 $PY $S/listing_bulk.py parse-feedback ~/.vibe-seller/downloads/<slug>/REPORT.xlsm

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -313,13 +313,9 @@ reject on.
 
 **Upload the `.txt` `fill` wrote, NOT the `.xlsm`** (an openpyxl-saved
 `.xlsm` is rejected 90502 FATAL). Drive the `kat-file-upload` widget with
-the file-chooser recipe in `browser-harness` § "Uploading a file".
-
-> **The `.txt` MUST be under `~/.vibe-seller/downloads/<slug>/`, never
-> `/tmp`.** `setFileInputFiles` reads the file in the browser process and
-> Ziniao's Chrome can't read `/tmp`, so a `/tmp` path silently no-ops —
-> Submit never enables, which looks like "the widget rejects my file". This
-> was the sole cause of failed child uploads.
+the file-chooser recipe in `browser-harness` § "Uploading a file" — which
+is also where the "keep the file in the downloads dir, not `/tmp`" rule
+lives.
 
 ```bash
 browser-use <<'PY'

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -297,7 +297,10 @@ new `parent_sku` / `variation_theme` (or clear `parent_sku` and set
 > delete task is independent and must discover SKUs from the account.
 
 ```bash
-$PY $S/listing_bulk.py fill TEMPLATE.xlsm --spec SPEC.json --out /tmp/<slug>/out.xlsm
+# Write under the store DOWNLOADS dir, NOT /tmp — the browser must read
+# the .txt to upload it, and Ziniao's Chrome can't read /tmp (§4).
+$PY $S/listing_bulk.py fill TEMPLATE.xlsm --spec SPEC.json \
+    --out ~/.vibe-seller/downloads/<slug>/out.xlsm
 ```
 
 `fill` prints a warning (never fails) for an enum value not in the
@@ -308,95 +311,51 @@ reject on.
 
 ## 4. Upload the `.txt` + read the processing report
 
-**Upload the tab-delimited `.txt` that `fill` wrote, NOT the `.xlsm`.**
-An openpyxl-saved `.xlsm` is rejected with a **90502 FATAL** ("the file
-does not contain a worksheet with a template type that is supported for
-Excel upload") — the re-save alters the macro-workbook structure Amazon
-validates, and its own remedy is to upload a tab-delimited text file.
-The `.txt` reaches real content validation, which is what you want.
+**Upload the `.txt` `fill` wrote, NOT the `.xlsm`** (an openpyxl-saved
+`.xlsm` is rejected 90502 FATAL). Drive the `kat-file-upload` widget with
+the file-chooser recipe in `browser-harness` § "Uploading a file".
 
-On the upload page the file input is a `kat-file-upload` widget. Its
-`shadowRoot input#kat-file-attachment` is an **inert placeholder** — a
-`DOM.setFileInputFiles` on it returns success but leaves `files.length`
-at **0** (verified: objectId, `backendNodeId`, and `getDocument(pierce)`
-all no-op), so DON'T set that node and DON'T click "Browse"/`file://`.
-
-The widget creates its **real** input only when the "Upload file" button
-is clicked with a **trusted** gesture, and hands it to you via
-`Page.fileChooserOpened`. Intercept the chooser, trusted-click the button,
-set the file on that `backendNodeId` (`cdp()` params are keyword args):
+> **The `.txt` MUST be under `~/.vibe-seller/downloads/<slug>/`, never
+> `/tmp`.** `setFileInputFiles` reads the file in the browser process and
+> Ziniao's Chrome can't read `/tmp`, so a `/tmp` path silently no-ops —
+> Submit never enables, which looks like "the widget rejects my file". This
+> was the sole cause of failed child uploads.
 
 ```bash
 browser-use <<'PY'
-import time
-cdp('Page.enable'); cdp('Page.setInterceptFileChooserDialog', enabled=True)
-drain_events()
+import os, time
+F = os.path.expanduser('~/.vibe-seller/downloads/<slug>/out.txt')  # browser-readable
+cdp('Page.enable'); cdp('Page.setInterceptFileChooserDialog', enabled=True); drain_events()
 box = js("""var b=document.querySelector('kat-file-upload').shadowRoot.querySelector('#select-file');
-            var r=b.getBoundingClientRect();
-            return {x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)};""")
-click_at_xy(box['x'], box['y'])          # TRUSTED click (not JS .click())
-bnid = None
+            var r=b.getBoundingClientRect(); return {x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)};""")
+click_at_xy(box['x'], box['y'])
+bnid=None
 for _ in range(8):
     time.sleep(0.5)
     for e in drain_events():
-        if 'fileChooserOpened' in str(e.get('method','')): bnid = e['params']['backendNodeId']
+        if 'fileChooserOpened' in str(e.get('method','')): bnid=e['params']['backendNodeId']
     if bnid: break
-cdp('DOM.setFileInputFiles', backendNodeId=bnid, files=['/tmp/<slug>/listing.txt'])
+cdp('DOM.setFileInputFiles', backendNodeId=bnid, files=[F])
 cdp('Page.setInterceptFileChooserDialog', enabled=False)
-print('attached to', bnid)
 PY
 ```
 
-(Generic recipe + the plain-input Method 1: `browser-harness` SKILL.md §
-"Uploading a file".)
-
-> **Submit is a TWO-CLICK flow — the first click only introspects.** On
-> the unified upload page (`/product-search/bulk`) clicking **Submit
-> products** the first time fires `listing/introspect-feed` (file-type
-> auto-detection) — it does NOT create a batch. When it returns, the page
-> shows the green **"File Type: Product Spreadsheet File (Automatically
-> detected)"** banner. You must then click **Submit products AGAIN**; only
-> the second click posts the feed and navigates to
-> `listing/status?reference_id=<batchId>…`. Watching for a batch id after a
-> single click and re-uploading when none appears is the trap that burns a
-> run. Sequence: attach → click Submit → wait for "Automatically detected"
-> → click Submit again → confirm the URL carries `reference_id=`.
->
-> **The red "Sorry! There's a network error. Try again later." banner is a
-> RED HERRING.** It is a stale toast that shows even when
-> `introspect-feed` returned **200** and the file is staged fine (verify
-> the introspect response status / the "Automatically detected" banner
-> instead). Do NOT treat it as an upload failure and do NOT re-upload on
-> it — that just spawns duplicate batches. Likewise the file widget's
-> shadow-root text carries hidden "File upload was unsuccessful" strings
-> even on a good stage — don't trust it; trust the introspect 200 + the
-> detected-file-type banner (`capture_screenshot()` + Read to see them).
-
-After the second click Amazon processes asynchronously; the batch row on
-**Check Upload Status** (`/listing/status`) shows `SKUs successful /
-submitted` and a **Download Processing Summary** link. Save it and parse
-it:
+**Submit is two clicks:** the 1st fires `introspect-feed` (file-type
+detection → green "Product Spreadsheet File (Automatically detected)"); the
+2nd posts the feed (URL gains `reference_id=`). Confirm staging by
+Submit-enabled / the detected banner — the widget's "File upload was
+unsuccessful" shadow text and any red "network error" toast are stale and
+lie. Then read the report (downloaded to the same dir):
 
 ```bash
-$PY $S/listing_bulk.py parse-feedback /tmp/<slug>/processing-summary.xlsm
+$PY $S/listing_bulk.py parse-feedback ~/.vibe-seller/downloads/<slug>/REPORT.xlsm
 ```
 
-It prints per-SKU `[Error|Warning] sku=… code=…: message`. Fix the
-flagged fields and re-upload.
-
-> **"Parent created, children N/A" (e.g. `1/8`) is a CONTENT rejection of
-> the children — NOT a browser/upload glitch.** If the batch shows a
-> reference id and the parent went live, the file uploaded FINE and
-> reached content validation; the children were rejected on their DATA.
-> **Download the Processing Summary and `parse-feedback` it** to get the
-> exact per-child reason (missing required field, `8560` no-ASIN /
-> GTIN-exempt attributes, offer/marketplace, apparel-size composite), then
-> fix those fields and re-upload the children. Do NOT conclude "the upload
-> widget is broken" and thrash on CDP/file-chooser mechanics — a live run
-> did exactly that for ~40 min and shipped an incomplete family. (A
-> brand-new variation family also often needs a second pass: the parent
-> creates first, the children attach on re-upload — so re-upload the
-> children once with a clean `fill`ed file before assuming a data error.)
+> **"Parent live, children N/A" (e.g. `1/8`) = a CONTENT rejection of the
+> children, not a browser bug** (the file uploaded fine). `parse-feedback`
+> the Processing Summary for the per-child reason and fix those fields; a
+> brand-new family often needs a second pass (parent first, children on
+> re-upload). Don't thrash the upload widget.
 
 > **The status page lists many past batches — download the report from
 > the row whose filename matches THIS upload**, or you'll parse a stale

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -4,20 +4,58 @@
 > category-specific: the column set and valid values differ per product
 > type, so `inspect` a fresh template before filling it.
 
-## 0. The template geometry (verified on a real fptcustom template)
+## 0. The template geometry (two dialects — auto-detected)
 
-The `Template` sheet is a wide table with a **three-row header**:
+Amazon ships **two** flat-file templates and `listing_bulk.py` handles
+both; `inspect` prints which (`dialect: legacy` / `dialect: unified`).
+
+**legacy (`TemplateType=fptcustom`)** — the classic flat file, a
+three-row header:
 
 ```
 Excel row 1   TemplateType=fptcustom | Version | Signature | group names
 Excel row 2   Local Label Names   (LOCALISED — e.g. "Seller SKU")
-Excel row 3   field API names     (item_sku, update_delete, ...)  <-- key on THIS
+Excel row 3   field API names     (item_sku, update_delete, ...)  <-- keyed
 Excel row 4+  data rows
 ```
 
-`listing_bulk.py` locates the field-name row structurally (the row that
-contains `item_sku`) and addresses every field by API name — **never**
-by the localised label above it. Data rows are appended from row 4.
+**unified (NGS "Beta Product Spreadsheet")** — the current Seller Central
+template, a five-row header and PREFILLED example rows:
+
+```
+Excel row 1   settings=feedType=…&labelRow=4&attributeRow=5&dataRow=8…  (signature blob)
+Excel row 2   instructions ("Use ENGLISH … do not delete the colored head")
+Excel row 3   group names (Listing Identity | Variations | …)
+Excel row 4   Local Label Names   (LOCALISED)
+Excel row 5   field API names     <-- keyed
+Excel row 6-7 PREFILLED example SKU + a "do not delete this row" instruction
+Excel row 8+  where the UI expects your data
+```
+
+Every field name in the unified dialect is **decorated**: the SKU is
+`contribution_sku#1.value`, the operation is `::record_action` (tokens
+`Create or Replace (Full Update)` / `Edit (Partial Update)` / `Delete`),
+parentage is `parentage_level[marketplace_id=<id>]#1.value`, the parent
+link is `child_parent_sku_relationship[marketplace_id=<id>]#1.parent_sku`,
+the theme is `variation_theme#1.name`, the brand/title are
+`…[marketplace_id=<id>][language_tag=<tag>]#1.value`, the product id is
+`amzn1.volt.ca.product_id{_type,_value}`, and the offer price carries an
+`[audience=ALL]` insert
+(`purchasable_offer[marketplace_id=<id>][audience=ALL]#1.our_price…`).
+
+`listing_bulk.py` locates the field-name row **structurally** (the row
+carrying the SKU column — `item_sku` OR `contribution_sku`) and resolves
+every friendly role from the header, so the **same spec drives either
+dialect** — never key on a fixed row number or the localised label row.
+
+> **`fill` clears the prefilled example/instruction rows for you.** The
+> unified template ships an example SKU + a "do not delete this row"
+> instruction in the data area. **Do NOT hand-roll the upload file** — a
+> hand-rolled file that appends your SKUs *after* those rows uploads the
+> example + instruction as if they were real SKUs (a live run got
+> **"1/8 successful"** that way: only the parent created, the junk rows
+> and the children failed). `fill` deletes everything below the field-name
+> row before writing, so only your SKUs ship.
 
 The metadata sheets are the source of truth:
 
@@ -310,14 +348,34 @@ PY
 ```
 
 (Generic recipe + the plain-input Method 1: `browser-harness` SKILL.md §
-"Uploading a file".) Amazon stages the file, showing the filename +
-green **"File Type … (Automatically detected)"** and enabling **Submit
-products**. Confirm via `capture_screenshot()` + Read (the shadow-root
-text carries hidden "unsuccessful" strings even on success — don't trust
-it). Then `click_at_xy` **Submit products** and `wait_for_load()`. Amazon
-processes asynchronously; the batch row on **Check Upload Status** shows
-`SKUs successful / submitted` and a **Download Processing Summary** link.
-Save it and parse it:
+"Uploading a file".)
+
+> **Submit is a TWO-CLICK flow — the first click only introspects.** On
+> the unified upload page (`/product-search/bulk`) clicking **Submit
+> products** the first time fires `listing/introspect-feed` (file-type
+> auto-detection) — it does NOT create a batch. When it returns, the page
+> shows the green **"File Type: Product Spreadsheet File (Automatically
+> detected)"** banner. You must then click **Submit products AGAIN**; only
+> the second click posts the feed and navigates to
+> `listing/status?reference_id=<batchId>…`. Watching for a batch id after a
+> single click and re-uploading when none appears is the trap that burns a
+> run. Sequence: attach → click Submit → wait for "Automatically detected"
+> → click Submit again → confirm the URL carries `reference_id=`.
+>
+> **The red "Sorry! There's a network error. Try again later." banner is a
+> RED HERRING.** It is a stale toast that shows even when
+> `introspect-feed` returned **200** and the file is staged fine (verify
+> the introspect response status / the "Automatically detected" banner
+> instead). Do NOT treat it as an upload failure and do NOT re-upload on
+> it — that just spawns duplicate batches. Likewise the file widget's
+> shadow-root text carries hidden "File upload was unsuccessful" strings
+> even on a good stage — don't trust it; trust the introspect 200 + the
+> detected-file-type banner (`capture_screenshot()` + Read to see them).
+
+After the second click Amazon processes asynchronously; the batch row on
+**Check Upload Status** (`/listing/status`) shows `SKUs successful /
+submitted` and a **Download Processing Summary** link. Save it and parse
+it:
 
 ```bash
 $PY $S/listing_bulk.py parse-feedback /tmp/<slug>/processing-summary.xlsm
@@ -325,6 +383,20 @@ $PY $S/listing_bulk.py parse-feedback /tmp/<slug>/processing-summary.xlsm
 
 It prints per-SKU `[Error|Warning] sku=… code=…: message`. Fix the
 flagged fields and re-upload.
+
+> **"Parent created, children N/A" (e.g. `1/8`) is a CONTENT rejection of
+> the children — NOT a browser/upload glitch.** If the batch shows a
+> reference id and the parent went live, the file uploaded FINE and
+> reached content validation; the children were rejected on their DATA.
+> **Download the Processing Summary and `parse-feedback` it** to get the
+> exact per-child reason (missing required field, `8560` no-ASIN /
+> GTIN-exempt attributes, offer/marketplace, apparel-size composite), then
+> fix those fields and re-upload the children. Do NOT conclude "the upload
+> widget is broken" and thrash on CDP/file-chooser mechanics — a live run
+> did exactly that for ~40 min and shipped an incomplete family. (A
+> brand-new variation family also often needs a second pass: the parent
+> creates first, the children attach on re-upload — so re-upload the
+> children once with a clean `fill`ed file before assuming a data error.)
 
 > **The status page lists many past batches — download the report from
 > the row whose filename matches THIS upload**, or you'll parse a stale

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -455,6 +455,16 @@ def cmd_fill(args):
             f'{sorted(unknown_fields)}',
             file=sys.stderr,
         )
+    # The browser (Ziniao/macOS) can't read /tmp, so uploading a /tmp file
+    # silently no-ops (Submit never enables). Nudge the caller to write
+    # under the store downloads dir instead.
+    if os.path.realpath(txt_path).startswith(('/tmp/', '/private/tmp/')):
+        print(
+            f'warning: {txt_path} is under /tmp -- the browser cannot read '
+            'it and the upload will silently fail. Write --out under '
+            '~/.vibe-seller/downloads/<slug>/ instead.',
+            file=sys.stderr,
+        )
     print(f'wrote {len(rows)} data row(s) -> {args.out}')
     print(
         f'UPLOAD THIS (tab-delimited) -> {txt_path}  '

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -102,6 +102,7 @@ from listing_schema import (  # noqa: E402, F401
     ROLE_MATCHERS as _ROLE_MATCHERS,
     TEMPLATE_SHEET,
     Schema as _Schema,
+    base_attr as _base_attr,
     data_start_row as _data_start_row,
     field_columns as _field_columns,
     find_header_row as _find_header_row,
@@ -119,6 +120,19 @@ from marketplace_ids import (  # noqa: E402,F401
 )
 
 _OFFER_PRICE_SHORTHANDS = ('our_price', 'price', 'standard_price')
+
+# Item Highlight (`title_differentiation`) is an OPTIONAL field Amazon only
+# accepts when the Item Name is <= 75 chars; a longer title makes Amazon
+# reject the highlight with error 100476 ("Provide an Item Name that is 75
+# characters or less to use Item Highlights") -- a non-blocking SUCCESS
+# (OTHER) error that leaves the SKU in inventory but flagged "Action
+# required". The marketing item_name is routinely > 75 chars, so a spec
+# that fills Item Highlight (e.g. with the colour) silently poisons every
+# child. `fill` drops the optional highlight when the title is too long so
+# the SKU lands clean; the value belongs in `color_name`, never here.
+_ITEM_HIGHLIGHT_ATTR = 'title_differentiation'
+_ITEM_NAME_ATTR = 'item_name'
+_ITEM_HIGHLIGHT_MAX_TITLE = 75
 
 # A Parent row carries only shared catalogue data; offer, stock, images
 # and product-id live on Child rows -- so a Parent legitimately omits
@@ -282,6 +296,15 @@ def _row_fields(spec_row, top, schema):
     if spec_row.get('asin'):
         put('product_id', spec_row['asin'])
         put('product_id_type', 'asin', overwrite=False)
+    # Offer shorthands (`our_price`/`price`/`quantity`) belong in `fields`,
+    # but the skill tells the agent to put "a bare our_price/quantity on
+    # each child" -- naturally read as a ROW-LEVEL key. Fold those from the
+    # row into fields (a value already in `fields` wins) so the price/stock
+    # routes to the target marketplace either way, instead of being
+    # silently dropped -> an empty offer column the agent then hand-picks.
+    for k in (*_OFFER_PRICE_SHORTHANDS, 'quantity'):
+        if spec_row.get(k) not in (None, '') and k not in out:
+            out[k] = spec_row[k]
     # Drop keys with no value so we never blank an intended default.
     return {k: v for k, v in out.items() if v not in (None, '')}
 
@@ -340,6 +363,35 @@ def _route_offer_price(fields, cols, mkt_id, i, sku, warnings):
                     tgt = f'fulfillment_availability#{n}.{k.split(".", 1)[1]}'
                     if tgt != k:
                         fields[tgt] = fields.pop(k)
+
+
+def _drop_unusable_item_highlight(fields, i, sku, warnings):
+    """Drop an optional Item Highlight when the Item Name is too long.
+
+    Amazon only accepts `title_differentiation` (Item Highlight) when the
+    row's `item_name` is <= 75 chars; otherwise it returns error 100476 and
+    parks the SKU in "Action required" (SUCCESS OTHER). The field is
+    OPTIONAL, so when the title exceeds the limit we drop the highlight and
+    warn rather than upload a value that guarantees a rejection. Mutates
+    ``fields``. No-op when no highlight is set or the title fits.
+    """
+    hi = next(
+        (k for k in fields if _base_attr(k) == _ITEM_HIGHLIGHT_ATTR), None
+    )
+    if hi is None or not str(fields[hi]).strip():
+        return
+    name = next(
+        (v for k, v in fields.items() if _base_attr(k) == _ITEM_NAME_ATTR), ''
+    )
+    if len(str(name)) > _ITEM_HIGHLIGHT_MAX_TITLE:
+        dropped = fields.pop(hi)
+        warnings.append(
+            f'row {i} sku={sku}: dropped Item Highlight '
+            f'({hi}={dropped!r}) -- item_name is '
+            f'{len(str(name))} chars (> {_ITEM_HIGHLIGHT_MAX_TITLE}), which '
+            f'Amazon rejects with error 100476. Item Highlight is optional; '
+            f'put the colour in color_name, not here.'
+        )
 
 
 def cmd_fill(args):
@@ -401,6 +453,10 @@ def cmd_fill(args):
         # so it can't land in the wrong `purchasable_offer` block (which
         # creates an ASIN-only listing stuck in "Missing offer").
         _route_offer_price(fields, cols, mkt_id, i, sku, warnings)
+
+        # Drop an optional Item Highlight the title is too long for, so it
+        # can't poison the SKU with a 100476 rejection (SUCCESS OTHER).
+        _drop_unusable_item_highlight(fields, i, sku, warnings)
 
         # Enum validation: reject an invalid operation-family token hard;
         # warn (never fail) on other enums so an unseen-but-valid token
@@ -613,8 +669,13 @@ def cmd_parse_feedback(args):
         )
         if n_err:
             print(
-                'Fix ALL errors (parent first) and re-upload; a SKU with '
-                'any error is NOT created (feed "successful" != live).'
+                'NOT DONE. Fix ALL errors (parent first) and re-upload. A '
+                'SKU with any error is either not created OR created but '
+                'flagged "Action required" (SUCCESS OTHER) -- it shows up in '
+                'inventory yet the error is UNRESOLVED. Inventory presence '
+                'is NOT "done"; only 18320 (missing main image) is a legit '
+                'deferral. Re-run parse-feedback on the new report until the '
+                'sole remaining error is 18320.'
             )
             # Non-zero exit so a caller/CI sees the feed had blocking
             # errors -- matches the table-scan path below.

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -45,9 +45,12 @@ Template geometry
   legacy : row 1 TemplateType/signature | row 2 localised labels |
            row 3 field API names <-- keyed | row 4+ data
   unified: rows 1-4 settings/instructions/group/localised labels |
-           row 5 field API names <-- keyed | row 6+ data
-Both are found structurally (the row carrying the SKU field), never by a
-fixed row number.
+           row 5 field API names <-- keyed | rows 6..dataRow-1 a SKIPPED
+           example region | data from `dataRow` (the row-1 settings blob's
+           `dataRow=N`, e.g. 8)
+The field-name row is found structurally (the row carrying the SKU field);
+data is written at `dataRow` (legacy: field-name row + 1), never by a
+guessed fixed number.
 
 The operation column (`update_delete` legacy / `::record_action`
 unified):
@@ -99,6 +102,7 @@ from listing_schema import (  # noqa: E402, F401
     ROLE_MATCHERS as _ROLE_MATCHERS,
     TEMPLATE_SHEET,
     Schema as _Schema,
+    data_start_row as _data_start_row,
     field_columns as _field_columns,
     find_header_row as _find_header_row,
     is_sku_field as _is_sku_field,
@@ -207,12 +211,13 @@ def cmd_inspect(args):
         print(f'  values  : {dig(name)}')
         return
 
-    tt = ws.cell(row=1, column=1).value
+    tt = str(ws.cell(row=1, column=1).value or '')
     op_field = schema.field('operation')
-    print(f'template : {tt}')
+    data_row = _data_start_row(ws, header_row)
+    print(f'template : {tt[:80]}')
     print(f'dialect  : {schema.dialect}')
     print(f'sheets   : {wb.sheetnames}')
-    print(f'header at Excel row {header_row}; data starts row {header_row + 1}')
+    print(f'header at Excel row {header_row}; data starts row {data_row}')
     print(f'total fields: {len(cols)}   required fields: {len(required)}')
     print(
         '\noperation column ({}): create=blank / {}'.format(
@@ -367,12 +372,17 @@ def cmd_fill(args):
 
     unknown_fields = set()
     warnings = []
-    write_at = header_row + 1
-    # Clear pre-existing data rows first, so the template's prefilled
+    # Data begins at the template's data row (unified: the `dataRow=N` the
+    # settings blob names, with rows header_row+1..N-1 an example region
+    # Amazon SKIPS; legacy: header_row+1). Writing into that skipped gap
+    # silently drops SKUs.
+    write_at = _data_start_row(ws, header_row)
+    # Clear everything below the field-name row, so the template's prefilled
     # Example row (and its "do not delete this row" instruction row) or a
-    # reused workbook's stale rows can't upload as unintended SKUs.
-    if ws.max_row >= write_at:
-        ws.delete_rows(write_at, ws.max_row - write_at + 1)
+    # reused workbook's stale rows can't upload as unintended SKUs; the gap
+    # rows above write_at are then re-emitted empty by the TSV export.
+    if ws.max_row > header_row:
+        ws.delete_rows(header_row + 1, ws.max_row - header_row)
     for i, spec_row in enumerate(rows):
         op_token, op_key = _resolve_operation(
             spec_row.get('operation'), schema.dialect

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -2,9 +2,8 @@
 """Amazon listing flat-file (category template) inspect + fill + feedback.
 
 Drives the "Add Products via Upload" round trip: download a category
-template (a macro-enabled `.xlsm` flat file, TemplateType=fptcustom),
-fill parent/child rows from a JSON spec, upload it, then parse the
-processing report Amazon returns.
+template (a macro-enabled `.xlsm` flat file), fill parent/child rows from
+a JSON spec, upload it, then parse the processing report Amazon returns.
 
 Why a script (vs. clicking the listing wizard)
 ----------------------------------------------
@@ -15,23 +14,47 @@ supported batch interface -- the same philosophy as `amazon-ads`'
 `ads_bulk.py`, but listing templates are **category-specific** (the
 column set differs per product type), so this tool cannot use a fixed
 positional schema. Instead it keys every field by its **field API name**
-(the row that contains `item_sku`), which is identical in every console
-language -- only the human label row above it is localised.
+(the row that contains the SKU column), which is identical in every
+console language -- only the human label row above it is localised.
 
-Template geometry (verified on a real fptcustom template)
----------------------------------------------------------
-  Excel row 1  TemplateType/Version/Signature + group names
-  Excel row 2  Local Label Names  (LOCALISED -- never keyed on)
-  Excel row 3  field API names    (item_sku, update_delete, ...) <-- keyed
-  Excel row 4+ data rows
+Two template dialects
+---------------------
+Amazon ships two flat-file templates and the tool auto-detects which:
 
-The operation column is `update_delete`:
-  blank  -> Create   (the default when no ASIN is supplied)
-  Update / partialupdate / delete
-The parent-child cluster is `parent_child` (Parent/Child),
-`relationship_type` (Variation), `variation_theme` (e.g. Color),
-`parent_sku`. Update-by-ASIN sets `external_product_id` = the ASIN and
-`external_product_id_type` = asin.
+  legacy  (TemplateType=fptcustom) -- the classic flat file. Field API
+          names are bare: `item_sku`, `update_delete`, `parent_child`,
+          `relationship_type`, `variation_theme`, `parent_sku`,
+          `external_product_id[_type]`.
+  unified (NGS "Beta Product Spreadsheet") -- the current Seller Central
+          template. Every field name is decorated: the SKU is
+          `contribution_sku#1.value`, the operation is `::record_action`,
+          parentage is `parentage_level[marketplace_id=<id>]#1.value`, the
+          parent link is
+          `child_parent_sku_relationship[marketplace_id=<id>]#1.parent_sku`,
+          the theme is `variation_theme#1.name`, and the product id lives
+          in `amzn1.volt.ca.product_id{_type,_value}`.
+
+Every field the tool addresses by a friendly role (sku, operation,
+product_type, brand, parentage, parent_sku, variation_theme, product id,
+offer price) is resolved STRUCTURALLY from the header (`_Schema`), so the
+same spec drives either dialect. Fields not covered by a role are still
+addressed by their exact API name via the spec's `fields` map.
+
+Template geometry
+-----------------
+  legacy : row 1 TemplateType/signature | row 2 localised labels |
+           row 3 field API names <-- keyed | row 4+ data
+  unified: rows 1-4 settings/instructions/group/localised labels |
+           row 5 field API names <-- keyed | row 6+ data
+Both are found structurally (the row carrying the SKU field), never by a
+fixed row number.
+
+The operation column (`update_delete` legacy / `::record_action`
+unified):
+  blank -> Create (the default when no ASIN is supplied)
+  update / partialupdate / delete map to each dialect's own tokens.
+Update-by-ASIN sets the product-id field to the ASIN and its type to
+`asin`.
 
 The template's own sheets are the source of truth for validation:
   'Data Definitions'  -> which fields are Required
@@ -66,6 +89,24 @@ except ImportError:
 # The script dir is on sys.path when run as a CLI; add it for path-based
 # imports (tests) too.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Template structure + metadata parsing live in a sibling module so this
+# file stays within the line cap. Public names there; alias to the
+# `_`-prefixed internal names used here (and re-exported for tests).
+from listing_schema import (  # noqa: E402, F401
+    DEFN_SHEET,
+    DROPDOWN_SHEET,
+    OP_TOKENS as _OP_TOKENS,
+    ROLE_MATCHERS as _ROLE_MATCHERS,
+    TEMPLATE_SHEET,
+    Schema as _Schema,
+    field_columns as _field_columns,
+    find_header_row as _find_header_row,
+    is_sku_field as _is_sku_field,
+    load_required_fields as _load_required_fields,
+    load_valid_values as _load_valid_values,
+    our_price_col as _our_price_col,
+    valid_value_case as _valid_value_case,
+)
 from marketplace_ids import (  # noqa: E402,F401
     MARKETPLACE_IDS,  # re-exported for callers/tests
     fulfillment_index as _fulfillment_index_for_marketplace,
@@ -73,54 +114,26 @@ from marketplace_ids import (  # noqa: E402,F401
     resolve as _resolve_marketplace_id,
 )
 
-# The Template sheet holds the flat file. Metadata lives in siblings.
-TEMPLATE_SHEET = 'Template'
-DEFN_SHEET = 'Data Definitions'
-VALID_SHEET = 'Valid Values'
-DROPDOWN_SHEET = 'Dropdown Lists'
-
-# The operation column and the tokens Amazon accepts in it. A blank
-# cell means Create -- that is the default and cannot be a literal
-# token, so callers pass operation='create' and we clear the cell.
-OP_COLUMN = 'update_delete'
-OP_TOKENS = {
-    'create': '',
-    'update': 'Update',
-    'partialupdate': 'partialupdate',
-    'delete': 'delete',
-}
-
-# Fields the caller addresses through friendly per-row keys, mapped to
-# their flat-file field API name. Everything else goes in `fields`.
-IDENTITY_FIELD = 'item_sku'
-PRODUCT_TYPE_FIELD = 'feed_product_type'
-BRAND_FIELD = 'brand_name'
-
-# Price MUST go in the `purchasable_offer[marketplace_id=<id>]` block for
-# the marketplace being listed on, else the product is ASIN-only ("Missing
-# offer", never live). The full country->id table and the resolver live in
-# `marketplace_ids`; the id is read straight off the template's columns.
-
-# Bare `our_price` + top-level `marketplace` -> the exact marketplace-
-# scoped column, so the price can never land in the wrong block.
-_OUR_PRICE_TEMPLATE = (
-    'purchasable_offer[marketplace_id={id}]#1.our_price#1.schedule'
-    '#1.value_with_tax'
-)
 _OFFER_PRICE_SHORTHANDS = ('our_price', 'price', 'standard_price')
 
 # A Parent row carries only shared catalogue data; offer, stock, images
 # and product-id live on Child rows -- so a Parent legitimately omits
-# these even when the template marks them Required (don't warn).
+# these even when the template marks them Required (don't warn). Prefixes
+# cover both dialects (`color_name`/legacy id vs `color`/`amzn1.volt.ca`).
 CHILD_LEVEL_PREFIXES = (
     'purchasable_offer',
     'fulfillment_availability',
     'main_image_url',
+    'main_product_image',
     'other_image_url',
+    'other_product_image',
     'swatch_image_url',
     'external_product_id',
+    'amzn1.volt.ca.product_id',
     'color_name',
+    'color[',
     'size_name',
+    'size[',
     'apparel_size',
 )
 
@@ -150,132 +163,6 @@ def _keep_vba(path):
     return path.lower().endswith('.xlsm')
 
 
-def _find_header_row(ws, max_scan=8):
-    """Return the 1-based row index whose cells carry field API names.
-
-    Identified structurally by the presence of `item_sku`, so it works
-    regardless of console language (the label row above it is localised;
-    this row is not).
-    """
-    for r in range(1, max_scan + 1):
-        values = [c.value for c in ws[r]]
-        if IDENTITY_FIELD in values:
-            return r
-    raise ValueError(
-        f"could not find the field-name row (no '{IDENTITY_FIELD}' in the "
-        f'first {max_scan} rows) -- is this a listing flat-file template?'
-    )
-
-
-def _field_columns(ws, header_row):
-    """Map field API name -> list of 1-based column indices.
-
-    Repeated fields (bullet_point1..N are distinct, but some templates
-    reuse a bare name across marketplace-scoped offer blocks) map to
-    multiple columns; the first is used for scalar writes.
-    """
-    cols = {}
-    for cell in ws[header_row]:
-        name = cell.value
-        if name:
-            cols.setdefault(str(name), []).append(cell.column)
-    return cols
-
-
-def _load_required_fields(wb):
-    """Field API names marked Required in the Data Definitions sheet.
-
-    Data Definitions layout: header at Excel row 2, then per-field rows
-    with columns Group Name | Field Name | Local Label | Definition |
-    Accepted Values | Example | Required?.
-    """
-    if DEFN_SHEET not in wb.sheetnames:
-        return set()
-    ws = wb[DEFN_SHEET]
-    rows = list(ws.iter_rows(values_only=True))
-    required = set()
-    for row in rows[2:]:
-        if not row or len(row) < 7:
-            continue
-        field_name, req = row[1], row[6]
-        if field_name and req and str(req).strip().lower() == 'required':
-            required.add(str(field_name).strip())
-    return required
-
-
-def _load_valid_values(wb):
-    """Map field API name -> set of accepted enum tokens (lowercased).
-
-    Read from 'Dropdown Lists', whose row 3 holds field API names as
-    column headers and the rows below hold the tokens for each. Returns
-    {} silently if the sheet is absent or shaped unexpectedly -- enum
-    checks then degrade to warnings only.
-    """
-    if DROPDOWN_SHEET not in wb.sheetnames:
-        return {}
-    ws = wb[DROPDOWN_SHEET]
-    rows = list(ws.iter_rows(values_only=True))
-    if len(rows) < 4:
-        return {}
-    # The field-name header inside Dropdown Lists is the row that
-    # contains a known enum field; probe the first few rows for it.
-    hdr_idx = None
-    for i in range(min(5, len(rows))):
-        if rows[i] and OP_COLUMN in [str(c) for c in rows[i] if c]:
-            hdr_idx = i
-            break
-    if hdr_idx is None:
-        return {}
-    hdr = rows[hdr_idx]
-    out = {}
-    for ci, name in enumerate(hdr):
-        if not name:
-            continue
-        vals = set()
-        for ri in range(hdr_idx + 1, len(rows)):
-            v = rows[ri][ci] if ci < len(rows[ri]) else None
-            if v not in (None, ''):
-                vals.add(str(v).strip().lower())
-        if vals:
-            out[str(name).strip()] = vals
-    return out
-
-
-def _valid_value_case(wb):
-    """Map field API name -> {lowercased token: template's exact-case token}.
-
-    Amazon rejects a case-mismatched enum on some fields (verified live:
-    `apparel_size_system` accepts `UAE/KSA` but rejects `uae/ksa`), so a
-    spec value must be written in the template's own case. This mirrors
-    `_load_valid_values` but keeps the original casing as the value.
-    """
-    if DROPDOWN_SHEET not in wb.sheetnames:
-        return {}
-    ws = wb[DROPDOWN_SHEET]
-    rows = list(ws.iter_rows(values_only=True))
-    if len(rows) < 4:
-        return {}
-    hdr_idx = None
-    for i in range(min(5, len(rows))):
-        if rows[i] and OP_COLUMN in [str(c) for c in rows[i] if c]:
-            hdr_idx = i
-            break
-    if hdr_idx is None:
-        return {}
-    out = {}
-    for ci, name in enumerate(rows[hdr_idx]):
-        if not name:
-            continue
-        m = {}
-        for ri in range(hdr_idx + 1, len(rows)):
-            v = rows[ri][ci] if ci < len(rows[ri]) else None
-            if v not in (None, ''):
-                m[str(v).strip().lower()] = str(v).strip()
-        if m:
-            out[str(name).strip()] = m
-    return out
-
-
 def _export_tsv(ws, path):
     """Write the Template sheet as a tab-delimited .txt (the upload file).
 
@@ -283,8 +170,10 @@ def _export_tsv(ws, path):
     90502 FATAL ("worksheet template type not supported for Excel
     upload") because the re-save alters the macro-workbook structure it
     validates. Its own remedy is to upload a tab-delimited text file, so
-    this is the artefact you actually upload -- keyed by the row-3 field
-    names, uniform column count so nothing shifts.
+    this is the artefact you actually upload -- the WHOLE sheet including
+    the settings/signature/label header block (Amazon's introspect-feed
+    keys on it to detect the file type), uniform column count so nothing
+    shifts.
     """
     max_c = ws.max_column
     with open(path, 'w', newline='', encoding='utf-8') as fh:
@@ -302,6 +191,7 @@ def cmd_inspect(args):
     ws = wb[TEMPLATE_SHEET]
     header_row = _find_header_row(ws)
     cols = _field_columns(ws, header_row)
+    schema = _Schema(cols)
     required = _load_required_fields(wb)
     valid = _load_valid_values(wb)
 
@@ -318,67 +208,75 @@ def cmd_inspect(args):
         return
 
     tt = ws.cell(row=1, column=1).value
+    op_field = schema.field('operation')
     print(f'template : {tt}')
+    print(f'dialect  : {schema.dialect}')
     print(f'sheets   : {wb.sheetnames}')
     print(f'header at Excel row {header_row}; data starts row {header_row + 1}')
     print(f'total fields: {len(cols)}   required fields: {len(required)}')
     print(
         '\noperation column ({}): create=blank / {}'.format(
-            OP_COLUMN, ' / '.join(t for t in OP_TOKENS.values() if t)
+            op_field,
+            ' / '.join(t for t in schema.op_tokens().values() if t),
         )
     )
-    print('\nvariation cluster:')
-    for f in (
-        'parent_child',
-        'relationship_type',
-        'variation_theme',
-        'parent_sku',
-        'external_product_id',
-        'external_product_id_type',
-    ):
-        if f in cols:
-            print(f'  {f:26} col={cols[f][0]:<4} values={dig(f)}')
+    # The resolved logical roles: the actual columns a spec's friendly keys
+    # (and offer-price routing) write to for THIS template's dialect.
+    print('\nresolved roles (friendly key -> the column it fills):')
+    for role in _ROLE_MATCHERS:
+        name = schema.field(role)
+        if name:
+            print(f'  {role:16} -> {name}   values={dig(name)}')
     print('\nrequired fields:')
     for f in sorted(required):
         print(f'  {f:30} values={dig(f)}')
 
 
-def _resolve_operation(op):
+def _resolve_operation(op, dialect):
+    tokens = _OP_TOKENS[dialect]
     key = (op or 'create').strip().lower()
-    if key not in OP_TOKENS:
+    if key not in tokens:
         raise SystemExit(
-            f"error: operation '{op}' is not one of {', '.join(OP_TOKENS)}"
+            f"error: operation '{op}' is not one of {', '.join(tokens)}"
         )
-    return OP_TOKENS[key], key
+    return tokens[key], key
 
 
-def _row_fields(spec_row, top):
+def _row_fields(spec_row, top, schema):
     """Flatten one spec row into {field_api_name: value}.
 
     Friendly per-row keys (sku, asin, parent_sku, parentage,
-    variation_theme) fold into their flat-file field names; `fields`
+    variation_theme) fold into their flat-file field names -- resolved
+    through `schema` so the SAME spec drives either dialect; `fields`
     carries everything else verbatim by API name. Top-level `product_type`
     and `brand` supply defaults when a row omits them.
     """
     out = dict(spec_row.get('fields') or {})
-    out.setdefault(PRODUCT_TYPE_FIELD, top.get('product_type'))
-    if top.get('brand'):
-        out.setdefault(BRAND_FIELD, top['brand'])
-    if spec_row.get('sku'):
-        out[IDENTITY_FIELD] = spec_row['sku']
-    if spec_row.get('parent_sku'):
-        out['parent_sku'] = spec_row['parent_sku']
-    if spec_row.get('parentage'):
-        out['parent_child'] = spec_row['parentage']
-    if spec_row.get('variation_theme'):
-        out['variation_theme'] = spec_row['variation_theme']
-    # Any variation row MUST carry relationship_type or a child errors
-    # "relationship_type = null" and never creates. Derive it (explicit wins).
-    if spec_row.get('parentage') or spec_row.get('variation_theme'):
+
+    def put(role, value, overwrite=True):
+        name = schema.field(role)
+        if name and value not in (None, ''):
+            if overwrite or name not in out:
+                out[name] = value
+
+    put('product_type', top.get('product_type'), overwrite=False)
+    put('brand', top.get('brand'), overwrite=False)
+    put('sku', spec_row.get('sku'))
+    put('parent_sku', spec_row.get('parent_sku'))
+    put('parentage', spec_row.get('parentage'))
+    put('variation_theme', spec_row.get('variation_theme'))
+    # A legacy variation row MUST carry relationship_type or a child errors
+    # "relationship_type = null" and never creates (explicit wins). The
+    # unified template has no such column -- the parent link is carried by
+    # parentage_level + child_parent_sku_relationship -- so only add it when
+    # the template actually has a `relationship_type` column.
+    if (spec_row.get('parentage') or spec_row.get('variation_theme')) and (
+        'relationship_type' in schema.cols
+    ):
         out.setdefault('relationship_type', 'Variation')
     if spec_row.get('asin'):
-        out['external_product_id'] = spec_row['asin']
-        out.setdefault('external_product_id_type', 'asin')
+        put('product_id', spec_row['asin'])
+        put('product_id_type', 'asin', overwrite=False)
     # Drop keys with no value so we never blank an intended default.
     return {k: v for k, v in out.items() if v not in (None, '')}
 
@@ -392,7 +290,7 @@ def _route_offer_price(fields, cols, mkt_id, i, sku, warnings):
     only WARN when the target marketplace ends up with no price -- the
     "Missing offer / never live" trap. Mutates ``fields``.
     """
-    target_col = _OUR_PRICE_TEMPLATE.format(id=mkt_id) if mkt_id else None
+    target_col = _our_price_col(cols, mkt_id)
     shorthand = next((k for k in _OFFER_PRICE_SHORTHANDS if k in fields), None)
     if shorthand:
         if mkt_id is None:
@@ -400,13 +298,13 @@ def _route_offer_price(fields, cols, mkt_id, i, sku, warnings):
                 f'error: row {i} sku={sku} sets a price but the spec has no '
                 f'\'marketplace\' -- add e.g. "marketplace": "SA"'
             )
-        if target_col not in cols:
+        if target_col is None:
             raise SystemExit(
                 f'error: row {i} sku={sku}: template has no offer column for '
                 f'marketplace_id={mkt_id} (account may not sell there)'
             )
         fields[target_col] = fields.pop(shorthand)
-    if mkt_id is not None and target_col not in fields:
+    if mkt_id is not None and (target_col is None or target_col not in fields):
         other = [
             k
             for k in fields
@@ -453,6 +351,8 @@ def cmd_fill(args):
     ws = wb[TEMPLATE_SHEET]
     header_row = _find_header_row(ws)
     cols = _field_columns(ws, header_row)
+    schema = _Schema(cols)
+    op_field = schema.field('operation')
     required = _load_required_fields(wb)
     valid = _load_valid_values(wb)
     case = _valid_value_case(wb)
@@ -468,14 +368,22 @@ def cmd_fill(args):
     unknown_fields = set()
     warnings = []
     write_at = header_row + 1
-    # Clear pre-existing data rows first, so an Example row or a reused
-    # workbook's stale rows can't upload as unintended SKUs.
+    # Clear pre-existing data rows first, so the template's prefilled
+    # Example row (and its "do not delete this row" instruction row) or a
+    # reused workbook's stale rows can't upload as unintended SKUs.
     if ws.max_row >= write_at:
         ws.delete_rows(write_at, ws.max_row - write_at + 1)
     for i, spec_row in enumerate(rows):
-        op_token, op_key = _resolve_operation(spec_row.get('operation'))
-        fields = _row_fields(spec_row, spec)
-        sku = fields.get(IDENTITY_FIELD)
+        op_token, op_key = _resolve_operation(
+            spec_row.get('operation'), schema.dialect
+        )
+        fields = _row_fields(spec_row, spec, schema)
+        # Map any bare/undecorated content field name to this template's
+        # actual column (unified decorates them), so the SAME spec fills
+        # either dialect. Offer shorthands (our_price/quantity) have no
+        # column of their own and pass through to _route_offer_price.
+        fields = {schema.resolve_field(k): v for k, v in fields.items()}
+        sku = fields.get(schema.field('sku'))
         if not sku:
             raise SystemExit(f'error: row {i} has no sku')
 
@@ -498,13 +406,14 @@ def cmd_fill(args):
         # Required-field guard applies to Create rows only. Update/
         # partialupdate touch a subset; delete needs just sku+operation.
         if op_key == 'create':
-            is_parent = str(fields.get('parent_child', '')).lower() == 'parent'
+            parentage = fields.get(schema.field('parentage'), '')
+            is_parent = str(parentage).lower() == 'parent'
             no_battery = _is_falsey(
                 fields.get('are_batteries_included')
             ) and _is_falsey(fields.get('batteries_required'))
             missing = []
             for f in required:
-                if f not in cols or f in fields or f == OP_COLUMN:
+                if f not in cols or f in fields or f == op_field:
                     continue
                 if is_parent and f.startswith(CHILD_LEVEL_PREFIXES):
                     continue
@@ -519,8 +428,8 @@ def cmd_fill(args):
 
         target = ws[write_at + i]
         # Operation column: write the token (blank cell = Create).
-        if OP_COLUMN in cols:
-            target[cols[OP_COLUMN][0] - 1].value = op_token or None
+        if op_field and op_field in cols:
+            target[cols[op_field][0] - 1].value = op_token or None
         for fname, fval in fields.items():
             if fname not in cols:
                 unknown_fields.add(fname)
@@ -596,7 +505,7 @@ def _template_cell_errors(path):
             c.column: str(c.value).strip() for c in ws[header_row] if c.value
         }
         sku_col = next(
-            (col for col, n in names.items() if n == IDENTITY_FIELD), None
+            (col for col, n in names.items() if _is_sku_field(n)), None
         )
         for row in ws.iter_rows(min_row=header_row + 1):
             sku = ''
@@ -641,9 +550,11 @@ def _report_comment_errors(path):
     except ValueError:
         return []
     names = [c.value for c in ws[hdr]]
-    if IDENTITY_FIELD not in names:
+    sku_col = next(
+        (i for i, n in enumerate(names) if n and _is_sku_field(str(n))), None
+    )
+    if sku_col is None:
         return []
-    sku_col = names.index(IDENTITY_FIELD)
     out = []
     for r in range(hdr + 1, ws.max_row + 1):
         sku = ws.cell(r, sku_col + 1).value
@@ -685,6 +596,9 @@ def cmd_parse_feedback(args):
                 'Fix ALL errors (parent first) and re-upload; a SKU with '
                 'any error is NOT created (feed "successful" != live).'
             )
+            # Non-zero exit so a caller/CI sees the feed had blocking
+            # errors -- matches the table-scan path below.
+            sys.exit(1)
         return
 
     rows = list(_iter_report_rows(args.file))

--- a/app/skills_v2/amazon-listing/scripts/listing_schema.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_schema.py
@@ -20,6 +20,8 @@ either:
 and re-exports the ones tests reach for.
 """
 
+import re
+
 # The Template sheet holds the flat file. Metadata lives in siblings.
 TEMPLATE_SHEET = 'Template'
 DEFN_SHEET = 'Data Definitions'
@@ -220,6 +222,26 @@ def find_header_row(ws, max_scan=8):
         f'contribution_sku -- in the first {max_scan} rows) -- is this a '
         'listing flat-file template?'
     )
+
+
+def data_start_row(ws, header_row):
+    """The 1-based row where DATA must begin.
+
+    Legacy: immediately below the field-name row (`header_row + 1`).
+    Unified: the row-1 `settings=…&dataRow=N&…` blob names N, and Amazon
+    treats the rows between the field-name row and N as a prefilled EXAMPLE
+    region that it SKIPS on upload. Writing data into that gap silently
+    drops those SKUs (verified live: children in rows 6-7 were skipped, so a
+    6-child feed processed as 4/6). Honour `dataRow` so every row is read.
+    """
+    settings = ws.cell(row=1, column=1).value
+    if settings:
+        m = re.search(r'dataRow=(\d+)', str(settings))
+        if m:
+            n = int(m.group(1))
+            if n > header_row:
+                return n
+    return header_row + 1
 
 
 def field_columns(ws, header_row):

--- a/app/skills_v2/amazon-listing/scripts/listing_schema.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_schema.py
@@ -1,0 +1,332 @@
+"""Flat-file template structure: dialect detection, role resolution,
+header/column parsing, and metadata (required fields, valid values).
+
+Kept as a standalone module (like `marketplace_ids`) so `listing_bulk.py`
+stays within the repo line cap and the "how is this template shaped"
+logic lives in one place. Everything here is pure openpyxl-object /
+string manipulation — no CLI, no I/O.
+
+Amazon ships two flat-file dialects and this module hides the difference
+behind logical roles (see `ROLE_MATCHERS`), so one JSON spec drives
+either:
+
+  legacy  (TemplateType=fptcustom) -- bare field API names: `item_sku`,
+          `update_delete`, `parent_child`, `variation_theme`, ...
+  unified (NGS "Beta Product Spreadsheet") -- decorated names:
+          `contribution_sku#1.value`, `::record_action`,
+          `parentage_level[marketplace_id=<id>]#1.value`, ...
+
+`listing_bulk.py` imports these (aliased to `_`-prefixed internal names)
+and re-exports the ones tests reach for.
+"""
+
+# The Template sheet holds the flat file. Metadata lives in siblings.
+TEMPLATE_SHEET = 'Template'
+DEFN_SHEET = 'Data Definitions'
+VALID_SHEET = 'Valid Values'
+DROPDOWN_SHEET = 'Dropdown Lists'
+
+# The operation ("record action") column and its tokens PER DIALECT. A
+# blank cell means Create in both -- that is the default and cannot be a
+# literal token, so callers pass operation='create' and we clear the cell.
+OP_TOKENS = {
+    'legacy': {
+        'create': '',
+        'update': 'Update',
+        'partialupdate': 'partialupdate',
+        'delete': 'delete',
+    },
+    'unified': {
+        'create': '',
+        'update': 'Create or Replace (Full Update)',
+        'partialupdate': 'Edit (Partial Update)',
+        'delete': 'Delete',
+    },
+}
+
+# Logical field roles, each matched STRUCTURALLY against a header column's
+# API name so one spec drives either dialect. `n` = full API name, `b` =
+# base attribute (marketplace/language brackets, the `#N.sub` suffix and
+# the unified `::` prefix stripped), `lf` = leaf (text after the last `.`).
+# The FIRST header column that matches a role wins (columns are visited in
+# sheet order). Anything not covered here is addressed by exact API name.
+ROLE_MATCHERS = {
+    'sku': lambda n, b, lf: n == 'item_sku' or b == 'contribution_sku',
+    'operation': lambda n, b, lf: (
+        n == 'update_delete' or b == 'record_action'
+    ),
+    'product_type': lambda n, b, lf: (
+        n == 'feed_product_type' or b == 'product_type'
+    ),
+    'brand': lambda n, b, lf: (
+        n == 'brand_name' or (b == 'brand' and lf == 'value')
+    ),
+    'parentage': lambda n, b, lf: (
+        n == 'parent_child' or b == 'parentage_level'
+    ),
+    'parent_sku': lambda n, b, lf: n == 'parent_sku'
+    or (b == 'child_parent_sku_relationship' and lf == 'parent_sku'),
+    'variation_theme': lambda n, b, lf: n == 'variation_theme'
+    or (b == 'variation_theme' and lf == 'name'),
+    'product_id': lambda n, b, lf: (
+        n == 'external_product_id' or n == 'amzn1.volt.ca.product_id_value'
+    ),
+    'product_id_type': lambda n, b, lf: (
+        n == 'external_product_id_type' or n == 'amzn1.volt.ca.product_id_type'
+    ),
+}
+
+# Cross-dialect attribute renames: a bare spec key on the left resolves to
+# a column whose base attribute is on the right when the two dialects named
+# the same concept differently (legacy `color_name` -> unified `color`).
+FIELD_ALIASES = {
+    'color_name': 'color',
+    'size_name': 'size',
+}
+
+
+def base_attr(name):
+    """The bare attribute token of a flat-file field API name.
+
+    Strips the dialect decorations so both dialects reduce to a common
+    key: the unified `::` action prefix, the marketplace/language brackets,
+    and the `#N.subfield` suffix. Examples:
+      `item_sku`                          -> `item_sku`
+      `contribution_sku#1.value`          -> `contribution_sku`
+      `::record_action`                   -> `record_action`
+      `parentage_level[marketplace_id=X]#1.value` -> `parentage_level`
+    """
+    s = str(name).lstrip(':')
+    for ch in ('[', '#'):
+        i = s.find(ch)
+        if i != -1:
+            s = s[:i]
+    return s
+
+
+def leaf(name):
+    """Text after the last `.` of a field API name (the sub-field), e.g.
+    `child_parent_sku_relationship[...]#1.parent_sku` -> `parent_sku`,
+    `variation_theme#1.name` -> `name`. Empty when there is no `.`."""
+    s = str(name)
+    return s.rsplit('.', 1)[-1] if '.' in s else ''
+
+
+def is_sku_field(name):
+    """The identity (SKU) column, in either dialect: legacy `item_sku` or
+    unified `contribution_sku#1.value`."""
+    return name == 'item_sku' or base_attr(name) == 'contribution_sku'
+
+
+def is_op_field(name):
+    """The operation column, in either dialect: legacy `update_delete` or
+    unified `::record_action`."""
+    return name == 'update_delete' or base_attr(name) == 'record_action'
+
+
+class Schema:
+    """Resolves logical field roles to the actual header columns present,
+    so parent/child/offer fields are addressed uniformly across the legacy
+    (fptcustom) and unified (NGS Beta) template dialects.
+
+    `cols` is the {field API name -> [1-based column indices]} map from
+    `field_columns`. `roles` maps a logical role (see `ROLE_MATCHERS`) to
+    the first header column that matched it. `dialect` is 'unified' when the
+    operation column is `::record_action`, else 'legacy'.
+    """
+
+    def __init__(self, cols):
+        self.cols = cols
+        self.roles = {}
+        for name in cols:
+            b, lf = base_attr(name), leaf(name)
+            for role, match in ROLE_MATCHERS.items():
+                if role not in self.roles and match(name, b, lf):
+                    self.roles[role] = name
+        op = self.roles.get('operation', '')
+        self.dialect = (
+            'unified' if base_attr(op) == 'record_action' else 'legacy'
+        )
+
+    def field(self, role):
+        """The header field API name bound to a role, or None."""
+        return self.roles.get(role)
+
+    def op_tokens(self):
+        return OP_TOKENS[self.dialect]
+
+    def resolve_field(self, name):
+        """Map a spec `fields` key to the actual header column.
+
+        A spec written with a bare/undecorated attribute name (e.g.
+        `item_name`, `product_description`, `recommended_browse_nodes`)
+        must reach the unified template's decorated column
+        (`item_name[marketplace_id=X][language_tag=Y]#1.value`). Resolution
+        order: an EXACT column always wins (so legacy specs and explicit
+        decorated names are untouched); else the first column with the same
+        base attribute, preferring a scalar `.value` leaf; else a known
+        cross-dialect rename (`color_name`->`color`); else the name
+        unchanged (the caller then warns it is not in this template).
+        """
+        if name in self.cols:
+            return name
+        base = base_attr(name)
+        alias = FIELD_ALIASES.get(base)
+        for target in (base, alias):
+            if not target:
+                continue
+            cands = [c for c in self.cols if base_attr(c) == target]
+            if cands:
+                val = [c for c in cands if leaf(c) == 'value']
+                return (val or cands)[0]
+        return name
+
+
+def our_price_col(cols, mkt_id):
+    """The `our_price ... value_with_tax` offer column for a marketplace.
+
+    Found structurally so it matches BOTH the legacy
+    `purchasable_offer[marketplace_id=X]#1.our_price#1.schedule#1.value_with_tax`
+    and the unified `...[marketplace_id=X][audience=ALL]#1.our_price...`
+    column -- the `[audience=ALL]` insert is why a fixed template string
+    can't be used. Returns the column name or None.
+    """
+    if not mkt_id:
+        return None
+    for name in cols:
+        if (
+            f'marketplace_id={mkt_id}]' in name
+            and '.our_price' in name
+            and name.endswith('value_with_tax')
+        ):
+            return name
+    return None
+
+
+def find_header_row(ws, max_scan=8):
+    """Return the 1-based row index whose cells carry field API names.
+
+    Identified structurally by the presence of the SKU column (`item_sku`
+    legacy or `contribution_sku#1.value` unified), so it works regardless of
+    console language (the label row above it is localised; this row is not)
+    AND regardless of template dialect / header depth (legacy row 3, unified
+    row 5).
+    """
+    for r in range(1, max_scan + 1):
+        if any(is_sku_field(str(c.value)) for c in ws[r] if c.value):
+            return r
+    raise ValueError(
+        'could not find the field-name row (no SKU column -- item_sku or '
+        f'contribution_sku -- in the first {max_scan} rows) -- is this a '
+        'listing flat-file template?'
+    )
+
+
+def field_columns(ws, header_row):
+    """Map field API name -> list of 1-based column indices.
+
+    Repeated fields (bullet_point1..N are distinct, but some templates
+    reuse a bare name across marketplace-scoped offer blocks) map to
+    multiple columns; the first is used for scalar writes.
+    """
+    cols = {}
+    for cell in ws[header_row]:
+        name = cell.value
+        if name:
+            cols.setdefault(str(name), []).append(cell.column)
+    return cols
+
+
+def load_required_fields(wb):
+    """Field API names marked Required in the Data Definitions sheet.
+
+    Data Definitions layout: header at Excel row 2, then per-field rows
+    with columns Group Name | Field Name | Local Label | Definition |
+    Accepted Values | Example | Required?.
+    """
+    if DEFN_SHEET not in wb.sheetnames:
+        return set()
+    ws = wb[DEFN_SHEET]
+    rows = list(ws.iter_rows(values_only=True))
+    required = set()
+    for row in rows[2:]:
+        if not row or len(row) < 7:
+            continue
+        field_name, req = row[1], row[6]
+        if field_name and req and str(req).strip().lower() == 'required':
+            required.add(str(field_name).strip())
+    return required
+
+
+def load_valid_values(wb):
+    """Map field API name -> set of accepted enum tokens (lowercased).
+
+    Read from 'Dropdown Lists', whose field-name header row (found by
+    probing for the operation column of either dialect) holds field API
+    names as column headers and the rows below hold the tokens for each.
+    Returns {} silently if the sheet is absent or shaped unexpectedly --
+    enum checks then degrade to warnings only.
+    """
+    if DROPDOWN_SHEET not in wb.sheetnames:
+        return {}
+    ws = wb[DROPDOWN_SHEET]
+    rows = list(ws.iter_rows(values_only=True))
+    if len(rows) < 4:
+        return {}
+    # The field-name header inside Dropdown Lists is the row that
+    # contains a known enum field; probe the first few rows for it.
+    hdr_idx = None
+    for i in range(min(5, len(rows))):
+        if rows[i] and any(is_op_field(str(c)) for c in rows[i] if c):
+            hdr_idx = i
+            break
+    if hdr_idx is None:
+        return {}
+    hdr = rows[hdr_idx]
+    out = {}
+    for ci, name in enumerate(hdr):
+        if not name:
+            continue
+        vals = set()
+        for ri in range(hdr_idx + 1, len(rows)):
+            v = rows[ri][ci] if ci < len(rows[ri]) else None
+            if v not in (None, ''):
+                vals.add(str(v).strip().lower())
+        if vals:
+            out[str(name).strip()] = vals
+    return out
+
+
+def valid_value_case(wb):
+    """Map field API name -> {lowercased token: template's exact-case token}.
+
+    Amazon rejects a case-mismatched enum on some fields (verified live:
+    `apparel_size_system` accepts `UAE/KSA` but rejects `uae/ksa`), so a
+    spec value must be written in the template's own case. This mirrors
+    `load_valid_values` but keeps the original casing as the value.
+    """
+    if DROPDOWN_SHEET not in wb.sheetnames:
+        return {}
+    ws = wb[DROPDOWN_SHEET]
+    rows = list(ws.iter_rows(values_only=True))
+    if len(rows) < 4:
+        return {}
+    hdr_idx = None
+    for i in range(min(5, len(rows))):
+        if rows[i] and any(is_op_field(str(c)) for c in rows[i] if c):
+            hdr_idx = i
+            break
+    if hdr_idx is None:
+        return {}
+    out = {}
+    for ci, name in enumerate(rows[hdr_idx]):
+        if not name:
+            continue
+        m = {}
+        for ri in range(hdr_idx + 1, len(rows)):
+            v = rows[ri][ci] if ci < len(rows[ri]) else None
+            if v not in (None, ''):
+                m[str(v).strip().lower()] = str(v).strip()
+        if m:
+            out[str(name).strip()] = m
+    return out

--- a/app/skills_v2/amazon-listing/scripts/listing_schema.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_schema.py
@@ -240,19 +240,35 @@ def field_columns(ws, header_row):
 def load_required_fields(wb):
     """Field API names marked Required in the Data Definitions sheet.
 
-    Data Definitions layout: header at Excel row 2, then per-field rows
-    with columns Group Name | Field Name | Local Label | Definition |
-    Accepted Values | Example | Required?.
+    Header at Excel row 2, then per-field rows. The `Field Name` and
+    `Required?` COLUMN POSITIONS differ by dialect (legacy has an extra
+    `Definition and Use` column, so `Required?` is col 6; unified drops it,
+    so it's col 5), so locate both by header name rather than a fixed
+    index. Only an exact `Required` counts -- `Conditionally Required` and
+    `Optional` are not hard requirements.
     """
     if DEFN_SHEET not in wb.sheetnames:
         return set()
     ws = wb[DEFN_SHEET]
     rows = list(ws.iter_rows(values_only=True))
+    if len(rows) < 3:
+        return set()
+    hdr = [str(c).strip().lower() if c is not None else '' for c in rows[1]]
+
+    def col(*needles):
+        for i, h in enumerate(hdr):
+            if any(n in h for n in needles):
+                return i
+        return None
+
+    fn_i, req_i = col('field name'), col('required')
+    if fn_i is None or req_i is None:
+        return set()
     required = set()
     for row in rows[2:]:
-        if not row or len(row) < 7:
+        if not row or len(row) <= max(fn_i, req_i):
             continue
-        field_name, req = row[1], row[6]
+        field_name, req = row[fn_i], row[req_i]
         if field_name and req and str(req).strip().lower() == 'required':
             required.add(str(field_name).strip())
     return required

--- a/app/skills_v2/amazon-listing/scripts/marketplace_ids.py
+++ b/app/skills_v2/amazon-listing/scripts/marketplace_ids.py
@@ -64,7 +64,7 @@ def fulfillment_index(cols, mkt_id):
     offer = [
         c
         for k, v in cols.items()
-        if f'marketplace_id={mkt_id}]' in k
+        if f'purchasable_offer[marketplace_id={mkt_id}]' in k
         for c in v
     ]
     if not offer:
@@ -86,9 +86,15 @@ def ids_in_template(cols):
     `purchasable_offer[marketplace_id=<id>]...` columns name exactly the
     marketplaces the template can list on -- ground truth independent of
     the table above, so a marketplace Amazon adds later still resolves.
+    Keyed on the OFFER block specifically: the unified template also
+    marketplace-scopes content columns (brand/item_name/parentage), so a
+    bare `marketplace_id=` scan would over-report marketplaces you can't
+    actually make an offer on.
     """
     ids = []
     for col in cols:
+        if 'purchasable_offer[marketplace_id=' not in str(col):
+            continue
         m = _MKT_ID_IN_COLUMN.search(str(col))
         if m and m.group(1) not in ids:
             ids.append(m.group(1))

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -194,14 +194,18 @@ PY
 
 ## Uploading a file to a web `<input type=file>`
 
-> **The file must live in a path the BROWSER can read — NOT `/tmp`.**
-> `setFileInputFiles` reads the file from disk *in the browser process*.
-> Ziniao's Chrome (macOS-sandboxed) cannot read `/tmp`, so a `/tmp` path
-> **silently no-ops** — `files.length` stays 0 and Submit never enables,
-> with no error. Put the file in the store's downloads dir
-> (`~/.vibe-seller/downloads/<slug>/`, the one path the browser is
-> guaranteed to read) and pass that absolute path. This alone was the
-> cause of "the upload widget won't accept my file" — not the widget.
+> **The file must be in a path the BROWSER PROCESS can read, passed in
+> that process's path form — NOT `/tmp`.** `setFileInputFiles` reads the
+> file in the browser, not the agent. Put it in the store's downloads dir
+> (`~/.vibe-seller/downloads/<slug>/`) — the one location guaranteed
+> readable on every backend. Otherwise it **silently no-ops**:
+> `files.length` stays 0, Submit never enables, no error. Per backend:
+> macOS Ziniao's Chrome is sandboxed and can't read `/tmp` (so a `/tmp`
+> file fails — this was the whole "the widget won't accept my file"
+> bug, not the widget); native-Windows Chrome has no such sandbox but the
+> winchrome case (WSL agent → native Windows Chrome) must pass the
+> **Windows-form** path (`C:\…\downloads\<slug>\file`, via `wslpath -w`) —
+> a `/mnt/c` or WSL path is unreadable by native Chrome.
 
 There is **no native upload helper**. Never coordinate-click the visible
 "Browse"/"Upload file" button expecting to then drive the OS file picker

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -194,6 +194,15 @@ PY
 
 ## Uploading a file to a web `<input type=file>`
 
+> **The file must live in a path the BROWSER can read — NOT `/tmp`.**
+> `setFileInputFiles` reads the file from disk *in the browser process*.
+> Ziniao's Chrome (macOS-sandboxed) cannot read `/tmp`, so a `/tmp` path
+> **silently no-ops** — `files.length` stays 0 and Submit never enables,
+> with no error. Put the file in the store's downloads dir
+> (`~/.vibe-seller/downloads/<slug>/`, the one path the browser is
+> guaranteed to read) and pass that absolute path. This alone was the
+> cause of "the upload widget won't accept my file" — not the widget.
+
 There is **no native upload helper**. Never coordinate-click the visible
 "Browse"/"Upload file" button expecting to then drive the OS file picker
 (you can't). Attach the file via CDP. **`cdp()` takes keyword args, NOT a

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -886,27 +886,21 @@ def _make_unified_template(path):
     row7[0] = "We've prefilled attributes. Please do not delete this row."
     ws.append(row7)
 
+    # Unified Data Definitions has NO 'Definition and Use' column, so
+    # 'Required?' sits at col 6 (index 5), not col 7 — the tool must find
+    # it by header name, not a fixed index.
     dd = wb.create_sheet(listing_bulk.DEFN_SHEET)
     dd.append(['How to complete your inventory template'])
     dd.append([
         'Group Name',
         'Field Name',
         'Local Label Name',
-        'Definition and Use',
         'Accepted Values',
         'Example',
         'Required?',
     ])
     for f in _UNI_FIELDS:
-        dd.append([
-            '',
-            f,
-            f,
-            '',
-            '',
-            '',
-            'Required' if f in _UNI_REQUIRED else '',
-        ])
+        dd.append(['', f, f, '', '', 'Required' if f in _UNI_REQUIRED else ''])
 
     dl = wb.create_sheet(listing_bulk.DROPDOWN_SHEET)
     dl.append([])
@@ -957,6 +951,9 @@ def test_unified_header_and_dialect_detected(unified_template):
     assert schema.field('brand') == _UNI_BRAND
     assert schema.field('product_id') == _UNI_ID_VALUE
     assert schema.field('product_id_type') == _UNI_ID_TYPE
+    # Required fields are parsed from the unified DD (6-col layout,
+    # 'Required?' located by header name, not a fixed index).
+    assert listing_bulk._load_required_fields(wb) == _UNI_REQUIRED
 
 
 def test_fill_unified_clears_prefilled_rows_and_maps_friendly_keys(

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -56,6 +56,7 @@ FIELDS = [
     'external_product_id',
     'external_product_id_type',
     'item_name',
+    'title_differentiation',
     'product_description',
     'recommended_browse_nodes',
     'main_image_url',
@@ -237,6 +238,59 @@ def test_fill_operation_column(template, tmp_path):
     assert by_sku['W-4']['update_delete'] == 'delete'
     # brand default applied to every row.
     assert all(r['brand_name'] == 'ACME' for r in rows)
+
+
+def test_fill_drops_item_highlight_when_title_too_long(
+    template, tmp_path, capsys
+):
+    # Item Highlight (title_differentiation) is only valid when item_name
+    # is <= 75 chars; a longer title makes Amazon reject it with 100476
+    # (SUCCESS OTHER). fill drops the optional highlight so the SKU lands
+    # clean, and warns. Regression for the long-title over-claim.
+    long_title = 'A' * 90
+    spec = {
+        'product_type': 'socks',
+        'brand': 'ACME',
+        'rows': [
+            {
+                'sku': 'W-LONG',
+                'operation': 'create',
+                'fields': {
+                    'item_name': long_title,
+                    'title_differentiation': 'Pure White',
+                },
+            }
+        ],
+    }
+    out = str(tmp_path / 'out.xlsx')
+    _run(['fill', template, '--spec', _spec(tmp_path, spec), '--out', out])
+    row = {r['item_sku']: r for r in _read_rows(out)}['W-LONG']
+    assert row['title_differentiation'] in (None, '')
+    err = capsys.readouterr().err
+    assert 'Item Highlight' in err and '100476' in err
+
+
+def test_fill_keeps_item_highlight_when_title_fits(template, tmp_path):
+    # A short title is under the limit, so a genuine Item Highlight is
+    # written unchanged -- the guard only strips the poison case.
+    spec = {
+        'product_type': 'socks',
+        'brand': 'ACME',
+        'rows': [
+            {
+                'sku': 'W-SHORT',
+                'operation': 'create',
+                'fields': {
+                    'item_name': 'ACME Socks',
+                    'title_differentiation': 'Breathable',
+                },
+            }
+        ],
+    }
+    out = str(tmp_path / 'out.xlsx')
+    _run(['fill', template, '--spec', _spec(tmp_path, spec), '--out', out])
+    row = {r['item_sku']: r for r in _read_rows(out)}['W-SHORT']
+    assert row['title_differentiation'] == 'Breathable'
 
 
 def test_parent_child_structure(template, tmp_path):
@@ -605,6 +659,39 @@ def test_fill_routes_bare_our_price_to_target_marketplace(
     row = _read_rows(out)[0]
     assert row[_SA_PRICE] == '19.99'  # target marketplace got the price
     assert row[_AE_PRICE] in (None, '')  # the wrong block stayed empty
+
+
+def test_fill_routes_row_level_our_price_and_quantity(mkt_template, tmp_path):
+    # The skill says put "a bare our_price / quantity on each child" -- an
+    # agent naturally puts them at the ROW level (sibling to `fields`), not
+    # inside `fields`. Both placements must route, else the offer column
+    # comes out empty and the agent thrashes hand-picking columns.
+    spec = _spec(
+        tmp_path,
+        {
+            'marketplace': 'SA',
+            'product_type': 'socks',
+            'rows': [
+                {
+                    'sku': 'K-WHT',
+                    'parentage': 'Child',
+                    'variation_theme': 'Color',
+                    'our_price': '19.99',  # row-level, not in fields
+                    'quantity': '100',  # row-level, not in fields
+                    'fields': {
+                        'item_name': 'x',
+                        'color_name': 'White',
+                        'feed_product_type': 'socks',
+                    },
+                }
+            ],
+        },
+    )
+    out = str(tmp_path / 'out.xlsx')
+    _run(['fill', mkt_template, '--spec', spec, '--out', out])
+    row = _read_rows(out)[0]
+    assert row[_SA_PRICE] == '19.99'
+    assert row[_AE_PRICE] in (None, '')
 
 
 def test_fill_warns_when_target_marketplace_has_no_offer(

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -861,7 +861,13 @@ def _make_unified_template(path):
     wb = openpyxl.Workbook()
     ws = wb.active
     ws.title = listing_bulk.TEMPLATE_SHEET
-    ws.append(['settings=feedType=256&contributorId=amzn1'])  # row 1
+    # row 1 settings — like the real template, carries the geometry
+    # (labelRow/attributeRow/dataRow). dataRow=8 means rows 6-7 are a
+    # skipped example region and data must start at row 8.
+    ws.append([
+        'settings=feedType=256&labelRow=4&attributeRow=5&dataRow=8'
+        '&contributorId=amzn1'
+    ])
     ws.append(['Use ENGLISH. DO NOT modify or delete the colored head'])
     ws.append(['Listing Identity'])  # row 3 group names
     ws.append(['SKU', 'Product Type', 'Listing Action'])  # row 4 labels (zh)
@@ -1113,6 +1119,54 @@ def test_fill_unified_tsv_keeps_settings_header(unified_template, tmp_path):
     assert len({len(r) for r in grid}) == 1  # uniform width, no drift
     # Prefilled Example row did not survive into the upload artefact.
     assert not any('EXAMPLE-SKU' in r for r in grid)
+
+
+def test_fill_unified_writes_data_at_datarow(unified_template, tmp_path):
+    """Unified data must start at the settings' `dataRow` (8 here), NOT
+    header_row+1. Amazon SKIPS the rows between the field-name row and
+    dataRow as an example region, so data written there is dropped
+    (verified live: children written into rows 6-7 processed as 4/6)."""
+    spec = {
+        'product_type': 'socks',
+        'brand': 'ACME',
+        'marketplace': 'SA',
+        'rows': [
+            {
+                'sku': 'P',
+                'operation': 'create',
+                'parentage': 'Parent',
+                'variation_theme': 'COLOR',
+                'fields': {'item_name': 'p'},
+            },
+            {
+                'sku': 'C',
+                'operation': 'create',
+                'parentage': 'Child',
+                'parent_sku': 'P',
+                'variation_theme': 'COLOR',
+                'fields': {
+                    'item_name': 'c',
+                    'our_price': '9.99',
+                    'quantity': '5',
+                },
+            },
+        ],
+    }
+    out = str(tmp_path / 'out.xlsx')
+    _run([
+        'fill',
+        unified_template,
+        '--spec',
+        _spec(tmp_path, spec),
+        '--out',
+        out,
+    ])
+    ws = openpyxl.load_workbook(out)[listing_bulk.TEMPLATE_SHEET]
+    # The example region (rows 6-7) is blank; data starts at row 8.
+    assert all(c.value in (None, '') for c in ws[6])
+    assert all(c.value in (None, '') for c in ws[7])
+    assert ws.cell(row=8, column=1).value == 'P'  # first data row = 8
+    assert ws.cell(row=9, column=1).value == 'C'
 
 
 def test_parse_feedback_unified_report_finds_child_error(tmp_path, capsys):

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -781,3 +781,370 @@ def test_route_remaps_wrong_index_fulfillment_to_target():
     listing_bulk._route_offer_price(fields, _MKT_COLS, _SA, 0, 'K-WHT', [])
     assert fields[_SA_QTY] == '100'
     assert _AE_QTY not in fields
+
+
+# --- unified (NGS "Beta Product Spreadsheet") template dialect ----------
+#
+# The current Seller Central template. Its field API names are decorated
+# (`contribution_sku#1.value`, `::record_action`, marketplace-scoped
+# parentage/parent-link/offer with an `[audience=ALL]` insert), its
+# field-name row sits at Excel row 5 (not 3), and it ships PREFILLED rows
+# (an Example SKU + a "do not delete this row" instruction). The legacy
+# tool keyed on `item_sku` and crashed here, which forced agents to
+# hand-roll the file -- and a hand-rolled file uploaded the prefilled
+# Example/instruction rows as real SKUs (verified: a live run got "1/8"
+# because those junk rows shipped). These tests pin that the SAME friendly
+# spec now drives this dialect and clears the prefilled rows.
+
+_UNI_SKU = 'contribution_sku#1.value'
+_UNI_PT = 'product_type#1.value'
+_UNI_OP = '::record_action'
+_UNI_PARENTAGE = f'parentage_level[marketplace_id={_SA}]#1.value'
+_UNI_PARENT_SKU = (
+    f'child_parent_sku_relationship[marketplace_id={_SA}]#1.parent_sku'
+)
+_UNI_THEME = 'variation_theme#1.name'
+_UNI_NAME = f'item_name[marketplace_id={_SA}][language_tag=en_AE]#1.value'
+_UNI_BRAND = f'brand[marketplace_id={_SA}][language_tag=en_AE]#1.value'
+_UNI_ID_TYPE = 'amzn1.volt.ca.product_id_type'
+_UNI_ID_VALUE = 'amzn1.volt.ca.product_id_value'
+_UNI_COLOR = f'color[marketplace_id={_SA}][language_tag=en_AE]#1.value'
+_UNI_QTY = 'fulfillment_availability#1.quantity'
+# The offer column carries the `[audience=ALL]` insert a fixed template
+# string can't match -- the routing must find it structurally.
+_UNI_PRICE = (
+    f'purchasable_offer[marketplace_id={_SA}][audience=ALL]'
+    '#1.our_price#1.schedule#1.value_with_tax'
+)
+
+# Column order matters: stock group must precede the offer block.
+_UNI_FIELDS = [
+    _UNI_SKU,
+    _UNI_PT,
+    _UNI_OP,
+    _UNI_PARENTAGE,
+    _UNI_PARENT_SKU,
+    _UNI_THEME,
+    _UNI_NAME,
+    _UNI_BRAND,
+    _UNI_ID_TYPE,
+    _UNI_ID_VALUE,
+    _UNI_COLOR,
+    _UNI_QTY,
+    _UNI_PRICE,
+]
+_UNI_REQUIRED = {
+    _UNI_SKU,
+    _UNI_PT,
+    _UNI_NAME,
+    _UNI_BRAND,
+    _UNI_PRICE,
+    _UNI_COLOR,
+}
+_UNI_ENUMS = {
+    _UNI_OP: [
+        'Create or Replace (Full Update)',
+        'Edit (Partial Update)',
+        'Delete',
+    ],
+    _UNI_PARENTAGE: ['Parent', 'Child'],
+    _UNI_THEME: ['COLLECTION_ITEM', 'COLOR', 'SIZE'],
+    _UNI_ID_TYPE: ['EAN', 'GTIN', 'UPC', 'ASIN', 'GTIN Exempt'],
+}
+
+
+def _make_unified_template(path):
+    """A synthetic unified template mirroring the real geometry: a 5-row
+    header (settings / instructions / group / localised labels / field API
+    names) and PREFILLED Example + instruction data rows that fill MUST
+    clear."""
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = listing_bulk.TEMPLATE_SHEET
+    ws.append(['settings=feedType=256&contributorId=amzn1'])  # row 1
+    ws.append(['Use ENGLISH. DO NOT modify or delete the colored head'])
+    ws.append(['Listing Identity'])  # row 3 group names
+    ws.append(['SKU', 'Product Type', 'Listing Action'])  # row 4 labels (zh)
+    ws.append(list(_UNI_FIELDS))  # row 5 field API names <-- keyed
+    # Row 6+: Amazon's prefilled Example row + a "do not delete" row.
+    example = {
+        _UNI_SKU: 'EXAMPLE-SKU',
+        _UNI_OP: '(Default) Create or Replace',
+        _UNI_PARENTAGE: 'Parent',
+        _UNI_PARENT_SKU: 'EXAMPLE-SKU',
+        _UNI_THEME: 'SIZE',
+        _UNI_ID_TYPE: 'UPC',
+        _UNI_ID_VALUE: '100000000001',
+        _UNI_PRICE: '9.00',
+    }
+    idx = {f: i for i, f in enumerate(_UNI_FIELDS)}
+    row6 = [''] * len(_UNI_FIELDS)
+    for f, v in example.items():
+        row6[idx[f]] = v
+    ws.append(row6)
+    row7 = [''] * len(_UNI_FIELDS)
+    row7[0] = "We've prefilled attributes. Please do not delete this row."
+    ws.append(row7)
+
+    dd = wb.create_sheet(listing_bulk.DEFN_SHEET)
+    dd.append(['How to complete your inventory template'])
+    dd.append([
+        'Group Name',
+        'Field Name',
+        'Local Label Name',
+        'Definition and Use',
+        'Accepted Values',
+        'Example',
+        'Required?',
+    ])
+    for f in _UNI_FIELDS:
+        dd.append([
+            '',
+            f,
+            f,
+            '',
+            '',
+            '',
+            'Required' if f in _UNI_REQUIRED else '',
+        ])
+
+    dl = wb.create_sheet(listing_bulk.DROPDOWN_SHEET)
+    dl.append([])
+    dl.append([])
+    enum_fields = list(_UNI_ENUMS)
+    dl.append(enum_fields)  # unified: header row carries `::record_action`
+    for i in range(max(len(v) for v in _UNI_ENUMS.values())):
+        dl.append([
+            _UNI_ENUMS[f][i] if i < len(_UNI_ENUMS[f]) else None
+            for f in enum_fields
+        ])
+    wb.save(path)
+
+
+@pytest.fixture
+def unified_template(tmp_path):
+    p = tmp_path / 'unified.xlsx'
+    _make_unified_template(str(p))
+    return str(p)
+
+
+def _read_unified_rows(path):
+    wb = openpyxl.load_workbook(path)
+    ws = wb[listing_bulk.TEMPLATE_SHEET]
+    names = [c.value for c in ws[5]]  # field API names at row 5
+    idx = {n: i for i, n in enumerate(names)}
+    rows = []
+    for r in ws.iter_rows(min_row=6, values_only=True):
+        if any(c is not None and str(c).strip() for c in r):
+            rows.append({n: r[idx[n]] for n in names if n})
+    return rows
+
+
+def test_unified_header_and_dialect_detected(unified_template):
+    wb = openpyxl.load_workbook(unified_template)
+    ws = wb[listing_bulk.TEMPLATE_SHEET]
+    # Field-name row is row 5 (unified), found structurally -- NOT item_sku.
+    assert listing_bulk._find_header_row(ws) == 5
+    cols = listing_bulk._field_columns(ws, 5)
+    schema = listing_bulk._Schema(cols)
+    assert schema.dialect == 'unified'
+    # Friendly roles resolve to the decorated unified columns.
+    assert schema.field('sku') == _UNI_SKU
+    assert schema.field('operation') == _UNI_OP
+    assert schema.field('parentage') == _UNI_PARENTAGE
+    assert schema.field('parent_sku') == _UNI_PARENT_SKU
+    assert schema.field('variation_theme') == _UNI_THEME
+    assert schema.field('brand') == _UNI_BRAND
+    assert schema.field('product_id') == _UNI_ID_VALUE
+    assert schema.field('product_id_type') == _UNI_ID_TYPE
+
+
+def test_fill_unified_clears_prefilled_rows_and_maps_friendly_keys(
+    unified_template, tmp_path
+):
+    """The core regression: the SAME friendly spec that drives legacy must
+    drive unified -- clearing Amazon's prefilled Example/instruction rows
+    (the "1/8" cause) and routing every field to its decorated column."""
+    spec = {
+        'product_type': 'socks',
+        'brand': 'ACME',
+        'marketplace': 'SA',
+        'rows': [
+            {
+                'sku': 'WIDGET-006',
+                'operation': 'create',
+                'parentage': 'Parent',
+                'variation_theme': 'COLOR',
+                'fields': {'item_name': 'ACME Socks'},
+            },
+            {
+                'sku': 'WIDGET-006-WHT',
+                'operation': 'create',
+                'parentage': 'Child',
+                'parent_sku': 'WIDGET-006',
+                'variation_theme': 'COLOR',
+                'fields': {
+                    'item_name': 'ACME Socks White',
+                    'our_price': '42.99',
+                    'quantity': '100',
+                },
+            },
+        ],
+    }
+    out = str(tmp_path / 'out.xlsx')
+    _run([
+        'fill',
+        unified_template,
+        '--spec',
+        _spec(tmp_path, spec),
+        '--out',
+        out,
+    ])
+    rows = _read_unified_rows(out)
+    skus = [r[_UNI_SKU] for r in rows]
+    # Prefilled Example + "do not delete" rows are GONE; only the spec rows.
+    assert 'EXAMPLE-SKU' not in skus
+    assert not any('do not delete' in str(r[_UNI_SKU]) for r in rows)
+    assert skus == ['WIDGET-006', 'WIDGET-006-WHT']
+    parent = next(r for r in rows if r[_UNI_SKU] == 'WIDGET-006')
+    child = next(r for r in rows if r[_UNI_SKU] == 'WIDGET-006-WHT')
+    # create -> blank operation cell; friendly keys hit unified columns.
+    assert parent[_UNI_OP] in (None, '')
+    assert parent[_UNI_PARENTAGE] == 'Parent'
+    assert parent[_UNI_PARENT_SKU] in (None, '')  # parent has no parent
+    assert parent[_UNI_BRAND] == 'ACME'  # top-level brand default applied
+    assert parent[_UNI_PRICE] in (None, '')  # offer is child-level
+    assert child[_UNI_PARENTAGE] == 'Child'
+    assert child[_UNI_PARENT_SKU] == 'WIDGET-006'
+    assert child[_UNI_THEME] == 'COLOR'
+    # bare our_price routed to the `[audience=ALL]` offer column...
+    assert str(child[_UNI_PRICE]) == '42.99'
+    # ...and bare quantity to the marketplace's fulfillment group.
+    assert str(child[_UNI_QTY]) == '100'
+
+
+def test_fill_unified_operation_tokens(unified_template, tmp_path):
+    spec = {
+        'product_type': 'socks',
+        'brand': 'ACME',
+        'marketplace': 'SA',
+        'rows': [
+            {'sku': 'W-1', 'operation': 'create', 'fields': {'item_name': 'x'}},
+            {'sku': 'W-2', 'operation': 'update', 'fields': {'item_name': 'x'}},
+            {
+                'sku': 'W-3',
+                'operation': 'partialupdate',
+                'fields': {'item_name': 'x'},
+            },
+            {'sku': 'W-4', 'operation': 'delete'},
+        ],
+    }
+    out = str(tmp_path / 'out.xlsx')
+    _run([
+        'fill',
+        unified_template,
+        '--spec',
+        _spec(tmp_path, spec),
+        '--out',
+        out,
+    ])
+    by_sku = {r[_UNI_SKU]: r for r in _read_unified_rows(out)}
+    assert by_sku['W-1'][_UNI_OP] in (None, '')  # create = blank
+    assert by_sku['W-2'][_UNI_OP] == 'Create or Replace (Full Update)'
+    assert by_sku['W-3'][_UNI_OP] == 'Edit (Partial Update)'
+    assert by_sku['W-4'][_UNI_OP] == 'Delete'
+
+
+def test_fill_unified_asin_folds_into_volt_product_id(
+    unified_template, tmp_path
+):
+    spec = {
+        'product_type': 'socks',
+        'brand': 'ACME',
+        'marketplace': 'SA',
+        'rows': [
+            {
+                'sku': 'W-1',
+                'operation': 'update',
+                'asin': 'B0EXAMPLE1',
+                'fields': {'item_name': 'x'},
+            },
+        ],
+    }
+    out = str(tmp_path / 'out.xlsx')
+    _run([
+        'fill',
+        unified_template,
+        '--spec',
+        _spec(tmp_path, spec),
+        '--out',
+        out,
+    ])
+    row = _read_unified_rows(out)[0]
+    assert row[_UNI_ID_VALUE] == 'B0EXAMPLE1'
+    # Canonicalised to the template's exact enum case (unified lists ASIN,
+    # not asin) -- Amazon is case-strict on some fields.
+    assert row[_UNI_ID_TYPE] == 'ASIN'
+
+
+def test_fill_unified_tsv_keeps_settings_header(unified_template, tmp_path):
+    """The uploaded .txt must retain the row-1 settings/signature block --
+    Amazon's introspect-feed keys on it to detect the file type. A
+    hand-rolled header-less TSV was rejected ("File upload unsuccessful")."""
+    spec = {
+        'product_type': 'socks',
+        'brand': 'ACME',
+        'marketplace': 'SA',
+        'rows': [
+            {'sku': 'W-1', 'operation': 'create', 'fields': {'item_name': 'x'}}
+        ],
+    }
+    out = str(tmp_path / 'out.xlsx')
+    _run([
+        'fill',
+        unified_template,
+        '--spec',
+        _spec(tmp_path, spec),
+        '--out',
+        out,
+    ])
+    txt = tmp_path / 'out.txt'
+    lines = [ln for ln in txt.read_text(encoding='utf-8').split('\n') if ln]
+    grid = [ln.split('\t') for ln in lines]
+    assert grid[0][0].startswith('settings=')  # detection header preserved
+    assert _UNI_SKU in grid[4]  # field-name row at index 4 (Excel row 5)
+    assert len({len(r) for r in grid}) == 1  # uniform width, no drift
+    # Prefilled Example row did not survive into the upload artefact.
+    assert not any('EXAMPLE-SKU' in r for r in grid)
+
+
+def test_parse_feedback_unified_report_finds_child_error(tmp_path, capsys):
+    """The blind spot that caused the 40-minute misdiagnosis: a unified
+    processing report must be parseable so the per-CHILD rejection reason
+    is surfaced (it was invisible because parse-feedback also keyed on
+    item_sku)."""
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = listing_bulk.TEMPLATE_SHEET
+    ws.append(['settings=feedType=256'])  # row 1
+    ws.append(['instructions'])  # row 2
+    ws.append(['group'])  # row 3
+    ws.append(['SKU', 'Colour'])  # row 4 localised labels
+    ws.append([_UNI_SKU, _UNI_COLOR])  # row 5 field API names
+    ws.append(['WIDGET-006-WHT', 'White'])  # row 6 data
+    ws.cell(row=6, column=1).comment = Comment(
+        'ERROR : 8560 does not match any ASINs; include a valid '
+        'standard_product_id or request GTIN exemption',
+        'Amazon',
+    )
+    p = tmp_path / 'report.xlsx'
+    wb.save(str(p))
+
+    errs = list(listing_bulk._template_cell_errors(str(p)))
+    assert errs and all(sku == 'WIDGET-006-WHT' for sku, _, _ in errs)
+    assert any('8560' in m for _, _, m in errs)
+
+    with pytest.raises(SystemExit):  # exit 1 -- a blocking error exists
+        _run(['parse-feedback', str(p)])
+    out = capsys.readouterr().out
+    assert 'WIDGET-006-WHT' in out and '8560' in out


### PR DESCRIPTION
## Problem

`listing_bulk.py` was hard-coded to the legacy `fptcustom` flat-file
template, and the upload flow wrote files to `/tmp`. Two failures
compounded on Amazon's current NGS "Beta Product Spreadsheet" (unified)
template:

1. **Unrecognized template.** The unified template decorates every field
   name (`contribution_sku#1.value`, `::record_action`,
   `parentage_level[marketplace_id=…]#1.value`,
   `purchasable_offer[…][audience=ALL]#1.our_price…`,
   `amzn1.volt.ca.product_id*`) and puts the field-name row at Excel row 5.
   `inspect`/`fill`/`parse-feedback` all raised "could not find the
   field-name row", so a hand-rolled upload file was used instead — losing
   the guard that clears the template's prefilled Example + "do not delete
   this row" rows, which then uploaded as junk SKUs.

2. **Uploads from `/tmp` silently no-op.** `setFileInputFiles` reads the
   file in the browser process, and the anti-detect Chrome (macOS-sandboxed)
   cannot read `/tmp` — Submit never enables, `introspect-feed` never fires,
   no batch is created, with no error. This got misdiagnosed as "the upload
   widget is broken". On batches that did submit, `parse-feedback` also
   crashed on the unified report, so the per-child rejection reason was
   invisible.

## Fix (from design)

Make the tool dialect-agnostic and route uploads through a browser-readable
path, so the bug class can't recur regardless of which template Amazon
serves or where the file is written.

- **`listing_schema.py`** (new sibling module, mirrors `marketplace_ids.py`):
  dialect detection + structural role resolution (`Schema`), header/column
  parsing, offer-column resolution, metadata parsing. Every friendly role
  (sku, operation, product_type, brand, parentage, parent_sku,
  variation_theme, product id, offer price) resolves from the header, so one
  spec drives either dialect. `load_required_fields` locates the
  `Field Name`/`Required?` columns by header name (unified DD has 6 columns,
  legacy 7).
- **`listing_bulk.py`**: per-dialect operation tokens; offer price matched
  structurally (handles the unified `[audience=ALL]` insert); bare content
  field names + cross-dialect aliases (`color_name`→`color`) resolve to
  decorated columns; `parse-feedback` finds the SKU column in either dialect
  and exits non-zero on cell-comment errors; `inspect` prints the detected
  dialect + role→column map; warns if `--out` lands under `/tmp`.
- **Upload path**: `fill --out` and the upload recipe target
  `~/.vibe-seller/downloads/<slug>/` — the one path the browser is
  guaranteed to read. Infra already creates it (`config.py` base at server
  start; `ziniao.py`/`chrome.py` per-store on browser start), so this is a
  path change, not new mkdir logic. `browser-harness` § "Uploading a file"
  leads with this rule (fixes every upload flow); `amazon-ads` bulk `--out`
  paths follow suit (same bug class).
- **`fill` writes data at the template's `dataRow`** — the unified template
  skips rows 6–7 as an example region (`labelRow=4&attributeRow=5&dataRow=8`);
  writing at row 6 silently dropped the first two children (a 6-child feed
  processed as 4/6).
- **Docs** trimmed to a concise guide: the two dialects, the
  prefilled-example-row trap, the two-click submit (introspect then submit),
  the stale "network error"/"unsuccessful" widget text, "1/N = content
  rejection → `parse-feedback`, don't thrash the widget", and "required is a
  guide" (fill what you can from valid values / `GTIN Exempt` for a new
  ASIN / defer the main image).

## Follow-up fixes (this round — from a live re-run on an Amazon SA store)

Re-running the previously-"completed" family surfaced that the agent had
**over-claimed success**: it declared "6/6 done" from the SKUs merely
*appearing* in Manage Inventory, while every batch was actually
`SUCCESS (OTHER)` / "Action required, 0 successful". The string `100476`
never appeared in the task's 1,000+ messages — it never `parse-feedback`'d
the report. Three design fixes so this can't recur:

- **Item Highlight → 100476 guard.** The colour ("Pure White"…) had been
  written into `title_differentiation` (Item Highlight), which Amazon only
  accepts when `item_name` ≤ 75 chars; the long marketing title made every
  child fail 100476. `fill` now **drops an optional Item Highlight when the
  row's `item_name` > 75 chars** and warns — the poison value can no longer
  reach the sheet. (The colour belongs in `color_name`.)
- **"SUCCESS (OTHER) is not done."** `parse-feedback` and the SKILL
  (`review.criteria`/`verify_by` + the "Done =" rule) now state that a
  record posting as `SUCCESS (OTHER)` / "Action required" **is not done**:
  it shows in inventory yet the named error is unresolved. Only 18320
  (missing main image) is a legit deferral; every other error must be fixed
  and re-uploaded, and `parse-feedback` on the latest report of **every**
  batch is required — inventory presence never substitutes for it.
- **Row-level `our_price`/`quantity` fold.** The SKILL tells the agent to
  put "a bare `our_price`/`quantity` on each child" — naturally read as a
  row-level key — but `_row_fields` dropped it, so the offer column came out
  empty and the agent thrashed hand-picking offer columns. `_row_fields` now
  folds the offer shorthands from the row into `fields` (an explicit
  `fields` value still wins), so price/stock routes to the target
  marketplace either way.

## Verification

- Unit tests: **32 pass** — legacy suite untouched, plus unified-template
  cases (dialect detection, friendly-key mapping, example-row clearing,
  operation tokens, product-id fold, TSV keeps the settings header, unified
  report parsing, required-field parsing, `dataRow` write) and the three
  follow-up guards (Item Highlight drop-when-long / keep-when-fits,
  row-level offer-shorthand routing).
- `inspect`/`fill` run against a real 219-column unified template: dialect
  detected, roles resolved, example rows cleared, offer routed to the
  `[audience=ALL]` column.
- **Live end-to-end** on an Amazon SA store: the file-chooser recipe
  **fails from `/tmp`** (Submit stays disabled) and **succeeds from the
  downloads dir**.
- **Live re-run after the follow-up fixes** (behavioural change validated;
  outcome partial): the agent reloaded the skill, **independently
  extracted** the 100476 Item Highlight error, cleared Item Highlight (the
  guard produced blank Item Highlight on every row in the live-built file),
  re-uploaded, and applied the offer (price SAR 42.99 + stock 100 confirmed
  set on the children). Critically, it **reported accurately** — deferring
  the still-processing batch instead of over-claiming.
  **Final state (report-confirmed):** the downloaded processing report for
  the last batch shows **6/6 SKUs with a single, identical error — "The main
  image is missing or incorrect … submit a compliant image to lift the
  suppression"** (submission_status = "changes were applied, but contain
  other error(s)"). No 100476, no attribute error, no offer error — the
  Item-Highlight and offer-routing fixes held. So the children are
  **created, linked (`Variations (6)`), priced SAR 42.99, stocked 100, and
  search-suppressed on the missing main image ALONE** — the one sanctioned
  deferral (we don't upload images; the seller adds one to go live). The
  upload feed reads 0/N successful because SUCCESS (OTHER) doesn't count
  toward "successful"; that is expected for the image-deferred state, not a
  failure to re-upload. The SKILL now requires reporting this precisely
  ("SUPPRESSED pending main image"), never as "live".

## Known remaining / not in this PR

- **GUI/SSE result-refresh gap.** On a *resumed* task's completion, the
  task-detail panel doesn't re-fetch the `result`/`status` field — it keeps
  showing the previous round's result until a manual reload. The DB/API hold
  the correct value; the SSE `task_update` on resume-completion should carry
  or trigger a re-fetch. Frontend-only, separate from this skill/tool PR
  (`tasks_conversation.py` + the task-detail SSE handler).
- **Submit-click reliability.** On the unified upload page, `click_at_xy` on
  the low "Submit products" button sometimes didn't register while a JS
  `.click()` on the `kat-button` did; consider making JS-click the default
  in the browser-harness recipe.
- **Windows/winchrome path form.** On the WSL-agent → native-Windows-Chrome
  backend, `setFileInputFiles` needs a Windows-form path (`C:\…` via
  `wslpath -w`), not `/mnt/c` — documented, not yet empirically closed on a
  real Windows listing run.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
