### PR TITLE
feat(frontend): loading spinner while a store's tasks load

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import { submitCreateTask as submitCreateTaskHandler } from './handlers/submitCr
 import { retryTask as retryTaskHandler } from './handlers/retryTask'
 import { continueTask as continueTaskHandler } from './handlers/continueTask'
 import { deleteTask as deleteTaskHandler } from './handlers/deleteTask'
+import { fetchBrowserProfiles as fetchBrowserProfilesHandler, restartZiniao as restartZiniaoHandler } from './handlers/fetchBrowserProfiles'
 import { sendChatMessage as sendChatMessageHandler } from './handlers/sendChatMessage'
 import type {
   Store, Task, TaskStep, AgentMessage, TodoItem, AuthUser, Profile,
@@ -303,60 +304,14 @@ export default function App() {
     if (selectedZiniaoAccountId === accountId) { setSelectedZiniaoAccountId(''); setZiniaoBrowsers([]); setBrowserFetchError('') }
     await loadZiniaoAccounts()
   }
-  const fetchBrowserProfiles = async (accountId: string) => {
-    if (!accountId) return
-    // Retry if previously in running_normal. The encoding is
-    // `ziniao:running_normal` or `ziniao:running_normal:<base64msg>`.
-    const wasNormalMode = browserFetchError === 'ziniao:running_normal' || browserFetchError.startsWith('ziniao:running_normal:')
-    setFetchingBrowsers(true); setZiniaoBrowsers([]); setSelectedBrowserOauth(''); setBrowserFetchError('')
-    // Reset retry state unless this is a retry from running_normal
-    if (!wasNormalMode) setZiniaoRetried(false)
-    try {
-      const browsers = await api.get(`/api/ziniao-accounts/${accountId}/browsers`)
-      setZiniaoBrowsers(browsers)
-      setZiniaoRetried(false)
-      if (browsers.length === 0) setBrowserFetchError('no_profiles')
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : ''
-      // Try to parse structured JSON status from backend. The server
-      // platform comes from /api/system/info (serverPlatform state) —
-      // we only carry the ziniao status + its own error text here.
-      try {
-        const status = JSON.parse(msg)
-        if (status.status) {
-          if (wasNormalMode && status.status === 'running_normal') setZiniaoRetried(true)
-          // Carry Ziniao's own err text through as an extra colon-
-          // delimited field so the UI can surface it. base64 the
-          // message so embedded colons / unicode don't tangle the
-          // parser on the other side.
-          const ziniaoMsg = (status.message || '').toString()
-          const encoded = ziniaoMsg
-            ? `:${btoa(unescape(encodeURIComponent(ziniaoMsg)))}`
-            : ''
-          setBrowserFetchError(`ziniao:${status.status}${encoded}`)
-          setFetchingBrowsers(false)
-          return
-        }
-      } catch { /* not JSON, fall through */ }
-      // Fallback: existing string-matching logic
-      if (msg.includes('/api/ziniao/launcher') || msg.includes('not running')) setBrowserFetchError('connect_error')
-      else if (msg.includes('Ziniao API error') || msg.includes('-10003')) setBrowserFetchError('api_error:' + msg)
-      else setBrowserFetchError('connect_error')
-    }
-    setFetchingBrowsers(false)
+  const browserProfilesDeps = {
+    api, browserFetchError, setFetchingBrowsers, setZiniaoBrowsers,
+    setSelectedBrowserOauth, setBrowserFetchError, setZiniaoRetried,
   }
-  const restartZiniao = async (accountId: string) => {
-    setFetchingBrowsers(true); setBrowserFetchError('')
-    try {
-      await api.post(`/api/ziniao-accounts/${accountId}/restart`)
-      setZiniaoRetried(false)
-      await fetchBrowserProfiles(accountId)
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : 'Restart failed'
-      setBrowserFetchError('restart_failed:' + msg)
-    }
-    setFetchingBrowsers(false)
-  }
+  const fetchBrowserProfiles = (accountId: string) =>
+    fetchBrowserProfilesHandler(accountId, browserProfilesDeps)
+  const restartZiniao = (accountId: string) =>
+    restartZiniaoHandler(accountId, browserProfilesDeps)
 
   // ─── Store helpers ─────────────────────────────────
   const createStore = async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,6 +54,12 @@ export default function App() {
   const [showAllTasks, setShowAllTasks] = useState(true)
   const [tasks, setTasks] = useState<Task[]>([])
   const [tasksLoading, setTasksLoading] = useState(false)
+  // Key ('<store_id>' or '__none__') of the task-list fetch currently
+  // in flight. Stamped when a store/all-stores view is selected; the
+  // response and its loading toggle are dropped if the ref has since
+  // changed, so a slow response for the previous store can't clobber
+  // the newly-selected store's list (stale-response-wins race).
+  const inFlightTasksKeyRef = useRef<string | null>(null)
   const [selectedTask, setSelectedTask] = useState<Task | null>(null)
   const [steps, setSteps] = useState<TaskStep[]>([])
   const [screenshots, setScreenshots] = useState<Record<string, string>>({})
@@ -368,14 +374,26 @@ export default function App() {
     setNavOpen(false)
     userActedRef.current = true; setSelectedStore(store); setShowAllTasks(false); setSelectedTask(null); setSteps([]); setScreenshots({}); setLogs([])
     setSelectedSchedule(null); setScheduleTasks([]); setTasks([]); setTasksLoading(true)
-    try { setTasks(await api.get(`/api/tasks?store_id=${store.id}`)) } finally { setTasksLoading(false) }
+    inFlightTasksKeyRef.current = store.id
+    try {
+      const data = await api.get(`/api/tasks?store_id=${store.id}`)
+      if (inFlightTasksKeyRef.current === store.id) setTasks(data)
+    } finally {
+      if (inFlightTasksKeyRef.current === store.id) setTasksLoading(false)
+    }
     loadSchedules()
   }
   const selectAllTasks = async () => {
     setNavOpen(false)
     userActedRef.current = true; setSelectedStore(null); setShowAllTasks(true); setSelectedTask(null); setSteps([]); setScreenshots({}); setLogs([])
     setSelectedSchedule(null); setScheduleTasks([]); setTasks([]); setTasksLoading(true)
-    try { setTasks(await api.get('/api/tasks?store_id=__none__')) } finally { setTasksLoading(false) }
+    inFlightTasksKeyRef.current = '__none__'
+    try {
+      const data = await api.get('/api/tasks?store_id=__none__')
+      if (inFlightTasksKeyRef.current === '__none__') setTasks(data)
+    } finally {
+      if (inFlightTasksKeyRef.current === '__none__') setTasksLoading(false)
+    }
     loadSchedules()
   }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -370,32 +370,26 @@ export default function App() {
     setShowProxy(false); setNewStoreProxyServer(''); setNewStoreProxyBypass(''); setShowCreateStore(false); await loadStores()
   }
 
-  const selectStore = async (store: Store) => {
+  // Select a store (or all-stores when `store` is null) and load its task
+  // list. The in-flight key ('<store_id>' or '__none__') guards against a
+  // slow response for the previous scope clobbering the newly-selected
+  // one (stale-response-wins race).
+  const selectScope = async (store: Store | null) => {
     setNavOpen(false)
-    userActedRef.current = true; setSelectedStore(store); setShowAllTasks(false); setSelectedTask(null); setSteps([]); setScreenshots({}); setLogs([])
+    userActedRef.current = true; setSelectedStore(store); setShowAllTasks(!store); setSelectedTask(null); setSteps([]); setScreenshots({}); setLogs([])
     setSelectedSchedule(null); setScheduleTasks([]); setTasks([]); setTasksLoading(true)
-    inFlightTasksKeyRef.current = store.id
+    const key = store ? store.id : '__none__'
+    inFlightTasksKeyRef.current = key
     try {
-      const data = await api.get(`/api/tasks?store_id=${store.id}`)
-      if (inFlightTasksKeyRef.current === store.id) setTasks(data)
+      const data = await api.get(`/api/tasks?store_id=${key}`)
+      if (inFlightTasksKeyRef.current === key) setTasks(data)
     } finally {
-      if (inFlightTasksKeyRef.current === store.id) setTasksLoading(false)
+      if (inFlightTasksKeyRef.current === key) setTasksLoading(false)
     }
     loadSchedules()
   }
-  const selectAllTasks = async () => {
-    setNavOpen(false)
-    userActedRef.current = true; setSelectedStore(null); setShowAllTasks(true); setSelectedTask(null); setSteps([]); setScreenshots({}); setLogs([])
-    setSelectedSchedule(null); setScheduleTasks([]); setTasks([]); setTasksLoading(true)
-    inFlightTasksKeyRef.current = '__none__'
-    try {
-      const data = await api.get('/api/tasks?store_id=__none__')
-      if (inFlightTasksKeyRef.current === '__none__') setTasks(data)
-    } finally {
-      if (inFlightTasksKeyRef.current === '__none__') setTasksLoading(false)
-    }
-    loadSchedules()
-  }
+  const selectStore = (store: Store) => selectScope(store)
+  const selectAllTasks = () => selectScope(null)
 
   const selectTask = async (task: Task) => {
     let fullTask = task

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -53,6 +53,7 @@ export default function App() {
   const [selectedStore, setSelectedStore] = useState<Store | null>(null)
   const [showAllTasks, setShowAllTasks] = useState(true)
   const [tasks, setTasks] = useState<Task[]>([])
+  const [tasksLoading, setTasksLoading] = useState(false)
   const [selectedTask, setSelectedTask] = useState<Task | null>(null)
   const [steps, setSteps] = useState<TaskStep[]>([])
   const [screenshots, setScreenshots] = useState<Record<string, string>>({})
@@ -366,15 +367,15 @@ export default function App() {
   const selectStore = async (store: Store) => {
     setNavOpen(false)
     userActedRef.current = true; setSelectedStore(store); setShowAllTasks(false); setSelectedTask(null); setSteps([]); setScreenshots({}); setLogs([])
-    setSelectedSchedule(null); setScheduleTasks([])
-    setTasks(await api.get(`/api/tasks?store_id=${store.id}`))
+    setSelectedSchedule(null); setScheduleTasks([]); setTasks([]); setTasksLoading(true)
+    try { setTasks(await api.get(`/api/tasks?store_id=${store.id}`)) } finally { setTasksLoading(false) }
     loadSchedules()
   }
   const selectAllTasks = async () => {
     setNavOpen(false)
     userActedRef.current = true; setSelectedStore(null); setShowAllTasks(true); setSelectedTask(null); setSteps([]); setScreenshots({}); setLogs([])
-    setSelectedSchedule(null); setScheduleTasks([])
-    setTasks(await api.get('/api/tasks?store_id=__none__'))
+    setSelectedSchedule(null); setScheduleTasks([]); setTasks([]); setTasksLoading(true)
+    try { setTasks(await api.get('/api/tasks?store_id=__none__')) } finally { setTasksLoading(false) }
     loadSchedules()
   }
 
@@ -658,7 +659,7 @@ export default function App() {
         <TasksView
           isMobile={isMobile} onOpenNav={() => setNavOpen(true)}
           taskPanelActive={!!taskPanelActive} taskPanelTitle={taskPanelTitle}
-          tasks={tasks} selectedTask={selectedTask} steps={steps} screenshots={screenshots} logs={logs}
+          tasks={tasks} tasksLoading={tasksLoading} selectedTask={selectedTask} steps={steps} screenshots={screenshots} logs={logs}
           agentMessages={agentMessages} todoItems={todoItems} pendingQuestions={pendingQuestions}
           conversationItems={conversationItems}
           selectedAnswers={selectedAnswers} otherInputs={otherInputs} showOtherInput={showOtherInput}

--- a/frontend/src/handlers/fetchBrowserProfiles.ts
+++ b/frontend/src/handlers/fetchBrowserProfiles.ts
@@ -1,0 +1,98 @@
+/**
+ * Handlers for loading a Ziniao account's browser profiles (and the
+ * force-restart retry).
+ *
+ * Extracted from App.tsx so the fetch → error-decoding sequence can be
+ * reasoned about (and unit-tested) on its own, and to keep the app shell
+ * under the module line limit. The error encoding is a colon-delimited
+ * string the Sidebar UI decodes:
+ *   `ziniao:<status>[:<base64 message>]`  — structured backend status
+ *   `no_profiles` | `connect_error` | `api_error:<msg>` | `restart_failed:<msg>`
+ */
+import type { ZiniaoBrowserProfile } from '../types'
+
+export interface BrowserProfilesApi {
+  get(url: string): Promise<ZiniaoBrowserProfile[]>
+  post(url: string, body?: unknown): Promise<unknown>
+}
+
+export interface BrowserProfilesDeps {
+  api: BrowserProfilesApi
+  /** Current error string — a `ziniao:running_normal[...]` value means the
+   *  next fetch is a retry from the "browser already running" state. */
+  browserFetchError: string
+  setFetchingBrowsers: React.Dispatch<React.SetStateAction<boolean>>
+  setZiniaoBrowsers: React.Dispatch<React.SetStateAction<ZiniaoBrowserProfile[]>>
+  setSelectedBrowserOauth: React.Dispatch<React.SetStateAction<string>>
+  setBrowserFetchError: React.Dispatch<React.SetStateAction<string>>
+  setZiniaoRetried: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+export async function fetchBrowserProfiles(
+  accountId: string,
+  deps: BrowserProfilesDeps,
+): Promise<void> {
+  if (!accountId) return
+  const {
+    api, browserFetchError, setFetchingBrowsers, setZiniaoBrowsers,
+    setSelectedBrowserOauth, setBrowserFetchError, setZiniaoRetried,
+  } = deps
+  // Retry if previously in running_normal. The encoding is
+  // `ziniao:running_normal` or `ziniao:running_normal:<base64msg>`.
+  const wasNormalMode =
+    browserFetchError === 'ziniao:running_normal' ||
+    browserFetchError.startsWith('ziniao:running_normal:')
+  setFetchingBrowsers(true); setZiniaoBrowsers([]); setSelectedBrowserOauth(''); setBrowserFetchError('')
+  // Reset retry state unless this is a retry from running_normal
+  if (!wasNormalMode) setZiniaoRetried(false)
+  try {
+    const browsers = await api.get(`/api/ziniao-accounts/${accountId}/browsers`)
+    setZiniaoBrowsers(browsers)
+    setZiniaoRetried(false)
+    if (browsers.length === 0) setBrowserFetchError('no_profiles')
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : ''
+    // Try to parse structured JSON status from backend. The server
+    // platform comes from /api/system/info (serverPlatform state) —
+    // we only carry the ziniao status + its own error text here.
+    try {
+      const status = JSON.parse(msg)
+      if (status.status) {
+        if (wasNormalMode && status.status === 'running_normal') setZiniaoRetried(true)
+        // Carry Ziniao's own err text through as an extra colon-
+        // delimited field so the UI can surface it. base64 the
+        // message so embedded colons / unicode don't tangle the
+        // parser on the other side.
+        const ziniaoMsg = (status.message || '').toString()
+        const encoded = ziniaoMsg
+          ? `:${btoa(unescape(encodeURIComponent(ziniaoMsg)))}`
+          : ''
+        setBrowserFetchError(`ziniao:${status.status}${encoded}`)
+        setFetchingBrowsers(false)
+        return
+      }
+    } catch { /* not JSON, fall through */ }
+    // Fallback: existing string-matching logic
+    if (msg.includes('/api/ziniao/launcher') || msg.includes('not running')) setBrowserFetchError('connect_error')
+    else if (msg.includes('Ziniao API error') || msg.includes('-10003')) setBrowserFetchError('api_error:' + msg)
+    else setBrowserFetchError('connect_error')
+  }
+  setFetchingBrowsers(false)
+}
+
+export async function restartZiniao(
+  accountId: string,
+  deps: BrowserProfilesDeps,
+): Promise<void> {
+  const { api, setFetchingBrowsers, setBrowserFetchError, setZiniaoRetried } = deps
+  setFetchingBrowsers(true); setBrowserFetchError('')
+  try {
+    await api.post(`/api/ziniao-accounts/${accountId}/restart`)
+    setZiniaoRetried(false)
+    await fetchBrowserProfiles(accountId, deps)
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Restart failed'
+    setBrowserFetchError('restart_failed:' + msg)
+  }
+  setFetchingBrowsers(false)
+}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -113,6 +113,7 @@
     "messagePlaceholder": "Type your message...",
     "deleteConfirm": "Are you sure you want to delete this task?",
     "deleteConfirmCascade": "This task has {{count}} sub-task(s). Deleting it will also remove the entire subtree and all on-disk files. Continue?",
+    "loading": "Loading tasks...",
     "noTasks": "No tasks yet",
     "createFirstTask": "Create your first task to get started",
     "selectTaskHint": "Select a task or click \"+ New Task\" to create one",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -113,6 +113,7 @@
     "messagePlaceholder": "输入您的消息...",
     "deleteConfirm": "确定要删除此任务吗？",
     "deleteConfirmCascade": "此任务包含 {{count}} 个子任务，删除将级联移除整个子任务树及其磁盘文件。是否继续？",
+    "loading": "任务加载中...",
     "noTasks": "暂无任务",
     "createFirstTask": "创建您的第一个任务开始使用",
     "selectTaskHint": "选择一个任务，或点击「+ 新建任务」创建",

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -28,6 +28,7 @@ interface TasksViewProps {
   taskPanelActive: boolean
   taskPanelTitle: string
   tasks: Task[]
+  tasksLoading: boolean
   selectedTask: Task | null
   steps: TaskStep[]
   screenshots: Record<string, string>
@@ -91,6 +92,7 @@ export function TasksView({
   taskPanelActive,
   taskPanelTitle,
   tasks,
+  tasksLoading,
   selectedTask,
   steps,
   screenshots,
@@ -260,6 +262,12 @@ export function TasksView({
             )}
             <div className="flex-1 overflow-y-auto">
               {taskSubTab === 'onetime' ? (
+                tasksLoading ? (
+                  <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+                    <div className="w-6 h-6 rounded-full border-2 border-indigo-500 border-t-transparent animate-spin mb-3" />
+                    <p className="text-sm text-gray-400">{t('tasks.loading', 'Loading tasks...')}</p>
+                  </div>
+                ) : (
                 <>
                   {onetimeTasks.map(task => (
                     <button
@@ -308,6 +316,7 @@ export function TasksView({
                     </div>
                   )}
                 </>
+                )
               ) : (
                 /* ── Scheduled tab: store-specific + all-stores schedules ── */
                 <ScheduleList


### PR DESCRIPTION
## What

Clicking a store awaited the task fetch (`setTasks(await api.get(...))`) with the old/empty list still on screen. Users saw a blank panel — or a premature **"No tasks yet"** — for a few seconds and assumed the app was broken. A related latent race could also leave the *wrong* store's tasks showing.

## Changes

### 1. Loading spinner while a store's tasks load
- Add a `tasksLoading` flag in `App.tsx`, set around the fetch in `selectStore` / `selectAllTasks`, cleared in `finally` (resets even if the request errors). Tasks are cleared immediately on switch so no stale list lingers.
- `TasksView` renders a spinner + **"Loading tasks..."** in the one-time task list while `tasksLoading` is true, instead of the empty state.
- The background SSE-driven refresh (`refresh.loadTasks`) intentionally does **not** set the flag — it refreshes in place without clearing the list, so there's no flicker on live updates.
- New i18n key `tasks.loading` (EN: "Loading tasks...", ZH: "任务加载中...").

### 2. Drop stale task-list responses when switching stores
`setTasks([])` + loading already cleared the old list, but a slow in-flight fetch for the **previous** store could still resolve after a newer store was selected and overwrite the list — so you'd end up looking at another store's tasks under the current store's header (matches the reported 点了别的店铺还显示另外店铺的任务).

Guard the fetch with `inFlightTasksKeyRef` (mirrors the existing `inFlightScheduleIdRef` pattern): stamp the target key (`<store_id>` or `__none__`) on select, and apply the response / clear the loading flag only if the ref still matches. A late response for a since-abandoned store is discarded.

## Verification

Eyeballed live via Playwright:
- Slow store switch (3s network throttle on `/api/tasks`) → spinner + "Loading tasks..." shows, old tasks gone.
- Slow store A then fast store B → after A's 3s-late response arrives, B's list stays intact (header stays on B, A's tasks never leak in).

`tsc --noEmit` clean; existing TasksView tests pass (10/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)