### PR TITLE
fix(auth): 24h sliding session + redirect to login on expiry

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime, timedelta
 
-from fastapi import Depends, HTTPException, Request
+from fastapi import Depends, HTTPException, Request, Response
 import jwt
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,16 +13,44 @@ from app.models.app_settings import AppSettings
 from app.models.user import User
 
 ALGORITHM = 'HS256'
-TOKEN_EXPIRE_DAYS = 7
 COOKIE_NAME = 'auth_token'
 
+# Interactive browser login sessions are short-lived and roll forward on
+# real user activity (POST /api/auth/refresh, driven by the frontend
+# keepalive). Idle longer than this and the cookie lapses → the client
+# is bounced to the login page. Kept deliberately short for security.
+USER_SESSION_EXPIRE = timedelta(hours=24)
 
-def create_token(user_id: str, role: str) -> str:
-    expire = datetime.now(UTC) + timedelta(days=TOKEN_EXPIRE_DAYS)
+# Service tokens (ai_bot wrapper auto-start curl, `system`) are NOT
+# interactive: they get baked into per-store browser-use wrapper scripts
+# and must keep authenticating for long-running / scheduled work that
+# can fire well after the wrapper was written. They must outlive a user
+# session, so this — not the 24h window — is create_token's default.
+SERVICE_TOKEN_EXPIRE = timedelta(days=7)
+
+
+def create_token(
+    user_id: str, role: str, *, expires_delta: timedelta | None = None
+) -> str:
+    """Sign a JWT. Defaults to the long-lived service-token TTL; pass
+    ``expires_delta=USER_SESSION_EXPIRE`` for interactive logins."""
+    expire = datetime.now(UTC) + (expires_delta or SERVICE_TOKEN_EXPIRE)
     return jwt.encode(
         {'sub': user_id, 'role': role, 'exp': expire},
         JWT_SECRET,
         algorithm=ALGORITHM,
+    )
+
+
+def set_session_cookie(response: Response, token: str) -> None:
+    """Write the interactive-session auth cookie. Single source of truth
+    for cookie flags/TTL, shared by login and the sliding refresh."""
+    response.set_cookie(
+        key=COOKIE_NAME,
+        value=token,
+        httponly=True,
+        samesite='lax',
+        max_age=int(USER_SESSION_EXPIRE.total_seconds()),
     )
 
 

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -9,10 +9,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import telemetry
 from app.auth import (
     COOKIE_NAME,
-    TOKEN_EXPIRE_DAYS,
+    USER_SESSION_EXPIRE,
     create_token,
     get_current_user,
     is_auth_required,
+    set_session_cookie,
 )
 from app.config import DEFAULT_USER_ID
 from app.database import get_db
@@ -54,7 +55,7 @@ async def login(body: LoginRequest, db: AsyncSession = Depends(get_db)):
         raise HTTPException(status_code=401, detail='Invalid credentials')
     if not verify_password(body.password, user.password_hash):
         raise HTTPException(status_code=401, detail='Invalid credentials')
-    token = create_token(user.id, user.role)
+    token = create_token(user.id, user.role, expires_delta=USER_SESSION_EXPIRE)
     response = JSONResponse(
         content={
             'id': user.id,
@@ -66,13 +67,26 @@ async def login(body: LoginRequest, db: AsyncSession = Depends(get_db)):
             'plan_mode_default': user.plan_mode_default,
         }
     )
-    response.set_cookie(
-        key=COOKIE_NAME,
-        value=token,
-        httponly=True,
-        samesite='lax',
-        max_age=TOKEN_EXPIRE_DAYS * 86400,
+    set_session_cookie(response, token)
+    return response
+
+
+@router.post('/refresh')
+async def refresh_session(current_user: User = Depends(get_current_user)):
+    """Roll the session cookie forward by another full window.
+
+    The frontend keepalive calls this on real user activity so an
+    actively-used session never expires out from under the user; the
+    24h window only elapses on genuine idleness. When auth is required
+    and the cookie has already lapsed, ``get_current_user`` raises 401
+    here — which the shared API client turns into an ``auth:expired``
+    redirect to the login page (no hung screen).
+    """
+    token = create_token(
+        current_user.id, current_user.role, expires_delta=USER_SESSION_EXPIRE
     )
+    response = JSONResponse(content={'ok': True})
+    set_session_cookie(response, token)
     return response
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { Sidebar } from './components/Sidebar'
 import { MobileMenuButton } from './components/MobileMenuButton'
 import { useWsFiles } from './hooks/useWsFiles'
 import { useUpdateCheck } from './hooks/useUpdateCheck'
+import { useSessionKeepalive } from './hooks/useSessionKeepalive'
 import { useIsMobile } from './hooks/useIsMobile'
 import { useMobileBackStack } from './hooks/useMobileBackStack'
 import { CreateTaskModal } from './components/CreateTaskModal'
@@ -192,6 +193,10 @@ export default function App() {
   }, [])
 
   const { updateCheck, dismissUpdateCheck } = useUpdateCheck(currentUser)
+
+  // Roll the session forward on activity and bounce to login on idle
+  // expiry — only meaningful when auth is on (otherwise never 401s).
+  useSessionKeepalive(authChecked && !!currentUser && authRequired)
 
   // Device/browser Back pops the mobile drill-down instead of leaving.
   useMobileBackStack({

--- a/frontend/src/hooks/__tests__/useSessionKeepalive.test.ts
+++ b/frontend/src/hooks/__tests__/useSessionKeepalive.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useSessionKeepalive } from '../useSessionKeepalive'
+
+// Mock the shared API client — we only assert which endpoint each tick
+// hits. The 401 → AUTH_EXPIRED_EVENT behavior lives in api.ts and is
+// covered by apiAuthExpired.test.ts.
+const get = vi.fn(() => Promise.resolve({}))
+const post = vi.fn(() => Promise.resolve({}))
+vi.mock('../../api', () => ({ api: { get: (...a: unknown[]) => get(...a), post: (...a: unknown[]) => post(...a) } }))
+
+describe('useSessionKeepalive', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    get.mockClear()
+    post.mockClear()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('does nothing when disabled', () => {
+    renderHook(() => useSessionKeepalive(false))
+    vi.advanceTimersByTime(5 * 60_000)
+    expect(get).not.toHaveBeenCalled()
+    expect(post).not.toHaveBeenCalled()
+  })
+
+  it('heartbeats /api/auth/me when there is no activity', () => {
+    renderHook(() => useSessionKeepalive(true))
+    vi.advanceTimersByTime(60_000)
+    expect(get).toHaveBeenCalledWith('/api/auth/me')
+    expect(post).not.toHaveBeenCalled()
+  })
+
+  it('rolls the session via /api/auth/refresh after user activity', () => {
+    renderHook(() => useSessionKeepalive(true))
+    // Simulate a real interaction, then let a tick fire.
+    window.dispatchEvent(new Event('pointerdown'))
+    vi.advanceTimersByTime(60_000)
+    expect(post).toHaveBeenCalledWith('/api/auth/refresh')
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it('reverts to heartbeat once activity stops', () => {
+    renderHook(() => useSessionKeepalive(true))
+    window.dispatchEvent(new Event('keydown'))
+    vi.advanceTimersByTime(60_000) // refresh (activity since last roll)
+    vi.advanceTimersByTime(60_000) // no new activity → heartbeat
+    expect(post).toHaveBeenCalledTimes(1)
+    expect(get).toHaveBeenCalledTimes(1)
+    expect(get).toHaveBeenCalledWith('/api/auth/me')
+  })
+
+  it('stops polling after unmount', () => {
+    const { unmount } = renderHook(() => useSessionKeepalive(true))
+    unmount()
+    vi.advanceTimersByTime(5 * 60_000)
+    expect(get).not.toHaveBeenCalled()
+    expect(post).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/hooks/useSessionKeepalive.ts
+++ b/frontend/src/hooks/useSessionKeepalive.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react'
+import { api } from '../api'
+
+// Poll cadence. On each tick we either roll the session forward (if the
+// user has interacted since the last roll) or just probe liveness. 60s
+// bounds how long an idle-expired session can sit on a frozen screen
+// before it's bounced to login.
+const TICK_MS = 60_000
+
+/**
+ * Keeps an interactive login session honest while the app is open.
+ *
+ * Two jobs, both leaning on the shared API client (which fires
+ * `AUTH_EXPIRED_EVENT` on any 401 → App.tsx clears the user → LoginPage):
+ *
+ *  1. **Roll on activity** — when the user has done something since the
+ *     last roll, POST /api/auth/refresh to push the 24h window forward.
+ *     An actively-used session therefore never expires under the user.
+ *  2. **Detect idle expiry** — when there's been no activity, GET
+ *     /api/auth/me as a heartbeat. Once the idle window lapses this 401s
+ *     and the client redirects to login instead of hanging.
+ *
+ * Refreshing is gated on *real* interaction (not the heartbeat itself) —
+ * otherwise the passive poll would keep the session alive forever and
+ * "idle > 24h logs out" could never happen.
+ *
+ * Only run when auth is actually required; with auth disabled the server
+ * never 401s, so there's nothing to keep alive or detect.
+ */
+export function useSessionKeepalive(enabled: boolean) {
+  // Flipped true by any real interaction, cleared each time we roll the
+  // session. A flag (not a timestamp diff) so behavior never depends on
+  // clock granularity — one interaction between ticks rolls once.
+  const activitySinceRefresh = useRef(false)
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const bump = () => { activitySinceRefresh.current = true }
+    const events = ['pointerdown', 'keydown', 'visibilitychange'] as const
+    events.forEach(e => window.addEventListener(e, bump, { passive: true }))
+
+    const tick = () => {
+      if (activitySinceRefresh.current) {
+        activitySinceRefresh.current = false
+        api.post('/api/auth/refresh').catch(() => { /* 401 → auth:expired */ })
+      } else {
+        api.get('/api/auth/me').catch(() => { /* 401 → auth:expired */ })
+      }
+    }
+
+    const id = window.setInterval(tick, TICK_MS)
+    return () => {
+      window.clearInterval(id)
+      events.forEach(e => window.removeEventListener(e, bump))
+    }
+  }, [enabled])
+}

--- a/tests/unit/test_auth_tokens.py
+++ b/tests/unit/test_auth_tokens.py
@@ -1,0 +1,46 @@
+"""Unit tests for JWT token TTL semantics.
+
+The interactive user-session TTL must be short (24h, sliding) while the
+service-token default (ai_bot wrapper auto-start, `system`) stays long so
+scheduled / long-running browser work keeps authenticating. These two
+must not be coupled — see app/auth.py.
+"""
+
+from datetime import UTC, datetime
+
+import jwt
+import pytest
+
+from app.auth import (
+    ALGORITHM,
+    SERVICE_TOKEN_EXPIRE,
+    USER_SESSION_EXPIRE,
+    create_token,
+)
+from app.config import JWT_SECRET
+
+pytestmark = pytest.mark.unit
+
+
+def _exp(token: str) -> datetime:
+    payload = jwt.decode(token, JWT_SECRET, algorithms=[ALGORITHM])
+    return datetime.fromtimestamp(payload['exp'], tz=UTC)
+
+
+def test_user_session_ttl_is_24h():
+    token = create_token('u1', 'admin', expires_delta=USER_SESSION_EXPIRE)
+    ttl = _exp(token) - datetime.now(UTC)
+    # ~24h, allowing a little slack for test execution time.
+    assert USER_SESSION_EXPIRE.total_seconds() == 24 * 3600
+    assert 23 * 3600 < ttl.total_seconds() <= 24 * 3600 + 60
+
+
+def test_service_token_default_outlives_user_session():
+    """create_token's default is the long service TTL, not the 24h one —
+    so shortening login sessions doesn't shorten wrapper/bot tokens."""
+    token = create_token('bot', 'ai_bot')
+    ttl = _exp(token) - datetime.now(UTC)
+    assert SERVICE_TOKEN_EXPIRE > USER_SESSION_EXPIRE
+    assert ttl.total_seconds() > USER_SESSION_EXPIRE.total_seconds()
+    # Defaults to the service TTL (7 days).
+    assert (7 * 24 - 1) * 3600 < ttl.total_seconds() <= 7 * 24 * 3600 + 60

--- a/tests/workflow/test_wf_auth.py
+++ b/tests/workflow/test_wf_auth.py
@@ -116,9 +116,7 @@ class TestRefresh:
         r = await unauthed_client.post('/api/auth/refresh')
         assert r.status_code == 401
 
-    async def test_refresh_expired_token_401(
-        self, unauthed_client, admin_user
-    ):
+    async def test_refresh_expired_token_401(self, unauthed_client, admin_user):
         """An expired session cookie is rejected, not silently accepted.
 
         This is the contract the frontend heartbeat relies on: once the

--- a/tests/workflow/test_wf_auth.py
+++ b/tests/workflow/test_wf_auth.py
@@ -1,7 +1,12 @@
 """Workflow tests for authentication and admin user management."""
 
+from datetime import UTC, datetime, timedelta
+
+import jwt
 import pytest
 
+from app.auth import ALGORITHM
+from app.config import JWT_SECRET
 from app.models.user import User
 from app.password import hash_password
 
@@ -94,6 +99,44 @@ class TestLogout:
         r = await admin_client.post('/api/auth/logout')
         assert r.status_code == 200
         assert r.json() == {'ok': True}
+
+
+class TestRefresh:
+    """Sliding-session refresh — rolls the cookie forward on activity."""
+
+    async def test_refresh_rolls_cookie(self, admin_client):
+        r = await admin_client.post('/api/auth/refresh')
+        assert r.status_code == 200
+        assert r.json() == {'ok': True}
+        # A fresh session cookie is re-issued on the response.
+        assert 'auth_token' in r.cookies
+
+    async def test_refresh_without_auth_401(self, unauthed_client):
+        """No cookie + auth required → 401 (drives the login redirect)."""
+        r = await unauthed_client.post('/api/auth/refresh')
+        assert r.status_code == 401
+
+    async def test_refresh_expired_token_401(
+        self, unauthed_client, admin_user
+    ):
+        """An expired session cookie is rejected, not silently accepted.
+
+        This is the contract the frontend heartbeat relies on: once the
+        24h window lapses, the next refresh/heartbeat 401s so the client
+        is bounced to login instead of hanging on a dead session.
+        """
+        expired = jwt.encode(
+            {
+                'sub': admin_user.id,
+                'role': 'admin',
+                'exp': datetime.now(UTC) - timedelta(minutes=1),
+            },
+            JWT_SECRET,
+            algorithm=ALGORITHM,
+        )
+        unauthed_client.cookies.set('auth_token', expired)
+        r = await unauthed_client.post('/api/auth/refresh')
+        assert r.status_code == 401
 
 
 class TestUserCrudAuthBoundary:


### PR DESCRIPTION
## Problem

Login sessions were **7 days** with no proactive expiry handling. When a token lapsed, an idle client kept its stale page and only redirected to login if the user happened to trigger an `api.*` call that 401'd — the always-open SSE stream is unauthenticated, so nothing surfaced the expiry. Net effect: the page appears to **hang** instead of returning to login.

## Fix (design, not symptom)

**Invariant:** an interactive session expires after 24h of *idle*, rolls forward while in use, and a lapsed session always lands on the login page.

1. **Separate TTLs** (`app/auth.py`). `create_token` now defaults to a long-lived `SERVICE_TOKEN_EXPIRE` (7d) — `ai_bot` wrapper auto-start / `system` tokens get baked into per-store browser-use wrappers and must outlive a day for scheduled/long-running work. Interactive logins pass `USER_SESSION_EXPIRE` (24h). Decoupling them means shortening the login window can't break browser auto-start.
2. **Sliding refresh** (`POST /api/auth/refresh`). Re-issues the cookie for another 24h; gated by `get_current_user`, so an expired cookie 401s here. `set_session_cookie` is the single source of cookie flags/TTL for both login and refresh.
3. **Proactive client keepalive** (`useSessionKeepalive`). While auth is on, a 60s tick rolls the window (`POST /refresh`) when the user has interacted since the last roll, else heartbeats (`GET /me`). Both go through the shared api client → its 401 handler fires `AUTH_EXPIRED_EVENT` → App clears the user → LoginPage. So an actively-used session never expires under the user, and an idle-expired one lands on login within ~60s instead of hanging. Refresh is gated on **real interaction** (not the heartbeat) so idle > 24h still logs out.

## Tests

- `tests/unit/test_auth_tokens.py` — user-session TTL is 24h; service-token default stays 7d (and outlives the user session).
- `tests/workflow/test_wf_auth.py::TestRefresh` — refresh rolls the cookie; no cookie → 401; expired cookie → 401 (the contract the heartbeat relies on).
- `frontend/.../useSessionKeepalive.test.ts` — heartbeats when idle, rolls on activity, reverts to heartbeat once activity stops, stops on unmount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)