### PR TITLE
fix(skills): block built-in Write/Edit on skill files; steer to save_skill

### DIFF
--- a/app/ai/bash_safety.py
+++ b/app/ai/bash_safety.py
@@ -392,6 +392,51 @@ def check_report_overwrite(
     return None
 
 
+# ── Skill-file write guard ────────────────────────────────────────
+#
+# The task's ``.claude/`` tree is a per-task COPY of the shared
+# workspace (WorkspaceManager copies, not symlinks, because Claude
+# Code's Glob won't traverse symlinked ** — see workspace/manager.py).
+# So a built-in Write/Edit against ``.claude/skills/<slug>/…`` reports
+# "updated successfully" but only mutates the throwaway copy — the
+# durable skill under ~/.vibe-seller/.claude/skills/ is untouched and
+# the change vanishes when the task ends. Observed live: an agent asked
+# to "update that skill to also post to WeCom" Edited the task-local
+# SKILL.md, saw success, and moved on — the skill never changed.
+#
+# The only durable path is the vibe_seller_save_skill MCP tool. Deny
+# built-in file writes anywhere under .claude/skills/ and point there.
+
+_SKILL_FILE_RE = re.compile(r'(?:^|/)\.claude/skills/[^/]+/')
+
+_SKILL_WRITE_DENY = (
+    'BLOCKED — do not create or edit skills with the Write/Edit tool. '
+    "A file under .claude/skills/ lives in the task's throwaway copy of "
+    'the workspace: the built-in tools report success but the change is '
+    'discarded when the task ends, so the skill is NOT durably saved. '
+    'To create or extend a user-space skill, load the "save-skill" '
+    'skill and use the vibe_seller_save_skill MCP tool — it overwrites '
+    'an existing updatable skill (that is how you extend) or creates a '
+    'new one. Built-in (maintainer-shipped) skills are read-only; if one '
+    'is the closest match, create a new user-space skill instead.'
+)
+
+
+def check_skill_file_write(tool_name: str, tool_input: dict) -> str | None:
+    """Deny a built-in Write/Edit targeting a ``.claude/skills/**`` path.
+
+    Skill files must be written through ``vibe_seller_save_skill``; the
+    built-in file tools silently fail to persist through the per-task
+    ``.claude`` copy. See the module comment above.
+    """
+    if tool_name not in ('Write', 'Edit', 'MultiEdit'):
+        return None
+    path = tool_input.get('file_path', '')
+    if not isinstance(path, str) or not _SKILL_FILE_RE.search(path):
+        return None
+    return _SKILL_WRITE_DENY
+
+
 # ── Ad-tuning reviewer-status guard ───────────────────────────────
 #
 # Before an ads-report task may Stop, the ``ads-report-review`` reviewer

--- a/app/ai/claude_backend_hooks.py
+++ b/app/ai/claude_backend_hooks.py
@@ -13,6 +13,7 @@ import logging
 from app.ai.bash_safety import (
     check_catalog_first_tool_args,
     check_report_overwrite,
+    check_skill_file_write,
     first_bash_deny,
     should_mark_catalog_read,
 )
@@ -278,6 +279,14 @@ class _HookMixin:
             )
             if deny_reason:
                 logger.warning('Report-overwrite guard: %s', self.task_id[:8])
+                await self._deny_pre_tool_use(request_id, deny_reason)
+                return
+            # Skill-file guard: built-in Write/Edit against
+            # .claude/skills/** only mutates the throwaway per-task copy
+            # and silently fails to persist — force vibe_seller_save_skill.
+            deny_reason = check_skill_file_write(inner_name, inner_input)
+            if deny_reason:
+                logger.warning('Skill-file write guard: %s', self.task_id[:8])
                 await self._deny_pre_tool_use(request_id, deny_reason)
                 return
             if should_mark_catalog_read(inner_name, inner_input):

--- a/app/skills_v2/save-skill/SKILL.md
+++ b/app/skills_v2/save-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: save-skill
-description: "Save the workflow you just carried out as a reusable skill, when the user asks to remember or reuse it — e.g. \"把这个任务的流程保存为技能\", \"save this workflow as a skill\", \"save to skill\", \"remember how to do this\", \"turn this into a skill\", \"next time do it the same way\". Search the existing skills first, then EXTEND the one that already covers this workflow or CREATE a new one — never duplicate. Writes user-space skills through the vibe_seller MCP tools so they persist and auto-load for future tasks."
+description: "Save the workflow you just carried out as a reusable skill — OR update an existing skill — whenever the user asks to remember, reuse, or amend it. Triggers include \"把这个任务的流程保存为技能\", \"save this workflow as a skill\", \"save to skill\", \"remember how to do this\", \"turn this into a skill\", \"next time do it the same way\", AND update/extend phrasings like \"update that skill\", \"extend the skill\", \"add this step to the skill\", \"make the skill also remember to…\", \"更新这个技能\", \"把这一步加到技能里\", \"让技能也记住…\". Search the existing skills first, then EXTEND the one that already covers this workflow or CREATE a new one — never duplicate. Skills are saved/extended ONLY through the vibe_seller_save_skill MCP tool (the built-in Write/Edit tools do not persist skill files); they then auto-load for future tasks."
 ---
 
 # Save this workflow as a skill

--- a/tests/unit/test_bash_safety.py
+++ b/tests/unit/test_bash_safety.py
@@ -14,6 +14,7 @@ from app.ai.bash_safety import (
     check_dangerous_kill,
     check_report_overwrite,
     check_report_script_write,
+    check_skill_file_write,
     is_catalog_path,
     should_mark_catalog_read,
 )
@@ -470,3 +471,63 @@ class TestReportForkGuard:
             'Write', {'file_path': 'AD_AUDIT_2026-06-12.md'}, tmp_path
         )
         assert deny is not None
+
+
+class TestSkillFileWriteGuard:
+    """Built-in Write/Edit against .claude/skills/** must be denied and
+    steered to vibe_seller_save_skill — the per-task .claude copy makes
+    those writes silently non-persistent."""
+
+    @pytest.mark.parametrize('tool', ['Write', 'Edit', 'MultiEdit'])
+    def test_absolute_skill_path_denied(self, tool):
+        deny = check_skill_file_write(
+            tool,
+            {
+                'file_path': (
+                    '/home/runner/.vibe-seller/tasks/abc/.claude/skills/'
+                    'csv-revenue-total/SKILL.md'
+                )
+            },
+        )
+        assert deny is not None
+        assert 'vibe_seller_save_skill' in deny
+
+    def test_relative_skill_path_denied(self):
+        deny = check_skill_file_write(
+            'Edit', {'file_path': '.claude/skills/my-skill/SKILL.md'}
+        )
+        assert deny is not None
+
+    def test_bundled_skill_file_denied(self):
+        """Not just SKILL.md — any file under the skill dir (references,
+        scripts) must go through save_skill's `files` map."""
+        deny = check_skill_file_write(
+            'Write',
+            {'file_path': '.claude/skills/my-skill/references/notes.md'},
+        )
+        assert deny is not None
+
+    def test_non_skill_path_allowed(self):
+        assert (
+            check_skill_file_write(
+                'Edit', {'file_path': 'stores/acme/CATALOG.md'}
+            )
+            is None
+        )
+
+    def test_other_dot_claude_path_allowed(self):
+        """Only skills/ is guarded — e.g. a settings file is not."""
+        assert (
+            check_skill_file_write(
+                'Write', {'file_path': '.claude/settings.json'}
+            )
+            is None
+        )
+
+    def test_read_tool_not_guarded(self):
+        assert (
+            check_skill_file_write(
+                'Read', {'file_path': '.claude/skills/my-skill/SKILL.md'}
+            )
+            is None
+        )


### PR DESCRIPTION
## Root cause (traced from CI server logs)

Fixes the flaky e2e `test_skill_save_reuse.py::test_create_then_extend` — *"extended skill does not mention the new WeCom step"*. It's a pre-existing bug on `main`, surfaced (not caused) by PR #73's CI.

I pulled the `e2e-server-logs` artifact and traced the follow-up-2 agent (task `04fa2726`). On *"update that same skill so it also posts to WeCom"*, the agent:

1. **Did not call `vibe_seller_save_skill`.** It ran a built-in `Edit` on the task-local `.claude/skills/csv-revenue-total/SKILL.md` and got back **"updated successfully"**.
2. But a task's `.claude/` tree is a **per-task copy** of the shared workspace (`WorkspaceManager` copies rather than symlinks, because Claude Code's Glob won't traverse symlinked `**` — `app/workspace/manager.py:581`). So the edit only mutated the throwaway copy; the durable skill under `~/.vibe-seller/.claude/skills/` never changed.
3. The test reads the durable file via the workspace API → correctly still no WeCom → assertion fails.

The agent even reasoned the skill was *"built-in and cannot be durably updated"* and recorded a note instead — a wrong-but-plausible fallback the **false success** handed it.

## Fix (design, not symptom)

Per debug-ci's *"prompts are advisory; enforce the contract in code"*:

1. **Enforce in code (primary).** New PreToolUse guard `check_skill_file_write` denies built-in `Write`/`Edit`/`MultiEdit` on any `.claude/skills/**` path and points the agent at `vibe_seller_save_skill`. The silent non-persisting edit — the whole trap — is now impossible; the agent gets a clear deny instead of a false success. Mirrors the existing report-overwrite guard and wires in beside it.
2. **Fix skill selection.** The `save-skill` skill's `description` only triggered on save/create/remember phrasings, so *"update/extend that skill"* didn't reliably load it and the agent freelanced. Broadened the triggers (EN + ZH) to cover update/extend/add-a-step, and stated skills persist only through `vibe_seller_save_skill`.

## Tests

`tests/unit/test_bash_safety.py::TestSkillFileWriteGuard` — absolute + relative skill paths denied (Write/Edit/MultiEdit), bundled files under the skill dir denied, non-skill and other `.claude/**` paths allowed, `Read` not guarded. Full `test_bash_safety.py` + `test_mcp_skills.py` green (92 passed).

## Note on the e2e test

The guard makes the *silent-failure* path impossible, and the broadened triggers make the correct path load reliably — so the agent is now forced onto `vibe_seller_save_skill`. Once this merges to `main`, PR #73 (and every other branch) can rebase to clear the flaky e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)