### PR TITLE
fix(agent): keep control channel open until review gates are satisfied

### DIFF
--- a/app/ai/claude_backend.py
+++ b/app/ai/claude_backend.py
@@ -182,6 +182,12 @@ class AgentSession(_HookMixin, _StreamMixin):
         self._input_closed: bool = False
         # Circuit breaker: track recent tool call signatures
         self._recent_tool_calls: list[str] = []
+        # How many times this session has re-driven the agent because a
+        # ``result`` arrived while a review gate was still unsatisfied.
+        # Bounds the review loop so a gate the agent can never satisfy
+        # still terminates. See the result branch in
+        # ``claude_backend_stream._handle_event``.
+        self._review_redrive_count: int = 0
         # PreToolUse-hook state. See app.ai.bash_safety and
         # app.ai.claude_backend_utils.check_skill_prereqs.
         self._loaded_skills: set[str] = set()
@@ -553,7 +559,26 @@ class AgentSession(_HookMixin, _StreamMixin):
 
     async def _send_stdin(self, msg: dict, *, label: str = 'stdin'):
         """Write a JSON message to the subprocess stdin."""
-        if not self._proc or not self._proc.stdin:
+        if not self._proc or not self._proc.stdin or self._input_closed:
+            # Dropping a tool-approval / hook reply after the control
+            # channel is gone is a contract violation, not a benign
+            # no-op: the CLI default-denies the unanswered tool with its
+            # generic "user doesn't want to take this action" message,
+            # which the agent misreads as a human interrupt. Make it
+            # loud so it can never again silently ship a placeholder
+            # result. (The result-branch review gate keeps the channel
+            # open through the review loop so this shouldn't fire.)
+            if self._input_closed and label in (
+                'control_response',
+                'hook_response',
+            ):
+                logger.warning(
+                    'Dropping %s for %s: control channel already closed '
+                    '— the tool call will default-deny. This is a '
+                    'review/lifecycle race.',
+                    label,
+                    self.task_id[:8],
+                )
             return
         line = json.dumps(msg, ensure_ascii=False) + '\n'
         if AGENT_DEBUG:

--- a/app/ai/claude_backend.py
+++ b/app/ai/claude_backend.py
@@ -182,12 +182,7 @@ class AgentSession(_HookMixin, _StreamMixin):
         self._input_closed: bool = False
         # Circuit breaker: track recent tool call signatures
         self._recent_tool_calls: list[str] = []
-        # How many times this session has re-driven the agent because a
-        # ``result`` arrived while a review gate was still unsatisfied.
-        # Bounds the review loop so a gate the agent can never satisfy
-        # still terminates. See the result branch in
-        # ``claude_backend_stream._handle_event``.
-        self._review_redrive_count: int = 0
+        self._review_redrive_count: int = 0  # review-gate re-drive bound
         # PreToolUse-hook state. See app.ai.bash_safety and
         # app.ai.claude_backend_utils.check_skill_prereqs.
         self._loaded_skills: set[str] = set()
@@ -560,22 +555,15 @@ class AgentSession(_HookMixin, _StreamMixin):
     async def _send_stdin(self, msg: dict, *, label: str = 'stdin'):
         """Write a JSON message to the subprocess stdin."""
         if not self._proc or not self._proc.stdin or self._input_closed:
-            # Dropping a tool-approval / hook reply after the control
-            # channel is gone is a contract violation, not a benign
-            # no-op: the CLI default-denies the unanswered tool with its
-            # generic "user doesn't want to take this action" message,
-            # which the agent misreads as a human interrupt. Make it
-            # loud so it can never again silently ship a placeholder
-            # result. (The result-branch review gate keeps the channel
-            # open through the review loop so this shouldn't fire.)
+            # Dropping an approval/hook reply after the channel is closed
+            # is a contract violation (the CLI default-denies the tool).
             if self._input_closed and label in (
                 'control_response',
                 'hook_response',
             ):
                 logger.warning(
-                    'Dropping %s for %s: control channel already closed '
-                    '— the tool call will default-deny. This is a '
-                    'review/lifecycle race.',
+                    'Dropping %s for %s: control channel closed — tool '
+                    'will default-deny (review/lifecycle race).',
                     label,
                     self.task_id[:8],
                 )

--- a/app/ai/claude_backend_stream.py
+++ b/app/ai/claude_backend_stream.py
@@ -12,6 +12,8 @@ import logging
 
 from app.ai.claude_backend_utils import (
     AGENT_DEBUG,
+    check_exec_review_status_for_stop,
+    check_review_status_for_stop,
     get_next_seq,
     parse_wait_condition,
 )
@@ -23,6 +25,12 @@ from app.models.task_message import TaskMessage
 from app.task_states import TaskStatus
 
 logger = logging.getLogger(__name__)
+
+# Max times a session will re-drive the agent when a `result` arrives
+# with a review gate still unsatisfied, before giving up and letting the
+# turn end. Matches the reviewer loop's iter-5 `incomplete` ceiling so a
+# gate the agent genuinely cannot satisfy still terminates.
+REVIEW_REDRIVE_MAX = 5
 
 # How long to wait on a single `stdout.readline()` before issuing
 # a stall-reaper heartbeat bump. The model can take minutes to
@@ -265,6 +273,51 @@ class _StreamMixin:
         elif etype == 'result':
             text = event.get('result', '')
             is_error = event.get('is_error', False)
+            # ── Review-gate guard (project-wide) ───────────────
+            # A `result` while a server-mandated review gate is still
+            # unsatisfied is NOT the end of the turn. The DoD/exec
+            # review loop runs AFTER the deliverable — it spawns a
+            # reviewer subagent and fixes the deliverable in place, and
+            # every one of those tool calls needs the approval channel.
+            # If we close stdin here (below), those approvals get
+            # dropped and the CLI default-denies them, so the review is
+            # abandoned and a placeholder result ships as "completed".
+            # Instead: keep the channel open and re-drive the agent with
+            # the gate's own deny reason (the same one the Stop hook
+            # uses), so it actually satisfies the gate on a LIVE channel.
+            # Bounded so an unsatisfiable gate still terminates. Uses the
+            # shared gate helpers, so this covers every review gate, not
+            # one task type.
+            if self._executing and not is_error:
+                gate_reason = check_review_status_for_stop(
+                    self.task_dir
+                ) or check_exec_review_status_for_stop(self.task_dir)
+                if (
+                    gate_reason
+                    and self._review_redrive_count < REVIEW_REDRIVE_MAX
+                ):
+                    self._review_redrive_count += 1
+                    logger.warning(
+                        'Review gate unsatisfied at result for %s — '
+                        're-driving agent (%d/%d) instead of closing the '
+                        'control channel',
+                        self.task_id[:8],
+                        self._review_redrive_count,
+                        REVIEW_REDRIVE_MAX,
+                    )
+                    await self._emit_message(
+                        'agent_event',
+                        json.dumps({
+                            'event': 'review_gate_redrive',
+                            'iter': self._review_redrive_count,
+                        }),
+                    )
+                    await self.send_user_message(
+                        'You cannot finish yet — a required review gate '
+                        'is not satisfied. Do NOT just re-answer; act on '
+                        'this and then finish:\n\n' + gate_reason
+                    )
+                    return
             if event.get('subtype') == 'success' and not is_error:
                 self._agent_success = True
             # ``None`` means Stop-hook reflection never fired this

--- a/tests/unit/test_handle_event_result.py
+++ b/tests/unit/test_handle_event_result.py
@@ -4,7 +4,7 @@ Verifies that only the first execution-phase result event is emitted
 as role='result'; subsequent results are demoted to 'assistant'.
 """
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -328,6 +328,77 @@ class TestReviewGateRedrive:
         assert emitted == [('result', 'Verified answer')]
         assert session._first_result_emitted is True
         assert session._review_redrive_count == 0
+
+    # ── The core regression: the control channel must stay OPEN while a
+    # review gate is unsatisfied. This is the exact invariant the
+    # production bug violated — a `result` closed stdin, so the DoD
+    # reviewer subagent's tool calls (and the in-place fixes) lost their
+    # approval channel and the CLI default-denied all of them. Neither
+    # the workflow tests (FakeAgent replaces AgentSession, never touches
+    # stdin) nor any e2e test covered this surface. These two pins do.
+
+    async def test_unsatisfied_gate_keeps_control_channel_open(self):
+        """Unsatisfied gate → stdin is NOT closed (approvals survive)."""
+        session = _make_session('auto')
+        session.task_dir = '/tmp/fake-task'
+        session._proc = Mock()
+        session._proc.stdin = Mock()
+
+        async def _noop(*a, **k):
+            pass
+
+        with (
+            patch.object(session, '_emit_message', _noop),
+            patch.object(session, 'send_user_message', _noop),
+            patch(
+                'app.ai.claude_backend_stream.check_review_status_for_stop',
+                return_value='Reviewer never ran — spawn the DoD reviewer.',
+            ),
+            patch(
+                'app.ai.claude_backend_stream'
+                '.check_exec_review_status_for_stop',
+                return_value=None,
+            ),
+        ):
+            await session._handle_event({
+                'type': 'result',
+                'result': 'placeholder',
+            })
+
+        # The bug: these would be True / called. The fix keeps them clean.
+        assert session._input_closed is False
+        session._proc.stdin.close.assert_not_called()
+
+    async def test_satisfied_gate_closes_control_channel(self):
+        """Gate satisfied → stdin DOES close so the CLI exits (the fix
+        must not regress normal end-of-turn)."""
+        session = _make_session('auto')
+        session.task_dir = '/tmp/fake-task'
+        session._proc = Mock()
+        session._proc.stdin = Mock()
+
+        async def _noop(*a, **k):
+            pass
+
+        with (
+            patch.object(session, '_emit_message', _noop),
+            patch(
+                'app.ai.claude_backend_stream.check_review_status_for_stop',
+                return_value=None,
+            ),
+            patch(
+                'app.ai.claude_backend_stream'
+                '.check_exec_review_status_for_stop',
+                return_value=None,
+            ),
+        ):
+            await session._handle_event({
+                'type': 'result',
+                'result': 'Verified answer',
+            })
+
+        assert session._input_closed is True
+        session._proc.stdin.close.assert_called_once()
 
 
 class TestHandleEventReflectionGuard:

--- a/tests/unit/test_handle_event_result.py
+++ b/tests/unit/test_handle_event_result.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from app.ai.claude_backend import AgentSession
+from app.ai.claude_backend_stream import REVIEW_REDRIVE_MAX
 
 pytestmark = pytest.mark.unit
 
@@ -217,6 +218,116 @@ class TestHandleEventResultDedup:
         assert emitted[0] == ('result', 'Auto result')
         assert emitted[1] == ('assistant', 'Extra ack')
         assert session._result_text == 'Auto result'
+
+
+class TestReviewGateRedrive:
+    """A result while a review gate is unsatisfied must NOT end the turn:
+    keep the control channel open and re-drive the agent instead of
+    closing stdin (which would silently deny the reviewer subagent's
+    tool calls). See app/ai/claude_backend_stream result branch."""
+
+    async def test_unsatisfied_gate_redrives_instead_of_emitting(self):
+        session = _make_session('auto')
+        session.task_dir = '/tmp/fake-task'
+        emitted: list[tuple[str, str]] = []
+        sent: list[str] = []
+
+        async def _mock_emit(role, content):
+            emitted.append((role, content))
+
+        async def _mock_send(msg):
+            sent.append(msg)
+
+        with (
+            patch.object(session, '_emit_message', _mock_emit),
+            patch.object(session, 'send_user_message', _mock_send),
+            patch(
+                'app.ai.claude_backend_stream.check_review_status_for_stop',
+                return_value='Reviewer never ran. Spawn the DoD reviewer.',
+            ),
+            patch(
+                'app.ai.claude_backend_stream'
+                '.check_exec_review_status_for_stop',
+                return_value=None,
+            ),
+        ):
+            await session._handle_event({
+                'type': 'result',
+                'result': 'placeholder — reviewer running in background',
+            })
+
+        # The placeholder result was NOT finalized as the turn's result.
+        assert session._first_result_emitted is False
+        assert session._result_text == ''
+        # The agent was re-driven with the gate's deny reason.
+        assert len(sent) == 1
+        assert 'Reviewer never ran' in sent[0]
+        assert session._review_redrive_count == 1
+        # A structured re-drive marker was emitted (not the result card).
+        assert any(r == 'agent_event' for r, _ in emitted)
+        assert not any(r == 'result' for r, _ in emitted)
+
+    async def test_redrive_is_bounded(self):
+        """After REVIEW_REDRIVE_MAX re-drives, the turn is allowed to end
+        so an unsatisfiable gate can't wedge the session forever."""
+        session = _make_session('auto')
+        session.task_dir = '/tmp/fake-task'
+        session._review_redrive_count = REVIEW_REDRIVE_MAX
+        emitted: list[tuple[str, str]] = []
+
+        async def _mock_emit(role, content):
+            emitted.append((role, content))
+
+        with (
+            patch.object(session, '_emit_message', _mock_emit),
+            patch(
+                'app.ai.claude_backend_stream.check_review_status_for_stop',
+                return_value='still gaps',
+            ),
+            patch(
+                'app.ai.claude_backend_stream'
+                '.check_exec_review_status_for_stop',
+                return_value=None,
+            ),
+        ):
+            await session._handle_event({
+                'type': 'result',
+                'result': 'Final answer',
+            })
+
+        # Bound hit → normal end-of-turn: result card emitted.
+        assert emitted == [('result', 'Final answer')]
+        assert session._first_result_emitted is True
+
+    async def test_satisfied_gate_ends_turn_normally(self):
+        """Gate satisfied (helpers return None) → result finalizes."""
+        session = _make_session('auto')
+        session.task_dir = '/tmp/fake-task'
+        emitted: list[tuple[str, str]] = []
+
+        async def _mock_emit(role, content):
+            emitted.append((role, content))
+
+        with (
+            patch.object(session, '_emit_message', _mock_emit),
+            patch(
+                'app.ai.claude_backend_stream.check_review_status_for_stop',
+                return_value=None,
+            ),
+            patch(
+                'app.ai.claude_backend_stream'
+                '.check_exec_review_status_for_stop',
+                return_value=None,
+            ),
+        ):
+            await session._handle_event({
+                'type': 'result',
+                'result': 'Verified answer',
+            })
+
+        assert emitted == [('result', 'Verified answer')]
+        assert session._first_result_emitted is True
+        assert session._review_redrive_count == 0
 
 
 class TestHandleEventReflectionGuard:


### PR DESCRIPTION
## Problem

A task with a review gate could finish "completed" with an **unfinished deliverable and a placeholder result** — and the agent's attempts to satisfy the gate were all denied. Traced from a real task's server logs.

**Root cause:** in auto mode the stream reader closes the CLI's stdin on the **first** `result` event (`claude_backend_stream`). But the review gates by design require work *after* the deliverable — the DoD/exec review loop spawns an adversarial **reviewer subagent** (Task tool) that writes `REVIEW_<date>_iter<N>.md`, then fixes the deliverable in place. Every one of those tool calls (the `Task` spawn, the subagent's own `Bash`/`Write`, the main agent's fixes) raises a `PreToolUse`/`canUseTool` approval over the control channel. Our handler answers via `_send_stdin`, which **silently no-ops once stdin is closed** (`claude_backend.py`). Unanswered approvals → the CLI default-denies each tool with its generic *"the user doesn't want to take this action"* message → the agent misreads it as a human interrupt, abandons the review, and the task ships a placeholder result. (Observed: ~182 denials, the gate *was* armed, no REVIEW file ever written.)

## Fix (design-level, project-wide)

Enforces one invariant in one place, for **every** review gate: *the control channel stays open while the agent still owes server-mandated review work.*

- **`claude_backend_stream` result branch:** before treating a `result` as end-of-turn (and closing stdin), consult the **same** gate helpers the Stop hook uses (`check_review_status_for_stop` OR `check_exec_review_status_for_stop`). If a gate is unsatisfied, don't finalize/close — keep the channel live and **re-drive** the agent with the gate's own deny reason so it satisfies the gate on a working channel. Bounded by `REVIEW_REDRIVE_MAX` (5, matching the reviewer loop's iter-5 ceiling) so an unsatisfiable gate still terminates. No-op for tasks with no review gate (helpers return `None`).
- **`_send_stdin`:** dropping a control/hook response after the channel is closed is a contract violation, not a benign no-op — now logged loudly so a placeholder can never again silently ship as success.

Covers DoD report review, general skill review, and exec review via the shared helpers — not one task type.

## Tests

- `tests/unit/test_handle_event_result.py::TestReviewGateRedrive` — unsatisfied gate re-drives instead of finalizing; bounded by `REVIEW_REDRIVE_MAX`; satisfied gate ends the turn normally. Full `test_handle_event_result.py` + `test_stop_reflection_hook.py` + `test_bash_safety.py` green.

## Live verification

Deployed to a real server and resumed the exact task that originally failed. Before (buggy): 182 denials, 0 REVIEW files, placeholder result. After (fixed): **0 denials, 2 re-drive markers, REVIEW iter1+iter2 both `Status: ok`, a full real result, task genuinely completed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)