### PR TITLE
fix: DoD review verifies the TARGET marketplace; save-skill mis-classification; e2e skill-test isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,11 @@ jobs:
           E2E_N="${E2E_WORKERS:-0}"
           XDIST_ARGS=""
           if [ "$E2E_N" -gt 1 ] 2>/dev/null; then
-            XDIST_ARGS="-n $E2E_N"
+            # --dist loadgroup so tests sharing a resource (the workspace
+            # skill namespace is workspace-global, not per-worker) can pin
+            # to one worker via @pytest.mark.xdist_group and never mutate
+            # it concurrently. Ungrouped tests still distribute by load.
+            XDIST_ARGS="-n $E2E_N --dist loadgroup"
           fi
           uv run pytest tests/e2e --e2e -v --log-cli-level=INFO \
             --reruns 1 \

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -5,6 +5,22 @@ allowed-tools: Bash(browser-use:*)
 requires: [amazon-shared]
 review:
   criteria: |
+    - The listing is live on the TARGET marketplace the user asked for
+      (the exact country / `sellercentral.amazon.<tld>`), confirmed on
+      THAT marketplace's own Manage Inventory — NOT merely "batch
+      submitted", and NOT live only on a different marketplace. Amazon
+      groups marketplaces two ways and you must not conflate them: a
+      UNIFIED regional account whose sibling marketplaces share ONE
+      catalog + an ACCOUNT-LEVEL bulk feed (the same batch id then shows
+      on every sibling's listing/status page, so a batch row on one is NOT
+      proof the SKU is live on another, and the offer can land on the
+      account's home marketplace only); versus a SEPARATE account (a
+      different region, or a legacy single-marketplace login) that is a
+      different catalog entirely, created and confirmed independently,
+      often with its own ASIN. Either way: if the TARGET marketplace's own
+      inventory does not show the SKU live, it is a GAP even when the
+      upload "succeeded" — a listing on the wrong marketplace, or only a
+      batch id, is not done.
     - Every attempted SKU is ACTUALLY LIVE, not just "uploaded": on
       Manage Inventory the parent shows Variations(N) and each child has
       a real ASIN (not "-"), with title / bullets / images matching the
@@ -21,12 +37,20 @@ review:
     - "*.xlsm"
     - "LISTING_*.md"
   verify_by: |
-    Open Manage Inventory (skucentral?mSku=<sku>, no &condition=New) for
-    each attempted SKU and confirm it exists with the intended content
-    and a real ASIN; download the LATEST processing report for EVERY
-    batch you uploaded and `parse-feedback` it -- confirm zero errors except
-    18320. Do NOT accept a batch shown "Action required / SUCCESS (OTHER)"
-    (e.g. 100476) as done. For a delete, confirm the SKU is gone.
+    Open Manage Inventory ON THE TARGET MARKETPLACE
+    (`sellercentral.amazon.<target-tld>/skucentral?mSku=<sku>`, no
+    &condition=New) for each attempted SKU and confirm it exists LIVE on
+    that marketplace with the intended content and a real ASIN, and that
+    its offer/price/stock show on that marketplace's Pricing view. Do NOT
+    accept a batch-status row on some marketplace's listing/status page as
+    proof — the batch id is account-level and appears on every
+    marketplace. If the target marketplace's inventory is empty but
+    another marketplace's shows the SKU, the offer landed on the wrong
+    marketplace: that is a GAP. Download the LATEST processing report for
+    EVERY batch you uploaded and `parse-feedback` it -- confirm zero
+    errors except 18320. Do NOT accept a batch shown "Action required /
+    SUCCESS (OTHER)" (e.g. 100476) as done. For a delete, confirm the SKU
+    is gone.
 ---
 
 # Amazon — Listing CRUD (flat-file upload)

--- a/app/skills_v2/save-skill/SKILL.md
+++ b/app/skills_v2/save-skill/SKILL.md
@@ -36,6 +36,23 @@ written with the built-in Write tool is discarded when the task ends.
 - **`custom` / `imported`** (`updatable: true`) — user-space. These are
   the only skills you may overwrite.
 
+**Never decide a skill is built-in FROM MEMORY, and never silently skip
+an update.** This is the failure that keeps a follow-up from landing: the
+user says "update that skill", you *recall* it as built-in, and you do
+nothing. Two rules kill it:
+
+1. **`source` comes from `vibe_seller_list_skills`, not memory** — call
+   it again for the update, every time. A skill YOU created earlier this
+   session is **`custom`** (user-space, updatable), NOT built-in — your
+   own `vibe_seller_save_skill` made it.
+2. **When in doubt, just attempt the save.** `vibe_seller_save_skill(slug,
+   merged_md)` OVERWRITES an updatable skill (that is the extend) and
+   only *rejects* a genuinely built-in slug — with a message telling you
+   to create a new one. So the server, not your guess, is the authority:
+   try the save; on rejection, create a new user-space skill. Never
+   conclude "it's built-in, nothing to do" and end the turn — that leaves
+   the user's request undone.
+
 ## Search, then judge: extend or create
 
 List the skills and read each `description` — that field, not the slug,

--- a/tests/e2e/test_followup_review_scoping.py
+++ b/tests/e2e/test_followup_review_scoping.py
@@ -115,6 +115,12 @@ def _followup(client, task_id, content, marker):
     return text
 
 
+# Shares the workspace-global skill namespace with the other
+# skill-mutating e2e tests, so it must run on the SAME xdist worker
+# (serially). Without this, a sibling test's whole-namespace cleanup
+# deleted this test's review skill mid-run and its follow-up stalled.
+# Requires ``--dist loadgroup`` (set in CI). See test_skill_save_reuse.py.
+@pytest.mark.xdist_group('workspace_skills')
 class TestFollowUpReviewScoping:
     def test_multi_round_followups_each_reviewed_separately(
         self, api_client, review_skill

--- a/tests/e2e/test_skill_prereq_hook.py
+++ b/tests/e2e/test_skill_prereq_hook.py
@@ -158,15 +158,26 @@ class TestSkillPrereqHookEndToEnd:
         task_id_prefix = task_id[:8]
         logger.info('Created prereq-hook task %s', task_id_prefix)
 
+        # This task loads ``noon-ads``, an AD_SKILL, which binds it to the
+        # ad DoD-review gate — ORTHOGONAL to the prereq hook under test.
+        # Whether the agent's fast-signoff reviewer lets the task reach
+        # ``completed`` (or it ends ``failed``/UNVERIFIED on that gate) is
+        # non-deterministic agent behavior and NOT this test's contract.
+        # The prereq-hook contract — (1) the deny fired, (2) noon-shared's
+        # content reached the agent — is fully observable either way (both
+        # happen while the agent works, before it attempts to finish), so
+        # we wait for any TERMINAL state and assert on those two, never on
+        # the final status. Coupling to status imported the flaky gate.
         result = poll_task_status(
             api_client,
             task_id,
-            target_statuses={'completed'},
-            fail_statuses={'failed'},
+            target_statuses={'completed', 'failed'},
             timeout=PIPELINE_TIMEOUT,
         )
-        assert result['status'] == 'completed', (
-            f'Task failed: {result.get("error", "unknown")}'
+        logger.info(
+            'prereq-hook task %s reached terminal status=%s',
+            task_id_prefix,
+            result.get('status'),
         )
 
         # ── Assertion 1: the hook actually fired a deny ─────────

--- a/tests/e2e/test_skill_save_reuse.py
+++ b/tests/e2e/test_skill_save_reuse.py
@@ -159,12 +159,18 @@ def orders_csv(tmp_path):
 
 @pytest.fixture
 def created_skills_cleanup(api_client):
-    """Delete any user-space skills this test creates, so the shared
-    dev workspace and re-runs stay clean."""
-    before = set(_custom_skills(api_client))
-    yield
-    after = set(_custom_skills(api_client))
-    for slug in after - before:
+    """Delete only the user-space skills THIS test registers (by adding
+    their slugs to the yielded set), so re-runs stay clean.
+
+    Must NOT delete the whole before/after delta of the skill list: that
+    namespace is workspace-global and shared across parallel xdist
+    workers, so a delta cleanup would delete a *sibling* test's skill
+    mid-run. The test owns the slugs it created and registers exactly
+    those.
+    """
+    owned: set[str] = set()
+    yield owned
+    for slug in owned:
         api_client.delete(f'{BASE_URL}/api/workspace/skills/{slug}')
 
 
@@ -177,6 +183,11 @@ def _assert_total(text, total):
 # ── Test ────────────────────────────────────────────
 
 
+# All skill-mutating e2e tests share the workspace-global skill namespace,
+# so they must run on the SAME xdist worker (serially) — never
+# concurrently. Otherwise one test's snapshot/cleanup races another's
+# create/delete. Requires ``--dist loadgroup`` (set in CI).
+@pytest.mark.xdist_group('workspace_skills')
 class TestSaveAndReuseSkill:
     def test_create_then_extend(
         self, api_client, orders_csv, wecom_stub, created_skills_cleanup
@@ -227,6 +238,7 @@ class TestSaveAndReuseSkill:
             'no user-space skill was created by "save as skill"; '
             f'custom skills: {sorted(customs_after_save)}'
         )
+        created_skills_cleanup.update(new_slugs)  # own these for teardown
         for slug in new_slugs:
             assert customs_after_save[slug]['source'] == 'custom'
 
@@ -264,11 +276,15 @@ class TestSaveAndReuseSkill:
         _wait_for_followup_result(api_client, task2['id'], count2)
 
         customs_final = _custom_skills(api_client)
-        # No brand-new near-duplicate skill appeared on the second save.
-        assert set(customs_final) == set(customs_after_save), (
+        # The second save must EXTEND the existing slug, not mint a new
+        # near-duplicate. Check only for a NEW slug appearing (a subset
+        # check, scoped to this test's serialized worker) rather than
+        # whole-namespace equality — equality would also trip if a
+        # sibling test's skill were added/removed in the shared namespace.
+        dup_slugs = set(customs_final) - set(customs_after_save)
+        assert not dup_slugs, (
             'second "save as skill" duplicated instead of extending; '
-            f'before={sorted(customs_after_save)} '
-            f'after={sorted(customs_final)}'
+            f'new slug(s) appeared: {sorted(dup_slugs)}'
         )
         # The originally-created skill now covers the WeCom step.
         assert any(

--- a/tests/e2e/test_skill_save_reuse_noon.py
+++ b/tests/e2e/test_skill_save_reuse_noon.py
@@ -93,6 +93,9 @@ def has_wecom_bot(api_client):
     return True
 
 
+# Serialize with the other skill-mutating e2e tests (shared workspace
+# skill namespace). See test_skill_save_reuse.py for the rationale.
+@pytest.mark.xdist_group('workspace_skills')
 class TestSaveAndReuseSkillLive:
     def test_create_then_extend_live(
         self, api_client, live_store, has_wecom_bot
@@ -171,9 +174,10 @@ class TestSaveAndReuseSkillLive:
         _wait_for_followup_result(api_client, task2['id'], count2)
 
         customs_final = _custom_skills(api_client)
-        assert set(customs_final) == set(customs_after_save), (
-            'second save duplicated instead of extending: '
-            f'{sorted(customs_after_save)} -> {sorted(customs_final)}'
+        dup_slugs = set(customs_final) - set(customs_after_save)
+        assert not dup_slugs, (
+            'second save duplicated instead of extending; '
+            f'new slug(s) appeared: {sorted(dup_slugs)}'
         )
         assert any(
             'wecom' in _skill_md(api_client, slug).lower()

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -25,6 +25,8 @@ import sys
 
 import pytest
 
+from app.ai.skill_review import parse_skill_review
+
 pytestmark = pytest.mark.unit
 
 openpyxl = pytest.importorskip('openpyxl')
@@ -1286,3 +1288,41 @@ def test_parse_feedback_unified_report_finds_child_error(tmp_path, capsys):
         _run(['parse-feedback', str(p)])
     out = capsys.readouterr().out
     assert 'WIDGET-006-WHT' in out and '8560' in out
+
+
+class TestReviewContractTargetMarketplace:
+    """The DoD review contract must require verifying the listing on the
+    TARGET marketplace — the design fix for the SA/AE confusion where a
+    listing "for AE" completed on an account-level batch that actually
+    showed on SA. Must cover BOTH account structures (unified pan-regional
+    and separate per-marketplace)."""
+
+    def _review(self):
+        skill_md = (
+            Path(__file__).resolve().parents[2]
+            / 'app'
+            / 'skills_v2'
+            / 'amazon-listing'
+            / 'SKILL.md'
+        )
+        review = parse_skill_review(skill_md)
+        assert review is not None, 'amazon-listing must declare a review block'
+        return (review.criteria + '\n' + review.verify_by).lower()
+
+    def test_requires_target_marketplace_verification(self):
+        text = self._review()
+        assert 'target' in text and 'marketplace' in text
+        # Verify on the target marketplace's OWN inventory, not a batch row.
+        assert 'manage inventory' in text or 'inventory' in text
+        assert 'batch' in text  # the account-level batch trap is named
+
+    def test_covers_both_account_structures(self):
+        text = self._review()
+        assert 'unified' in text, 'must name the unified pan-regional case'
+        assert 'separate' in text, 'must name the separate per-marketplace case'
+
+    def test_wrong_marketplace_is_a_gap(self):
+        text = self._review()
+        # A listing on the wrong marketplace / only a batch id must not pass.
+        assert 'gap' in text
+        assert 'wrong marketplace' in text or 'different marketplace' in text

--- a/tests/unit/test_mcp_skills.py
+++ b/tests/unit/test_mcp_skills.py
@@ -6,6 +6,7 @@ dispatch branches (vibe_seller_list_skills / vibe_seller_save_skill).
 """
 
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -224,3 +225,37 @@ class TestMcpDispatch:
             mock_api.assert_awaited_once_with(
                 'PUT', '/api/workspace/skills/s', {'skill_md': SKILL_MD}
             )
+
+
+class TestSaveSkillGuidanceForbidsMisclassification:
+    """The save-skill SKILL.md must forbid the observed failure: on an
+    "update that skill" follow-up the agent recalled a skill IT created
+    as built-in and silently skipped the extend. The server already
+    handles both cases (overwrite custom / reject built-in), so the fix
+    lives in the guidance: never decide built-in from memory, and never
+    skip an update."""
+
+    def _guidance(self):
+        p = (
+            Path(__file__).resolve().parents[2]
+            / 'app'
+            / 'skills_v2'
+            / 'save-skill'
+            / 'SKILL.md'
+        )
+        return p.read_text(encoding='utf-8').lower()
+
+    def test_forbids_deciding_builtin_from_memory(self):
+        g = self._guidance()
+        assert 'from memory' in g
+        # a skill the agent created this session is custom, not built-in
+        assert 'created' in g and 'custom' in g
+
+    def test_forbids_silently_skipping_an_update(self):
+        g = self._guidance()
+        assert 'never' in g and 'skip' in g
+
+    def test_tells_agent_to_attempt_the_save_and_let_server_decide(self):
+        g = self._guidance()
+        assert 'attempt the save' in g or 'just attempt' in g
+        assert 'overwrites' in g and 'reject' in g


### PR DESCRIPTION
Three design fixes, all surfaced by a live listing run where the user
asked to create a listing on one marketplace but it landed on a sibling
marketplace and was reported "done" anyway.

## 1. DoD review must verify the listing on the TARGET marketplace
`app/skills_v2/amazon-listing/SKILL.md`

A bulk-feed "batch submitted" is **not** proof the listing is live on the
marketplace the user asked for. The review `criteria`/`verify_by` now
require confirming the SKU is live on **THAT** marketplace's own Manage
Inventory (`sellercentral.amazon.<target-tld>/skucentral?mSku=<sku>`),
not merely batch-submitted and not live only on a different marketplace.

Region-general (no marketplace enumeration) and covers **both** account
structures Amazon uses:
- **Unified regional account** — sibling marketplaces share one catalog +
  an account-level bulk feed, so the same batch id shows on every
  sibling's status page (easy to mistake a sibling for the target).
- **Separate account** — a different region or a legacy
  single-marketplace login is a different catalog entirely.

Either way: if the target marketplace's own inventory doesn't show the
SKU live, it's a **GAP**. Also retains the existing "no partial family
(parent live, a child missing) is done" criterion.

Pinned by `tests/unit/test_amazon_listing_bulk_skill.py`
(`TestReviewContractTargetMarketplace`), which parses the review block
and asserts target-marketplace verification, both account structures,
and the batch/gap/wrong-marketplace language.

## 2. save-skill: don't mis-classify a user skill as built-in and skip the update
`app/skills_v2/save-skill/SKILL.md`

An agent that created a skill earlier in the session would later decide
**from memory** that it was "built-in" and silently skip an extend. The
guidance now forbids classifying built-in-ness from memory, states that
a skill you created this session is `custom` (not built-in), and says
that when in doubt just attempt `vibe_seller_save_skill(slug, merged)` —
the server overwrites an updatable skill and rejects a built-in one with
an actionable message. Pinned by
`tests/unit/test_mcp_skills.py::TestSaveSkillGuidanceForbidsMisclassification`.

## 3. e2e: isolate skill-mutating tests (unblocks CI)
`tests/e2e/*`, `.github/workflows/ci.yml`

The workspace skill namespace is workspace-global and shared across
parallel xdist workers, but three e2e tests treated it as private —
`test_create_then_extend`'s cleanup deleted the whole before/after delta
of the skill list, so under `-n` it deleted a **sibling** test's skill
mid-run (stalling that test's follow-up) and broke its own whole-set
assertion when a concurrent skill appeared/vanished. A race: it passed
when the cleanup windows didn't overlap, failed when they did.

Fix from design — a test must never mutate/inspect skills it doesn't own:
- Serialize skill-mutating e2e tests onto one worker via
  `@pytest.mark.xdist_group('workspace_skills')` + `--dist loadgroup` in
  CI (ungrouped tests still distribute by load — no regression).
- Scope cleanup to only the slugs a test registers, never the
  whole-namespace delta.
- Replace whole-namespace `==` assertions with a subset check that can't
  trip on a sibling's skill.

Also decoupled `test_skill_prereq_hook` from an orthogonal gate: it loads
`noon-ads` to exercise the prereq hook, which binds the task to the
always-require ad DoD-review gate (#57) — so ~10% of runs the real agent
refused the fast-signoff reviewer and the task ended `failed`, flaking a
`status == 'completed'` assertion. The test's real contract (deny fired +
prereq content reached the agent) is observable regardless of final
status, so it now waits for any terminal state and asserts only those.

Depends on the turn-scoped review rollover from #77 (merged into `main`,
present here via the merge commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)