### PR TITLE
fix(amazon-listing): cross-marketplace relisting (offer routing, operation, console-scope) + review gate can't be self-certified

### DIFF
--- a/app/ai/bash_safety.py
+++ b/app/ai/bash_safety.py
@@ -483,7 +483,7 @@ def _is_server_reviewed(audit_text: str) -> bool:
     return False
 
 
-def check_review_status(task_dir) -> str | None:
+def check_review_status(task_dir, subagent_ran=None) -> str | None:
     """Deny reason if the DoD reviewer hasn't returned ``ok`` (or
     ``incomplete`` at iter ≥ 5); else ``None``. Fires for ads skills AND
     any skill declaring a ``review:`` block; no-op otherwise.
@@ -508,7 +508,7 @@ def check_review_status(task_dir) -> str | None:
             # decides whether the task needed one (real deliverable →
             # gaps) or had nothing to verify (quick lookup → signs off
             # fast).
-            return report_reviewer.reviewer_verdict(task_dir)
+            return report_reviewer.reviewer_verdict(task_dir, subagent_ran)
         return None  # Nothing bound that requires review.
 
     # This path also gates the ENDING-TURN bypass (streaming result
@@ -539,7 +539,7 @@ def check_review_status(task_dir) -> str | None:
         )
 
     # Reviewer sign-off — shared with the set_task_result path.
-    return report_reviewer.reviewer_verdict(task_dir)
+    return report_reviewer.reviewer_verdict(task_dir, subagent_ran)
 
 
 # ── Ad-tuning execution-review guard ───────────────────────────────

--- a/app/ai/claude_backend.py
+++ b/app/ai/claude_backend.py
@@ -183,6 +183,12 @@ class AgentSession(_HookMixin, _StreamMixin):
         # Circuit breaker: track recent tool call signatures
         self._recent_tool_calls: list[str] = []
         self._review_redrive_count: int = 0  # review-gate re-drive bound
+        # True once the stream observes a review/verify SUBAGENT spawn
+        # (Agent/Task tool) this run. The Stop gate uses it to reject an
+        # accepting REVIEW verdict the main agent wrote WITHOUT actually
+        # running the reviewer subagent (the self-certification bypass).
+        # A fresh process per follow-up means this starts False each turn.
+        self._review_subagent_ran: bool = False
         # PreToolUse-hook state. See app.ai.bash_safety and
         # app.ai.claude_backend_utils.check_skill_prereqs.
         self._loaded_skills: set[str] = set()

--- a/app/ai/claude_backend.py
+++ b/app/ai/claude_backend.py
@@ -183,12 +183,6 @@ class AgentSession(_HookMixin, _StreamMixin):
         # Circuit breaker: track recent tool call signatures
         self._recent_tool_calls: list[str] = []
         self._review_redrive_count: int = 0  # review-gate re-drive bound
-        # True once the stream observes a review/verify SUBAGENT spawn
-        # (Agent/Task tool) this run. The Stop gate uses it to reject an
-        # accepting REVIEW verdict the main agent wrote WITHOUT actually
-        # running the reviewer subagent (the self-certification bypass).
-        # A fresh process per follow-up means this starts False each turn.
-        self._review_subagent_ran: bool = False
         # PreToolUse-hook state. See app.ai.bash_safety and
         # app.ai.claude_backend_utils.check_skill_prereqs.
         self._loaded_skills: set[str] = set()

--- a/app/ai/claude_backend_hooks.py
+++ b/app/ai/claude_backend_hooks.py
@@ -174,7 +174,8 @@ class _HookMixin:
         tasks (no ``AD_AUDIT_*.md`` in the workspace).
         """
         deny = check_review_status_for_stop(
-            self.task_dir, subagent_ran=self._review_subagent_ran
+            self.task_dir,
+            subagent_ran=getattr(self, '_review_subagent_ran', False),
         )
         if not deny:
             return False

--- a/app/ai/claude_backend_hooks.py
+++ b/app/ai/claude_backend_hooks.py
@@ -173,7 +173,9 @@ class _HookMixin:
         main agent runs to satisfy this gate. Quiet no-op for non-ads
         tasks (no ``AD_AUDIT_*.md`` in the workspace).
         """
-        deny = check_review_status_for_stop(self.task_dir)
+        deny = check_review_status_for_stop(
+            self.task_dir, subagent_ran=self._review_subagent_ran
+        )
         if not deny:
             return False
         logger.info(

--- a/app/ai/claude_backend_stream.py
+++ b/app/ai/claude_backend_stream.py
@@ -305,7 +305,8 @@ class _StreamMixin:
             # one task type.
             if self._executing and not is_error:
                 gate_reason = check_review_status_for_stop(
-                    self.task_dir, subagent_ran=self._review_subagent_ran
+                    self.task_dir,
+                    subagent_ran=getattr(self, '_review_subagent_ran', False),
                 ) or check_exec_review_status_for_stop(self.task_dir)
                 if (
                     gate_reason

--- a/app/ai/claude_backend_stream.py
+++ b/app/ai/claude_backend_stream.py
@@ -250,6 +250,20 @@ class _StreamMixin:
                     self._had_tool_use = True
                     tool_name = block.get('name', '')
                     tool_input = block.get('input', {})
+                    # A DoD/review verdict only counts when a real reviewer
+                    # SUBAGENT produced it. The main agent can't fabricate
+                    # this tool_use it never made, so flag a review-ish
+                    # Agent/Task spawn; the Stop gate rejects a self-written
+                    # verdict when this stayed False.
+                    if tool_name in ('Agent', 'Task'):
+                        _blob = json.dumps(
+                            tool_input, ensure_ascii=False
+                        ).lower()
+                        if any(
+                            k in _blob
+                            for k in ('review', 'verif', 'dod', 'audit')
+                        ):
+                            self._review_subagent_ran = True
                     if tool_name == 'TodoWrite':
                         todos = tool_input.get('todos', [])
                         await event_bus.emit(
@@ -291,7 +305,7 @@ class _StreamMixin:
             # one task type.
             if self._executing and not is_error:
                 gate_reason = check_review_status_for_stop(
-                    self.task_dir
+                    self.task_dir, subagent_ran=self._review_subagent_ran
                 ) or check_exec_review_status_for_stop(self.task_dir)
                 if (
                     gate_reason

--- a/app/ai/claude_backend_utils.py
+++ b/app/ai/claude_backend_utils.py
@@ -404,18 +404,22 @@ async def validate_fanout_plan_text(task_id: str, plan_text: str) -> str | None:
     return None
 
 
-def check_review_status_for_stop(task_dir: Path | None) -> str | None:
+def check_review_status_for_stop(
+    task_dir: Path | None, subagent_ran=None
+) -> str | None:
     """Return a deny reason for Stop if the ads-audit reviewer
     hasn't run (or returned gaps); otherwise ``None``.
 
     Thin wrapper around ``bash_safety.check_review_status`` that
     handles the empty-task_dir case for the hook caller. Quiet
     no-op for non-ads tasks (no ``AD_AUDIT_*.md`` in the workspace).
+    ``subagent_ran`` (False when the stream saw no review-subagent spawn
+    this turn) makes an accepting verdict get rejected as self-written.
     See ``amazon-ads/references/reviewer-loop.md`` for the contract.
     """
     if task_dir is None:
         return None
-    return check_review_status(task_dir)
+    return check_review_status(task_dir, subagent_ran)
 
 
 def check_exec_review_status_for_stop(

--- a/app/ai/stop_gates/report_reviewer.py
+++ b/app/ai/stop_gates/report_reviewer.py
@@ -146,7 +146,7 @@ def effective_status(content: str) -> tuple[str | None, list[str]]:
     return next(s for s in statuses if s not in known), statuses
 
 
-def reviewer_verdict(task_dir) -> str | None:
+def reviewer_verdict(task_dir, subagent_ran=None) -> str | None:
     """Deny reason if the reviewer hasn't signed off; else ``None``.
 
     Called for EVERY ads-skill-bound task (the caller established the
@@ -236,6 +236,22 @@ def reviewer_verdict(task_dir) -> str | None:
         else ''
     )
 
+    # A verdict is only trustworthy when an actual reviewer SUBAGENT
+    # produced it THIS turn. ``subagent_ran is False`` means the stream saw
+    # no review-subagent spawn since the last user turn, so an accepting
+    # verdict was self-written by the main agent — the exact self-
+    # certification bypass. Reject it. (``None`` = caller didn't supply the
+    # signal → keep legacy behavior; the ad floor still gates those.)
+    if subagent_ran is False and status in ('ok', 'incomplete'):
+        return (
+            f'{latest.name} says Status: {status}, but NO DoD reviewer '
+            'subagent ran this turn — a verdict you write yourself does '
+            'not count. Actually spawn the reviewer (Agent tool, '
+            'subagent_type="general-purpose") so it OPENS the live sources '
+            "(the processing report AND the TARGET marketplace's Manage "
+            'Inventory, over the same store browser) and writes the '
+            f'verdict to REVIEW_<date>_iter{iter_num + 1}.md.'
+        )
     if status == 'ok':
         return None
     if status == 'incomplete' and iter_num >= REVIEW_MAX_ITERS:

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -288,10 +288,22 @@ for an `8560` to fix reactively:
    report is account-level (byte-identical across a unified account's
    marketplace subdomains), or read them off Manage Inventory. Reuse the
    **same SKUs** on the target marketplace; same SKU keeps it idempotent.
-2. **Switch to the target marketplace and download ITS template** — use
-   Amazon's own marketplace switcher, don't hand-edit URLs on a gated
-   store, and `inspect` the fresh template. Offer/stock columns are
-   per-marketplace (see the offer prior above).
+2. **Switch the console to the target marketplace FIRST — the upload is
+   console-scoped.** A flat-file upload applies to whatever marketplace
+   the console is currently on, regardless of the offer columns in the
+   file; uploading while the console is still on the source marketplace
+   re-applies it to the SOURCE and never reaches the target. Switch via
+   Amazon's account switcher
+   (`/account-switcher/default/merchantMarketplace`). Fast path (current
+   layout): each marketplace is a clickable account `<button>` (class
+   `full-page-account-switcher-account`) — click the button, not the inert
+   `…-label` span, then **Select account**. **Always confirm it took** —
+   the header currency / marketplace name must change to the target. If
+   the click no-ops or the layout has changed, don't give up and upload on
+   the wrong console: screenshot, find the real clickable control, click
+   it, and re-confirm. Then download the target's template, `inspect` it,
+   and switch back to the home marketplace when done. Offer/stock columns
+   are per-marketplace (see the offer prior above).
 3. **Pin the ASIN on every row** so Amazon *matches* instead of minting:
    `external_product_id` = that row's existing ASIN (e.g. `B0EXAMPLE1`),
    `external_product_id_type: asin`. The catalog content already exists

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -304,6 +304,23 @@ for an `8560` to fix reactively:
    the wrong marketplace. Then download the target's template and
    `inspect` it. Offer/stock columns are per-marketplace (see the offer
    prior above).
+   - **The template is region-stamped — generate it with the TARGET store
+     ticked.** "Download Blank Template" → "Download Product Spreadsheet"
+     ("List products not currently in Amazon's catalog") → search the
+     product type (type into the search with **trusted** keystrokes, not a
+     JS value set) → Select it → in "stores where you want to create
+     offers", **tick the TARGET marketplace and untick the others** (the
+     default is the account's HOME marketplace, so a template "downloaded
+     from AE" is still stamped SA unless you fix this) → Generate. Reusing
+     another marketplace's file fails upload with
+     `UPLOAD_AND_DOWNLOAD_MARKETPLACES_DIFFERENT`, even on the right
+     subdomain.
+   - **Staging the file uses the file-chooser intercept, not the visible
+     input.** The `kat-file-upload` widget's `input#kat-file-attachment`
+     is a decoy — `setFileInputFiles` on it silently no-ops ("File not
+     uploaded"). Use the intercept + trusted-click recipe in
+     `browser-harness` § "Uploading a file" (Method 2). "Staged: False" is
+     this bug, not a rejected template.
 3. **Pin the ASIN on every row** so Amazon *matches* instead of minting:
    `external_product_id` = that row's existing ASIN (e.g. `B0EXAMPLE1`),
    `external_product_id_type: asin`. The catalog content already exists

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -216,18 +216,17 @@ a family that the parent shows **"Variations (N)"**.
   a long-title item. That is **NOT done**: fix the exact field the report
   names (Item Highlight is optional — clear it; the colour belongs in
   `color_name`) and re-upload. Only 18320 is a legit deferral.
-- **When the image IS the only remaining error, say so — never call it
-  "live".** A SUCCESS (OTHER) whose sole error is the missing main image
-  ("submit a compliant image to lift the suppression") means the SKU is
-  **created + priced + stocked but SEARCH-SUPPRESSED** — it is NOT buyable
-  or discoverable until the seller adds an image. That is the accepted
-  deferred done-state, but the final result MUST report it precisely:
-  "N children created, linked, priced, stocked — **SUPPRESSED pending main
-  image** (seller adds the image to go live)". Do **not** write "live",
-  "done", "全部完成", or imply the listings are sellable. The Manage
-  Inventory row will read "Search suppressed" / "No image available" and
-  the upload feed will read 0/N successful — that is expected for this
-  state, not a failure to re-upload over.
+- **When the image is the only remaining error, report it as
+  image-deferred, not "live".** A SUCCESS (OTHER) whose sole error is the
+  missing main image ("submit a compliant image to lift the suppression")
+  means the SKU is created + priced + stocked but **search-suppressed** —
+  not buyable or discoverable until the seller adds an image. That is the
+  accepted deferred done-state; report it as such (e.g. "N children
+  created, linked, priced, stocked — suppressed pending main image, seller
+  adds it to go live") rather than "live" or "done". The Manage Inventory
+  row reads "Search suppressed" / "No image available" and the upload feed
+  reads 0/N successful — expected for this state, not a failure to
+  re-upload over.
 - **A buyable child that `8560`s ("doesn't match any ASINs … include
   standard_product_id")** — Amazon is refusing to *mint a new ASIN* for
   it. Two cases, decided by whether that child's ASIN already exists:
@@ -291,15 +290,28 @@ for an `8560` to fix reactively:
    **same SKUs** on the target marketplace; same SKU keeps it idempotent.
 2. **Switch to the target marketplace and download ITS template** — use
    Amazon's own marketplace switcher, don't hand-edit URLs on a gated
-   store. Offer/stock columns are per-marketplace (see the offer prior
-   above).
+   store, and `inspect` the fresh template. Offer/stock columns are
+   per-marketplace (see the offer prior above).
 3. **Pin the ASIN on every row** so Amazon *matches* instead of minting:
    `operation: update`, `external_product_id` = that row's existing ASIN
    (e.g. `B0EXAMPLE1`), `external_product_id_type: asin`. The catalog
    content already exists under the ASIN — you are only adding this
    marketplace's **offer**, so set it via the top-level
-   `"marketplace": "<CC>"` + bare `our_price`/`quantity` (offer prior),
-   not by re-describing the product.
+   `"marketplace": "<CC>"` + bare `our_price` + `quantity` +
+   `fulfillment_channel_code` (offer prior), not by re-describing the
+   product.
+   - Pick each row's `operation` by whether that SKU's offer already
+     exists in the target marketplace: **no offer there yet → `update`**
+     (Create or Replace is the only op that creates it); **offer already
+     exists → `update` or `partialupdate`** (both fine — `update`
+     overwrites every field incl. blanks, `partialupdate` only the fields
+     you send). A partial re-run (e.g. 2 of 6 already live) mixes them
+     per row.
+   - A fulfillment group needs a `fulfillment_channel_code` together with
+     its `quantity`, or Amazon rejects the offer ("does not have enough
+     values"). It's marketplace-specific (read the target template's valid
+     values); `fill` routes a bare `fulfillment_channel_code` to the
+     target group and warns if a group has a quantity but no code.
 4. **Verify** the target ASINs equal the source ones (same ASIN ⇒ shared
    reviews) and that the offer is live in the TARGET marketplace's
    Pricing view — the feed's "N/N successful" does not prove either.
@@ -331,8 +343,8 @@ PY=<project-venv>/bin/python3     # needs openpyxl + rapidocr-onnxruntime
   each dialect's columns, so the SAME spec drives either. **Always drive
   the upload file through `fill` — never hand-roll it**: a hand-rolled
   file skips `fill`'s guard that clears the unified template's prefilled
-  example/instruction rows, and uploading those as SKUs is what produced a
-  live **"1/8 successful"** (parent only, all children failed). See
+  example/instruction rows, and uploading those as SKUs creates only the
+  parent — the children fail. See
   `references/template-round-trip.md` § 0.
   - `inspect TEMPLATE.xlsm [--field NAME]` — dump the dialect, the field
     set, which fields are Required, the accepted enum tokens, and the

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -328,20 +328,30 @@ for an `8560` to fix reactively:
    set it via the top-level `"marketplace": "<CC>"` + bare `our_price` +
    `quantity` + `fulfillment_channel_code` (offer prior), not by
    re-describing the product.
-   - **Use `operation: partialupdate` to add the offer to a matched
-     ASIN.** The catalog exists under the ASIN, so you merge in only this
-     marketplace's offer. `update` (Create or Replace) instead demands
-     re-supplying EVERY required catalog field (item_name, description,
-     bullet_point, fabric_type, country_of_origin, …) and rejects the row
-     for any that's missing — i.e. re-describing the product, which the
-     ASIN match exists to avoid. Reserve `update` for when you truly mean
-     to (re)write the full catalog content; use `create` only for a
-     genuinely new ASIN.
+   - **Operation depends on whether the ASIN exists in the TARGET
+     catalog — check that FIRST** (open `amazon.<tld>/dp/<ASIN>`, or read
+     the first upload's report):
+     - **Shared catalog** (the ASIN resolves on the target marketplace):
+       pin it + `operation: partialupdate` and add only this marketplace's
+       offer — don't re-describe the product.
+     - **Separate catalog** (the target `/dp/<ASIN>` is "Page Not Found",
+       or the upload reports *"the offer cannot be added because the
+       product is not in the catalogue … listing a product from one
+       marketplace to another"* / an `8560`): the ASIN **cannot be
+       shared**. A match/partialupdate fails. You must **CREATE fresh** —
+       a new ASIN (GTIN-exempt) with the FULL required product data
+       (`item_name`, `color_name`, `variation_theme`, description,
+       bullets, …), exactly like the original create on the source
+       marketplace. Regional siblings (e.g. SA vs AE) are frequently
+       SEPARATE catalogs, so this is the common cross-region case — expect
+       to create, not just add an offer.
    - Supply the **complete offer** — `our_price` + `quantity` +
      `fulfillment_channel_code` — on each child. A fulfillment group needs
      a channel code together with its quantity, or Amazon rejects the
      offer ("does not have enough values"). The code is marketplace-
-     specific (read the target template's valid values); `fill` routes a
+     specific — use a value from the TARGET template's own valid set;
+     another marketplace's value (e.g. `fulfilment by merchant (default)`)
+     is rejected as "Invalid enumerated value … (<mkt>)". `fill` routes a
      bare `fulfillment_channel_code` to the target group and warns if a
      group has a quantity but no code.
 4. **Verify** the target ASINs equal the source ones (same ASIN ⇒ shared

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -293,25 +293,28 @@ for an `8560` to fix reactively:
    store, and `inspect` the fresh template. Offer/stock columns are
    per-marketplace (see the offer prior above).
 3. **Pin the ASIN on every row** so Amazon *matches* instead of minting:
-   `operation: update`, `external_product_id` = that row's existing ASIN
-   (e.g. `B0EXAMPLE1`), `external_product_id_type: asin`. The catalog
-   content already exists under the ASIN — you are only adding this
-   marketplace's **offer**, so set it via the top-level
-   `"marketplace": "<CC>"` + bare `our_price` + `quantity` +
-   `fulfillment_channel_code` (offer prior), not by re-describing the
-   product.
-   - Pick each row's `operation` by whether that SKU's offer already
-     exists in the target marketplace: **no offer there yet → `update`**
-     (Create or Replace is the only op that creates it); **offer already
-     exists → `update` or `partialupdate`** (both fine — `update`
-     overwrites every field incl. blanks, `partialupdate` only the fields
-     you send). A partial re-run (e.g. 2 of 6 already live) mixes them
-     per row.
-   - A fulfillment group needs a `fulfillment_channel_code` together with
-     its `quantity`, or Amazon rejects the offer ("does not have enough
-     values"). It's marketplace-specific (read the target template's valid
-     values); `fill` routes a bare `fulfillment_channel_code` to the
-     target group and warns if a group has a quantity but no code.
+   `external_product_id` = that row's existing ASIN (e.g. `B0EXAMPLE1`),
+   `external_product_id_type: asin`. The catalog content already exists
+   under the ASIN — you are only adding this marketplace's **offer**, so
+   set it via the top-level `"marketplace": "<CC>"` + bare `our_price` +
+   `quantity` + `fulfillment_channel_code` (offer prior), not by
+   re-describing the product.
+   - **Use `operation: partialupdate` to add the offer to a matched
+     ASIN.** The catalog exists under the ASIN, so you merge in only this
+     marketplace's offer. `update` (Create or Replace) instead demands
+     re-supplying EVERY required catalog field (item_name, description,
+     bullet_point, fabric_type, country_of_origin, …) and rejects the row
+     for any that's missing — i.e. re-describing the product, which the
+     ASIN match exists to avoid. Reserve `update` for when you truly mean
+     to (re)write the full catalog content; use `create` only for a
+     genuinely new ASIN.
+   - Supply the **complete offer** — `our_price` + `quantity` +
+     `fulfillment_channel_code` — on each child. A fulfillment group needs
+     a channel code together with its quantity, or Amazon rejects the
+     offer ("does not have enough values"). The code is marketplace-
+     specific (read the target template's valid values); `fill` routes a
+     bare `fulfillment_channel_code` to the target group and warns if a
+     group has a quantity but no code.
 4. **Verify** the target ASINs equal the source ones (same ASIN ⇒ shared
    reviews) and that the offer is live in the TARGET marketplace's
    Pricing view — the feed's "N/N successful" does not prove either.

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -288,22 +288,22 @@ for an `8560` to fix reactively:
    report is account-level (byte-identical across a unified account's
    marketplace subdomains), or read them off Manage Inventory. Reuse the
    **same SKUs** on the target marketplace; same SKU keeps it idempotent.
-2. **Switch the console to the target marketplace FIRST — the upload is
-   console-scoped.** A flat-file upload applies to whatever marketplace
-   the console is currently on, regardless of the offer columns in the
-   file; uploading while the console is still on the source marketplace
-   re-applies it to the SOURCE and never reaches the target. Switch via
-   Amazon's account switcher
-   (`/account-switcher/default/merchantMarketplace`). Fast path (current
-   layout): each marketplace is a clickable account `<button>` (class
-   `full-page-account-switcher-account`) — click the button, not the inert
-   `…-label` span, then **Select account**. **Always confirm it took** —
-   the header currency / marketplace name must change to the target. If
-   the click no-ops or the layout has changed, don't give up and upload on
-   the wrong console: screenshot, find the real clickable control, click
-   it, and re-confirm. Then download the target's template, `inspect` it,
-   and switch back to the home marketplace when done. Offer/stock columns
-   are per-marketplace (see the offer prior above).
+2. **Do the WHOLE target flow on the target marketplace's own subdomain —
+   the upload is marketplace-scoped.** A flat-file upload applies to the
+   marketplace of the `sellercentral.amazon.<tld>` you're on, regardless
+   of the offer columns in the file; a `.sa` upload lands on SA even when
+   the account context shows the target. So for AE, run template download +
+   upload + Check Upload Status all on `sellercentral.amazon.ae/...` (EG →
+   `.eg`, etc.); the subdomain selects the marketplace for a unified
+   account. **Confirm the header shows the target** (marketplace name /
+   currency) before uploading. If the subdomain instead lands on an
+   account-picker ("Select an account"), switch there first — fast path
+   (current layout): click the target account's `<button>` (not the inert
+   label), then **Select account**, and if a click no-ops or the layout
+   changed, screenshot and find the real control rather than uploading on
+   the wrong marketplace. Then download the target's template and
+   `inspect` it. Offer/stock columns are per-marketplace (see the offer
+   prior above).
 3. **Pin the ASIN on every row** so Amazon *matches* instead of minting:
    `external_product_id` = that row's existing ASIN (e.g. `B0EXAMPLE1`),
    `external_product_id_type: asin`. The catalog content already exists

--- a/app/skills_v2/amazon-listing/references/template-round-trip.md
+++ b/app/skills_v2/amazon-listing/references/template-round-trip.md
@@ -52,9 +52,9 @@ dialect** — never key on a fixed row number or the localised label row.
 > unified template ships an example SKU + a "do not delete this row"
 > instruction in the data area. **Do NOT hand-roll the upload file** — a
 > hand-rolled file that appends your SKUs *after* those rows uploads the
-> example + instruction as if they were real SKUs (a live run got
-> **"1/8 successful"** that way: only the parent created, the junk rows
-> and the children failed). `fill` deletes everything below the field-name
+> example + instruction as if they were real SKUs — only the parent then
+> creates, and the junk rows and the children fail. `fill` deletes
+> everything below the field-name
 > row before writing, so only your SKUs ship.
 
 The metadata sheets are the source of truth:
@@ -218,7 +218,7 @@ fields.
 > set, not just the differentiator (see the Parent-vs-Child note below).
 
 > **Apparel (socks, clothing, …) — the full `apparel_size` composite is
-> required on EVERY row, parent included.** Verified live: a socks
+> required on EVERY row, parent included.** A socks (apparel)
 > variation only goes live when each row (parent + children) carries the
 > WHOLE size composite — `apparel_size_system`, `apparel_size_class`,
 > `apparel_size`, `apparel_body_type`, `apparel_height_type` — each a
@@ -256,8 +256,8 @@ a Parent row, and suppresses battery/hazmat required-field warnings when
 the row declares no batteries.
 
 > **Children are NOT minimal — fill each child's full required set.**
-> On a real socks create, minimal children (only `parent_sku` + colour +
-> offer) were rejected: Amazon required `item_name`, `target_gender`,
+> Minimal children (only `parent_sku` + colour + offer) get rejected:
+> Amazon requires `item_name`, `target_gender`,
 > `age_range_description`, `apparel_size_system`, and the compound
 > `apparel_body_type` / `apparel_height_type` **on every child row**. So
 > put the shared required attributes on the children too, not just the
@@ -365,7 +365,7 @@ each SKU has an ASIN and the parent shows **"Variations (N)"**. The feed
 count under-reports — records with errors still create stubs, and later
 re-uploads can complete them.
 
-### First-upload gotchas (verified on a socks template — priors, not a checklist)
+### First-upload gotchas (priors, not a checklist)
 
 - **`recommended_browse_nodes`** is a **gated set** per category — a
   guessed id is rejected. Pick one from the template's `Browse data`

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -302,7 +302,7 @@ def _row_fields(spec_row, top, schema):
     # row into fields (a value already in `fields` wins) so the price/stock
     # routes to the target marketplace either way, instead of being
     # silently dropped -> an empty offer column the agent then hand-picks.
-    for k in (*_OFFER_PRICE_SHORTHANDS, 'quantity'):
+    for k in (*_OFFER_PRICE_SHORTHANDS, 'quantity', 'fulfillment_channel_code'):
         if spec_row.get(k) not in (None, '') and k not in out:
             out[k] = spec_row[k]
     # Drop keys with no value so we never blank an intended default.
@@ -358,11 +358,36 @@ def _route_offer_price(fields, cols, mkt_id, i, sku, warnings):
                 fields[f'fulfillment_availability#{n}.quantity'] = fields.pop(
                     'quantity'
                 )
+            # A bare `fulfillment_channel_code` routes to the SAME target
+            # group as the quantity: a fulfillment group needs BOTH a
+            # quantity AND a channel code, so a bare code left unrouted
+            # would leave the target group with stock but no channel ->
+            # Amazon's "does not have enough values" rejection.
+            if 'fulfillment_channel_code' in fields:
+                fields[
+                    f'fulfillment_availability#{n}.fulfillment_channel_code'
+                ] = fields.pop('fulfillment_channel_code')
             for k in list(fields):
                 if k.startswith('fulfillment_availability#') and '.' in k:
                     tgt = f'fulfillment_availability#{n}.{k.split(".", 1)[1]}'
                     if tgt != k:
                         fields[tgt] = fields.pop(k)
+            # Guard the exact cross-marketplace trap: a target group with a
+            # quantity but no channel code is DOA. fill can't invent the
+            # code (it is marketplace/channel-specific), so warn loudly.
+            qty_key = f'fulfillment_availability#{n}.quantity'
+            code_key = f'fulfillment_availability#{n}.fulfillment_channel_code'
+            if fields.get(qty_key) not in (None, '') and fields.get(
+                code_key
+            ) in (None, ''):
+                warnings.append(
+                    f'row {i} sku={sku}: fulfillment group #{n} '
+                    f'(marketplace_id={mkt_id}) has a quantity but no '
+                    f'fulfillment_channel_code -- Amazon rejects the offer '
+                    f'("does not have enough values"). Add a bare '
+                    f'"fulfillment_channel_code" (the merchant/default code '
+                    f'for THIS marketplace) to the row.'
+                )
 
 
 def _drop_unusable_item_highlight(fields, i, sku, warnings):

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -98,6 +98,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from listing_schema import (  # noqa: E402, F401
     DEFN_SHEET,
     DROPDOWN_SHEET,
+    OFFER_PRICE_SHORTHANDS as _OFFER_PRICE_SHORTHANDS,
     OP_TOKENS as _OP_TOKENS,
     ROLE_MATCHERS as _ROLE_MATCHERS,
     TEMPLATE_SHEET,
@@ -110,6 +111,7 @@ from listing_schema import (  # noqa: E402, F401
     load_required_fields as _load_required_fields,
     load_valid_values as _load_valid_values,
     our_price_col as _our_price_col,
+    route_offer_price as _route_offer_price,
     valid_value_case as _valid_value_case,
 )
 from marketplace_ids import (  # noqa: E402,F401
@@ -118,8 +120,6 @@ from marketplace_ids import (  # noqa: E402,F401
     ids_in_template as _marketplace_ids_in_template,
     resolve as _resolve_marketplace_id,
 )
-
-_OFFER_PRICE_SHORTHANDS = ('our_price', 'price', 'standard_price')
 
 # Item Highlight (`title_differentiation`) is an OPTIONAL field Amazon only
 # accepts when the Item Name is <= 75 chars; a longer title makes Amazon
@@ -307,87 +307,6 @@ def _row_fields(spec_row, top, schema):
             out[k] = spec_row[k]
     # Drop keys with no value so we never blank an intended default.
     return {k: v for k, v in out.items() if v not in (None, '')}
-
-
-def _route_offer_price(fields, cols, mkt_id, i, sku, warnings):
-    """Route a bare ``our_price`` to the TARGET marketplace's offer column.
-
-    Expands ``our_price``/``price`` into
-    ``purchasable_offer[marketplace_id=<mkt_id>]#1.our_price...``. Explicit
-    full offer columns are left exactly as written (no silent move); we
-    only WARN when the target marketplace ends up with no price -- the
-    "Missing offer / never live" trap. Mutates ``fields``.
-    """
-    target_col = _our_price_col(cols, mkt_id)
-    shorthand = next((k for k in _OFFER_PRICE_SHORTHANDS if k in fields), None)
-    if shorthand:
-        if mkt_id is None:
-            raise SystemExit(
-                f'error: row {i} sku={sku} sets a price but the spec has no '
-                f'\'marketplace\' -- add e.g. "marketplace": "SA"'
-            )
-        if target_col is None:
-            raise SystemExit(
-                f'error: row {i} sku={sku}: template has no offer column for '
-                f'marketplace_id={mkt_id} (account may not sell there)'
-            )
-        fields[target_col] = fields.pop(shorthand)
-    if mkt_id is not None and (target_col is None or target_col not in fields):
-        other = [
-            k
-            for k in fields
-            if k.startswith('purchasable_offer[marketplace_id=')
-            and '.our_price' in k
-            and f'marketplace_id={mkt_id}]' not in k
-        ]
-        if other:
-            warnings.append(
-                f'row {i} sku={sku}: offer price is on {other[0]} but you are '
-                f'listing on marketplace_id={mkt_id}, which has NO offer -- the '
-                f'listing will be "Missing offer" (never live). Use "our_price".'
-            )
-    # Fulfillment/stock is NOT marketplace-bracketed: each
-    # `fulfillment_availability#N` group is tied by position to one
-    # marketplace's offer block. Route a bare `quantity` + normalise any
-    # `fulfillment_availability#k.*` to the TARGET marketplace's index, so
-    # stock can't land on the wrong marketplace (SA offer + AE qty = dead).
-    if mkt_id is not None:
-        n = _fulfillment_index_for_marketplace(cols, mkt_id)
-        if n is not None:
-            if 'quantity' in fields:
-                fields[f'fulfillment_availability#{n}.quantity'] = fields.pop(
-                    'quantity'
-                )
-            # A bare `fulfillment_channel_code` routes to the SAME target
-            # group as the quantity: a fulfillment group needs BOTH a
-            # quantity AND a channel code, so a bare code left unrouted
-            # would leave the target group with stock but no channel ->
-            # Amazon's "does not have enough values" rejection.
-            if 'fulfillment_channel_code' in fields:
-                fields[
-                    f'fulfillment_availability#{n}.fulfillment_channel_code'
-                ] = fields.pop('fulfillment_channel_code')
-            for k in list(fields):
-                if k.startswith('fulfillment_availability#') and '.' in k:
-                    tgt = f'fulfillment_availability#{n}.{k.split(".", 1)[1]}'
-                    if tgt != k:
-                        fields[tgt] = fields.pop(k)
-            # Guard the exact cross-marketplace trap: a target group with a
-            # quantity but no channel code is DOA. fill can't invent the
-            # code (it is marketplace/channel-specific), so warn loudly.
-            qty_key = f'fulfillment_availability#{n}.quantity'
-            code_key = f'fulfillment_availability#{n}.fulfillment_channel_code'
-            if fields.get(qty_key) not in (None, '') and fields.get(
-                code_key
-            ) in (None, ''):
-                warnings.append(
-                    f'row {i} sku={sku}: fulfillment group #{n} '
-                    f'(marketplace_id={mkt_id}) has a quantity but no '
-                    f'fulfillment_channel_code -- Amazon rejects the offer '
-                    f'("does not have enough values"). Add a bare '
-                    f'"fulfillment_channel_code" (the merchant/default code '
-                    f'for THIS marketplace) to the row.'
-                )
 
 
 def _drop_unusable_item_highlight(fields, i, sku, warnings):

--- a/app/skills_v2/amazon-listing/scripts/listing_schema.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_schema.py
@@ -22,6 +22,8 @@ and re-exports the ones tests reach for.
 
 import re
 
+from marketplace_ids import fulfillment_index
+
 # The Template sheet holds the flat file. Metadata lives in siblings.
 TEMPLATE_SHEET = 'Template'
 DEFN_SHEET = 'Data Definitions'
@@ -54,22 +56,21 @@ OP_TOKENS = {
 # sheet order). Anything not covered here is addressed by exact API name.
 ROLE_MATCHERS = {
     'sku': lambda n, b, lf: n == 'item_sku' or b == 'contribution_sku',
-    'operation': lambda n, b, lf: (
-        n == 'update_delete' or b == 'record_action'
-    ),
+    'operation': lambda n, b, lf: n == 'update_delete' or b == 'record_action',
     'product_type': lambda n, b, lf: (
         n == 'feed_product_type' or b == 'product_type'
     ),
     'brand': lambda n, b, lf: (
         n == 'brand_name' or (b == 'brand' and lf == 'value')
     ),
-    'parentage': lambda n, b, lf: (
-        n == 'parent_child' or b == 'parentage_level'
+    'parentage': lambda n, b, lf: n == 'parent_child' or b == 'parentage_level',
+    'parent_sku': lambda n, b, lf: (
+        n == 'parent_sku'
+        or (b == 'child_parent_sku_relationship' and lf == 'parent_sku')
     ),
-    'parent_sku': lambda n, b, lf: n == 'parent_sku'
-    or (b == 'child_parent_sku_relationship' and lf == 'parent_sku'),
-    'variation_theme': lambda n, b, lf: n == 'variation_theme'
-    or (b == 'variation_theme' and lf == 'name'),
+    'variation_theme': lambda n, b, lf: (
+        n == 'variation_theme' or (b == 'variation_theme' and lf == 'name')
+    ),
     'product_id': lambda n, b, lf: (
         n == 'external_product_id' or n == 'amzn1.volt.ca.product_id_value'
     ),
@@ -368,3 +369,90 @@ def valid_value_case(wb):
         if m:
             out[str(name).strip()] = m
     return out
+
+
+# Spec shorthands for the offer price -- resolved to the target
+# marketplace's `purchasable_offer[...]` column by `route_offer_price`.
+OFFER_PRICE_SHORTHANDS = ('our_price', 'price', 'standard_price')
+
+
+def route_offer_price(fields, cols, mkt_id, i, sku, warnings):
+    """Route a bare ``our_price`` to the TARGET marketplace's offer column.
+
+    Expands ``our_price``/``price`` into
+    ``purchasable_offer[marketplace_id=<mkt_id>]#1.our_price...``. Explicit
+    full offer columns are left exactly as written (no silent move); we
+    only WARN when the target marketplace ends up with no price -- the
+    "Missing offer / never live" trap. Mutates ``fields``.
+    """
+    target_col = our_price_col(cols, mkt_id)
+    shorthand = next((k for k in OFFER_PRICE_SHORTHANDS if k in fields), None)
+    if shorthand:
+        if mkt_id is None:
+            raise SystemExit(
+                f'error: row {i} sku={sku} sets a price but the spec has no '
+                f'\'marketplace\' -- add e.g. "marketplace": "SA"'
+            )
+        if target_col is None:
+            raise SystemExit(
+                f'error: row {i} sku={sku}: template has no offer column for '
+                f'marketplace_id={mkt_id} (account may not sell there)'
+            )
+        fields[target_col] = fields.pop(shorthand)
+    if mkt_id is not None and (target_col is None or target_col not in fields):
+        other = [
+            k
+            for k in fields
+            if k.startswith('purchasable_offer[marketplace_id=')
+            and '.our_price' in k
+            and f'marketplace_id={mkt_id}]' not in k
+        ]
+        if other:
+            warnings.append(
+                f'row {i} sku={sku}: offer price is on {other[0]} but you are '
+                f'listing on marketplace_id={mkt_id}, which has NO offer -- '
+                f'the listing will be "Missing offer" (never live). Use '
+                f'"our_price".'
+            )
+    # Fulfillment/stock is NOT marketplace-bracketed: each
+    # `fulfillment_availability#N` group is tied by position to one
+    # marketplace's offer block. Route a bare `quantity` + normalise any
+    # `fulfillment_availability#k.*` to the TARGET marketplace's index, so
+    # stock can't land on the wrong marketplace (SA offer + AE qty = dead).
+    if mkt_id is not None:
+        n = fulfillment_index(cols, mkt_id)
+        if n is not None:
+            if 'quantity' in fields:
+                fields[f'fulfillment_availability#{n}.quantity'] = fields.pop(
+                    'quantity'
+                )
+            # A bare `fulfillment_channel_code` routes to the SAME target
+            # group as the quantity: a fulfillment group needs BOTH a
+            # quantity AND a channel code, so a bare code left unrouted
+            # would leave the target group with stock but no channel ->
+            # Amazon's "does not have enough values" rejection.
+            if 'fulfillment_channel_code' in fields:
+                fields[
+                    f'fulfillment_availability#{n}.fulfillment_channel_code'
+                ] = fields.pop('fulfillment_channel_code')
+            for k in list(fields):
+                if k.startswith('fulfillment_availability#') and '.' in k:
+                    tgt = f'fulfillment_availability#{n}.{k.split(".", 1)[1]}'
+                    if tgt != k:
+                        fields[tgt] = fields.pop(k)
+            # Guard the exact cross-marketplace trap: a target group with a
+            # quantity but no channel code is DOA. fill can't invent the
+            # code (it is marketplace/channel-specific), so warn loudly.
+            qty_key = f'fulfillment_availability#{n}.quantity'
+            code_key = f'fulfillment_availability#{n}.fulfillment_channel_code'
+            if fields.get(qty_key) not in (None, '') and fields.get(
+                code_key
+            ) in (None, ''):
+                warnings.append(
+                    f'row {i} sku={sku}: fulfillment group #{n} '
+                    f'(marketplace_id={mkt_id}) has a quantity but no '
+                    f'fulfillment_channel_code -- Amazon rejects the offer '
+                    f'("does not have enough values"). Add a bare '
+                    f'"fulfillment_channel_code" (the merchant/default code '
+                    f'for THIS marketplace) to the row.'
+                )

--- a/app/skills_v2/amazon-shared/references/dod-review-loop.md
+++ b/app/skills_v2/amazon-shared/references/dod-review-loop.md
@@ -66,7 +66,17 @@ Open the live source with the wrapper you were given:
 work around it. SAMPLE and cross-check: pick specific items the
 deliverable claims and confirm them against the live page / file. PROVE
 NEGATIVES BY LOOKING ("deleted", "empty", "0 errors", "all uploaded" must
-be checked, not accepted). If there was genuinely nothing substantive to
+be checked, not accepted).
+
+**Verify the CURRENT artifact, never a stale one on disk.** A report /
+export / summary file already in the workspace or downloads dir may be
+from a PRIOR turn or a DIFFERENT marketplace — verifying it is a false
+pass. Pull THIS turn's artifact fresh from the live source (e.g. download
+the newest batch's Processing Summary from the TARGET marketplace's Check
+Upload Status) and confirm its identifier — batch id, marketplace,
+timestamp — matches the work this turn actually submitted before you read
+it. If you cannot find a current artifact for this turn's work, that is a
+gap, not an `ok`. If there was genuinely nothing substantive to
 verify (a quick lookup that produced no deliverable), write `Status: ok`
 with a one-line note — do not invent work.
 

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -872,6 +872,38 @@ def test_route_remaps_wrong_index_fulfillment_to_target():
     assert _AE_QTY not in fields
 
 
+def test_route_sends_channel_code_to_target_group():
+    # A bare fulfillment_channel_code routes to the target marketplace's
+    # fulfillment group (SA = #2), paired with its quantity -- a group needs
+    # both or Amazon rejects it ("does not have enough values").
+    fields = {
+        'our_price': '19.99',
+        'quantity': '100',
+        'fulfillment_channel_code': 'DEFAULT',
+    }
+    warnings = []
+    listing_bulk._route_offer_price(
+        fields, _MKT_COLS, _SA, 0, 'K-WHT', warnings
+    )
+    assert fields[_SA_QTY] == '100'
+    assert (
+        fields['fulfillment_availability#2.fulfillment_channel_code']
+        == 'DEFAULT'
+    )
+    assert warnings == []  # both quantity and code present -> no warning
+
+
+def test_route_warns_when_group_has_quantity_but_no_channel_code():
+    # quantity routed to the target group but no channel code -> the exact
+    # cross-marketplace rejection; warn so the caller supplies the code.
+    fields = {'our_price': '19.99', 'quantity': '100'}
+    warnings = []
+    listing_bulk._route_offer_price(
+        fields, _MKT_COLS, _SA, 0, 'K-WHT', warnings
+    )
+    assert any('fulfillment_channel_code' in w for w in warnings)
+
+
 # --- unified (NGS "Beta Product Spreadsheet") template dialect ----------
 #
 # The current Seller Central template. Its field API names are decorated

--- a/tests/unit/test_review_stop_gate.py
+++ b/tests/unit/test_review_stop_gate.py
@@ -120,6 +120,49 @@ class TestReviewStopGate:
         )
         assert check_review_status(tmp_path) is None
 
+    def _ok_review_task(self, tmp_path, monkeypatch):
+        """An ad-skill task whose floor passes and which has a
+        ``Status: ok`` REVIEW file on disk (the exact input the
+        self-certification bypass produces)."""
+        monkeypatch.setattr(
+            'app.ai.bash_safety.recorded_skills',
+            lambda t: frozenset({'amazon-ads'}),
+        )
+        monkeypatch.setattr(
+            ad_completeness_review, 'check', lambda *a, **k: None
+        )
+        (tmp_path / 'AD_AUDIT_2026-07-09.md').write_text(
+            '# r\n\n## Amazon SA\n', encoding='utf-8'
+        )
+        (tmp_path / 'REVIEW_2026-07-09_iter1.md').write_text(
+            '# Review\nStatus: ok\n', encoding='utf-8'
+        )
+
+    def test_self_written_ok_denied_when_no_subagent_ran(
+        self, tmp_path, monkeypatch
+    ):
+        # The bypass: a Status: ok REVIEW file the main agent wrote
+        # itself, with NO reviewer subagent spawned this turn. The gate
+        # must reject it and tell the agent to actually run the reviewer.
+        # (The old tests missed this because they fed the gate a REVIEW
+        # file and only checked its CONTENT — never its authorship.)
+        self._ok_review_task(tmp_path, monkeypatch)
+        deny = check_review_status(tmp_path, subagent_ran=False)
+        assert deny is not None and 'subagent' in deny.lower()
+
+    def test_ok_accepted_when_subagent_ran(self, tmp_path, monkeypatch):
+        # Same on-disk verdict, but a reviewer subagent DID run this turn
+        # (the stream saw the Agent spawn) → accept.
+        self._ok_review_task(tmp_path, monkeypatch)
+        assert check_review_status(tmp_path, subagent_ran=True) is None
+
+    def test_subagent_signal_absent_is_legacy(self, tmp_path, monkeypatch):
+        # subagent_ran=None (caller didn't supply the signal) keeps the
+        # legacy behavior so callers without the stream flag don't break.
+        self._ok_review_task(tmp_path, monkeypatch)
+        assert check_review_status(tmp_path) is None
+        assert check_review_status(tmp_path, subagent_ran=None) is None
+
     def test_review_file_nonstandard_name_accepted(self, tmp_path, monkeypatch):
         # A weak model may name the review file <PRODUCT>_REVIEW_<date>.md
         # instead of REVIEW_<date>_iter<N>.md. As long as it has a Status


### PR DESCRIPTION
## Problem

Relisting an existing variation family from one marketplace onto another
in the same account (e.g. SA → AE) failed repeatedly — and worse, the DoD
review gate let the agent **report false success** each time. Root causes
were found by re-running a real cross-marketplace listing task and
verifying every claim against Amazon's own processing reports, upload
console, and inventory.

## Root causes → fixes

1. **Offer rejected — `fulfillment_channel_code` never routed.** `fill`
   routed a bare `quantity` to the target marketplace's
   `fulfillment_availability#N` group but left a bare
   `fulfillment_channel_code` unrouted → the group had stock but no
   channel code → every child rejected ("does not have enough values").
   → `listing_bulk.py` routes the bare code to the same target group and
   warns when a group has quantity but no code. The code's *value* is also
   marketplace-specific — another marketplace's token is rejected as an
   invalid enumerated value; read it from the target template.
2. **Wrong operation for cross-marketplace.** The operation depends on
   whether the ASIN exists in the TARGET catalog: shared catalog →
   `partialupdate` adds just the offer (a full `update` re-demands every
   catalog field); **separate catalog** (target `/dp/<ASIN>` not found, or
   "offer cannot be added because the product is not in the catalogue" /
   `8560`) → the ASIN cannot be shared and the family must be **created
   fresh** (new ASIN, GTIN-exempt, full product data). Regional siblings
   are frequently separate catalogs, so the skill now makes the check
   explicit instead of assuming a shared catalog.
3. **Upload landed on the wrong marketplace.** A flat-file upload is
   scoped by the `sellercentral.amazon.<tld>` subdomain — uploading on the
   source's subdomain re-applies the file to the SOURCE even when the
   account context shows the target. The skill now runs the whole target
   flow (template download + upload + status) on the target's subdomain,
   with an account-picker fallback.
4. **The template itself is region-stamped.** The generator's store
   checkboxes default to the account's HOME marketplace, so a template
   "downloaded from the target console" is still stamped for the source
   unless the target store is ticked — otherwise upload fails with
   `UPLOAD_AND_DOWNLOAD_MARKETPLACES_DIFFERENT`. Documented, with the
   generator path.
5. **File staging silently no-ops on the decoy input.** The
   `kat-file-upload` widget's visible `input#kat-file-attachment` is inert
   — `setFileInputFiles` on it stages nothing ("File not uploaded"),
   which was misread as a rejected template. The skill points to the
   file-chooser-intercept recipe (browser-harness "Uploading a file",
   Method 2).
6. **The review gate accepted a self-written verdict.** The gate passed
   any `REVIEW_*.md` with `Status: ok`, so the agent bypassed it by
   writing the verdict itself while its batch was still processing. The
   stream now records whether a review/verify subagent actually ran this
   turn (an `Agent`/`Task` tool_use the main agent cannot fabricate), and
   `reviewer_verdict` rejects an accepting verdict when none did — with
   legacy behavior preserved when the signal isn't supplied. The reviewer
   prompt additionally requires verifying THIS turn's artifact pulled
   fresh from the live source (batch id / marketplace / timestamp must
   match), never a stale on-disk report — a false `ok` was observed from
   a reviewer that parsed a prior turn's report.

## Verification

- Unit tests: +5 listing-tool (channel-code routing/warn + existing
  offer/dialect suite), +3 review-gate authorship (deny when no subagent
  ran / accept when one did / legacy when signal absent). All green, ruff
  clean.
- Live end-to-end on a unified two-marketplace account: with the store
  ticked, the generated template is accepted on the target subdomain
  ("Automatically detected", no region error), stages via the intercept
  recipe, submits, and the batch appears in the TARGET console's own
  batch namespace — the exact chain that failed before these fixes. The
  target console's processing report then names the real per-SKU work
  remaining (separate catalog → full create), which the corrected skill
  now routes correctly.
- Review-gate fix verified live: the agent can no longer self-certify —
  denied verdicts force a real reviewer subagent run.

## Known follow-ups (next PR)

- Fresh-context execution for follow-ups/re-drives on long sessions
  (context rot made agents re-verify stale artifacts).
- Mechanize the browser recipes as deterministic helpers
  (upload/stage → batch id, template download, report fetch) instead of
  prose the model must re-derive.
- Key gate freshness to the tool-recorded batch id; never deny tools
  during a gate re-drive (fail open to the UNVERIFIED banner instead).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
