### PR TITLE
feat(agent-reliability): fresh-context guard, mechanized listing helpers, batch-keyed gate freshness

### DIFF
--- a/app/ai/bash_safety.py
+++ b/app/ai/bash_safety.py
@@ -26,6 +26,7 @@ import re
 from app.ai.skill_review import skills_requiring_review
 from app.ai.stop_gates import (
     ad_completeness_review,
+    listing_upload_gate,
     recorded_skills,
     report_reviewer,
 )
@@ -490,6 +491,13 @@ def check_review_status(task_dir, subagent_ran=None) -> str | None:
     """
     if task_dir is None:
         return None
+    # Batch-keyed upload freshness: armed purely by the presence of an
+    # UPLOAD_BATCH marker (the upload helper ran), independent of skill
+    # binding — an uploaded batch must have a clean parse-feedback
+    # verdict for THIS turn before anything else can pass the gate.
+    upload_deny = listing_upload_gate.check_upload_verdicts(task_dir)
+    if upload_deny:
+        return upload_deny
     # Identify ad-report tasks by BOUND SKILL, not filename (no escape).
     skills = recorded_skills(task_dir.name)
     is_ad_task = bool(skills & report_reviewer.AD_SKILLS)

--- a/app/ai/claude_backend_hooks.py
+++ b/app/ai/claude_backend_hooks.py
@@ -20,6 +20,7 @@ from app.ai.bash_safety import (
 from app.ai.claude_backend_utils import (
     AGENT_DEBUG,
     AUTO_APPROVE_CALLBACK,
+    REVIEW_REDRIVE_MAX,
     STOP_REFLECTION_CALLBACK,
     TOOL_APPROVAL_CALLBACK,
     build_tasklist_open_reason,
@@ -173,6 +174,14 @@ class _HookMixin:
         main agent runs to satisfy this gate. Quiet no-op for non-ads
         tasks (no ``AD_AUDIT_*.md`` in the workspace).
         """
+        # Past the re-drive budget the gate FAILS OPEN coherently: the
+        # stream banner-marks the result UNVERIFIED and this hook stands
+        # down so the CLI can actually exit. Keeping the deny alive past
+        # that point left the agent running against a closed approval
+        # channel — every tool call default-denied mid-recovery (observed
+        # live), which selects for gate ESCAPES over gate satisfaction.
+        if self._review_redrive_count >= REVIEW_REDRIVE_MAX:
+            return False
         deny = check_review_status_for_stop(
             self.task_dir,
             subagent_ran=getattr(self, '_review_subagent_ran', False),

--- a/app/ai/claude_backend_hooks.py
+++ b/app/ai/claude_backend_hooks.py
@@ -174,12 +174,10 @@ class _HookMixin:
         main agent runs to satisfy this gate. Quiet no-op for non-ads
         tasks (no ``AD_AUDIT_*.md`` in the workspace).
         """
-        # Past the re-drive budget the gate FAILS OPEN coherently: the
-        # stream banner-marks the result UNVERIFIED and this hook stands
-        # down so the CLI can actually exit. Keeping the deny alive past
-        # that point left the agent running against a closed approval
-        # channel — every tool call default-denied mid-recovery (observed
-        # live), which selects for gate ESCAPES over gate satisfaction.
+        # Past the re-drive budget the gate FAILS OPEN: the stream
+        # banner-marks the result UNVERIFIED and this hook stands down so
+        # the CLI can exit (a live deny + closed approval channel had
+        # every tool default-denied mid-recovery).
         if self._review_redrive_count >= REVIEW_REDRIVE_MAX:
             return False
         deny = check_review_status_for_stop(

--- a/app/ai/claude_backend_stream.py
+++ b/app/ai/claude_backend_stream.py
@@ -12,12 +12,16 @@ import logging
 
 from app.ai.claude_backend_utils import (
     AGENT_DEBUG,
+    REVIEW_REDRIVE_MAX,
     check_exec_review_status_for_stop,
     check_review_status_for_stop,
     get_next_seq,
     parse_wait_condition,
 )
-from app.ai.stop_gates.report_reviewer import rollover_reviews
+from app.ai.stop_gates.report_reviewer import (
+    partial_banner,
+    rollover_reviews,
+)
 from app.database import async_session
 from app.errors import STREAM_ERROR_MAP, categorize_error_text
 from app.events.bus import event_bus
@@ -31,7 +35,6 @@ logger = logging.getLogger(__name__)
 # with a review gate still unsatisfied, before giving up and letting the
 # turn end. Matches the reviewer loop's iter-5 `incomplete` ceiling so a
 # gate the agent genuinely cannot satisfy still terminates.
-REVIEW_REDRIVE_MAX = 5
 
 # How long to wait on a single `stdout.readline()` before issuing
 # a stall-reaper heartbeat bump. The model can take minutes to
@@ -334,6 +337,19 @@ class _StreamMixin:
                         'this and then finish:\n\n' + gate_reason
                     )
                     return
+                if gate_reason:
+                    # Re-drive budget exhausted → fail OPEN, never a
+                    # tool-denial limbo: the Stop hook stands down (see
+                    # _deny_stop_if_review_unsatisfied) and the result
+                    # ships banner-marked UNVERIFIED so nobody mistakes
+                    # it for a reviewed deliverable.
+                    logger.warning(
+                        'Review gate still unsatisfied after %d re-drives '
+                        'for %s — failing open with UNVERIFIED banner',
+                        REVIEW_REDRIVE_MAX,
+                        self.task_id[:8],
+                    )
+                    text = partial_banner() + (text or '')
             if event.get('subtype') == 'success' and not is_error:
                 self._agent_success = True
             # ``None`` means Stop-hook reflection never fired this

--- a/app/ai/claude_backend_utils.py
+++ b/app/ai/claude_backend_utils.py
@@ -404,6 +404,13 @@ async def validate_fanout_plan_text(task_id: str, plan_text: str) -> str | None:
     return None
 
 
+# Bound on review-gate re-drives per session. Past this the gate
+# FAILS OPEN: the stream banner-marks the result UNVERIFIED and the
+# Stop hook stands down so the CLI exits cleanly (never a closed
+# approval channel with a live deny).
+REVIEW_REDRIVE_MAX = 5
+
+
 def check_review_status_for_stop(
     task_dir: Path | None, subagent_ran=None
 ) -> str | None:

--- a/app/ai/stop_gates/listing_upload_gate.py
+++ b/app/ai/stop_gates/listing_upload_gate.py
@@ -1,0 +1,84 @@
+"""Batch-keyed freshness gate for listing flat-file uploads.
+
+``bh_upload_flatfile`` records every submitted batch as an
+``UPLOAD_BATCH_<id>.json`` marker in the task workspace, and
+``listing_bulk.py parse-feedback --batch-id <id>`` writes the matching
+``BATCH_<id>_VERDICT.json`` after reading THAT batch's processing
+report. This gate closes the loop: a task that uploaded a batch cannot
+finish until the batch has a verdict, and the verdict shows no
+non-image errors (the missing-main-image deferral is the one accepted
+"done with caveat" state).
+
+This makes report freshness structural instead of prompted: a reviewer
+can no longer pass the turn by reading a stale report from a prior
+turn or another marketplace — the verdict is keyed to the batch id the
+upload actually produced this turn. Markers/verdicts are moved aside
+at turn start together with the review files (``rollover_reviews``),
+so each turn is gated only on its own uploads.
+
+No markers → quiet no-op (the gate arms itself only when the upload
+helper ran).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+
+GATE_NAME = 'listing_upload_gate'
+
+_MARKER_RE = re.compile(r'^UPLOAD_BATCH_(\w+)\.json$')
+
+# Glob patterns for the turn-scoped artifacts this gate reads; also used
+# by ``rollover_reviews`` to move them aside at turn start.
+MARKER_GLOB = 'UPLOAD_BATCH_*.json'
+VERDICT_GLOB = 'BATCH_*_VERDICT.json'
+
+
+def check_upload_verdicts(task_dir) -> str | None:
+    """Deny reason if any uploaded batch lacks a clean verdict; else None.
+
+    A batch is clean when its verdict exists and reports zero non-image
+    errors. Unreadable marker/verdict files count as unresolved (fail
+    closed — the agent rewrites them by re-running the helper/parser).
+    """
+    if task_dir is None:
+        return None
+    try:
+        markers = sorted(Path(task_dir).glob(MARKER_GLOB))
+    except OSError:
+        return None
+    for marker in markers:
+        m = _MARKER_RE.match(marker.name)
+        if not m:
+            continue
+        batch_id = m.group(1)
+        verdict_path = Path(task_dir) / f'BATCH_{batch_id}_VERDICT.json'
+        if not verdict_path.is_file():
+            return (
+                f'Upload batch {batch_id} has no parse-feedback verdict '
+                "yet. Fetch THAT batch's processing report from the SAME "
+                'marketplace you uploaded to (bh_fetch_report with '
+                f'BATCH_ID={batch_id}), then run listing_bulk.py '
+                f'parse-feedback <report> --batch-id {batch_id}. The task '
+                'cannot finish on an unverified upload.'
+            )
+        try:
+            verdict = json.loads(verdict_path.read_text(encoding='utf-8'))
+            non_image = int(verdict.get('non_image_errors', 0))
+        except (OSError, ValueError, TypeError):
+            return (
+                f'{verdict_path.name} is unreadable — re-run '
+                f'listing_bulk.py parse-feedback --batch-id {batch_id} '
+                "on the batch's processing report."
+            )
+        if non_image > 0:
+            return (
+                f'Batch {batch_id} has {non_image} unresolved non-image '
+                'error(s) per its processing report. Fix exactly the '
+                'fields the report names, re-upload, and parse-feedback '
+                'the new batch. Only the missing-main-image error is '
+                'deferrable.'
+            )
+    return None

--- a/app/ai/stop_gates/listing_upload_gate.py
+++ b/app/ai/stop_gates/listing_upload_gate.py
@@ -37,11 +37,17 @@ VERDICT_GLOB = 'BATCH_*_VERDICT.json'
 
 
 def check_upload_verdicts(task_dir) -> str | None:
-    """Deny reason if any uploaded batch lacks a clean verdict; else None.
+    """Deny reason until every batch is verdicted and the LATEST is clean.
 
-    A batch is clean when its verdict exists and reports zero non-image
-    errors. Unreadable marker/verdict files count as unresolved (fail
-    closed — the agent rewrites them by re-running the helper/parser).
+    Two rules, matching how the upload loop really converges:
+      1. EVERY marker needs a verdict — each batch's report must have
+         been read (the anti-fake-success core).
+      2. Only the LATEST batch must be CLEAN (zero non-image errors).
+         Earlier batches are immutable history: a failed intermediate
+         that a later upload superseded can never be "fixed", so
+         requiring it clean would wedge the loop.
+    Unreadable marker/verdict files count as unresolved (fail closed —
+    the agent rewrites them by re-running the helper/parser).
     """
     if task_dir is None:
         return None
@@ -49,6 +55,8 @@ def check_upload_verdicts(task_dir) -> str | None:
         markers = sorted(Path(task_dir).glob(MARKER_GLOB))
     except OSError:
         return None
+    latest_id = None
+    latest_non_image = None
     for marker in markers:
         m = _MARKER_RE.match(marker.name)
         if not m:
@@ -61,8 +69,11 @@ def check_upload_verdicts(task_dir) -> str | None:
                 "yet. Fetch THAT batch's processing report from the SAME "
                 'marketplace you uploaded to (bh_fetch_report with '
                 f'BATCH_ID={batch_id}), then run listing_bulk.py '
-                f'parse-feedback <report> --batch-id {batch_id}. The task '
-                'cannot finish on an unverified upload.'
+                f'parse-feedback <report> --batch-id {batch_id} FROM THE '
+                'TASK WORKSPACE ROOT — the verdict is written to the '
+                'current directory and must land at '
+                f'{verdict_path}. The task cannot finish on an '
+                'unverified upload.'
             )
         try:
             verdict = json.loads(verdict_path.read_text(encoding='utf-8'))
@@ -73,12 +84,17 @@ def check_upload_verdicts(task_dir) -> str | None:
                 f'listing_bulk.py parse-feedback --batch-id {batch_id} '
                 "on the batch's processing report."
             )
-        if non_image > 0:
-            return (
-                f'Batch {batch_id} has {non_image} unresolved non-image '
-                'error(s) per its processing report. Fix exactly the '
-                'fields the report names, re-upload, and parse-feedback '
-                'the new batch. Only the missing-main-image error is '
-                'deferrable.'
-            )
+        # Batch ids are monotonically increasing within an account, so
+        # the lexically greatest marker is the newest upload.
+        if latest_id is None or batch_id > latest_id:
+            latest_id = batch_id
+            latest_non_image = non_image
+    if latest_id is not None and latest_non_image:
+        return (
+            f'Your LATEST batch {latest_id} has {latest_non_image} '
+            'unresolved non-image error(s) per its processing report. '
+            'Fix exactly the fields the report names, re-upload, and '
+            'parse-feedback the new batch. Only the missing-main-image '
+            'error is deferrable.'
+        )
     return None

--- a/app/ai/stop_gates/report_reviewer.py
+++ b/app/ai/stop_gates/report_reviewer.py
@@ -79,6 +79,11 @@ def rollover_reviews(task_dir) -> None:
     try:
         d = Path(task_dir)
         stale = [p for p in d.glob('*.md') if _REVIEW_NAME_RE.search(p.name)]
+        # Upload markers/verdicts are turn-scoped like reviews: a new
+        # turn's gate must not be satisfied (or armed) by a prior
+        # turn's batches. See stop_gates.listing_upload_gate.
+        stale += list(d.glob('UPLOAD_BATCH_*.json'))
+        stale += list(d.glob('BATCH_*_VERDICT.json'))
         if not stale:
             return
         root = d / PREV_TURNS_DIR

--- a/app/routers/tasks_conversation.py
+++ b/app/routers/tasks_conversation.py
@@ -4,10 +4,11 @@ import asyncio
 from datetime import UTC, datetime
 import json
 import logging
+import os
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.claude_backend_manager import agent_manager
@@ -50,6 +51,13 @@ from app.workspace.manager import workspace_manager
 
 logger = logging.getLogger(__name__)
 
+# Transcript size beyond which a follow-up starts a FRESH CLI session
+# (compacted context) instead of --resume. See the context-rot guard
+# in the message handler.
+FRESH_SESSION_MSG_LIMIT = int(
+    os.environ.get('VIBE_FRESH_SESSION_MSG_LIMIT', '400')
+)
+
 router = APIRouter(prefix='/api/tasks', tags=['tasks'])
 
 
@@ -80,6 +88,7 @@ async def _spawn_followup_agent(
     revert_status: TaskStatus,
     revert_error: str | None = None,
     revert_error_category: str | None = None,
+    resume: bool = True,
 ):
     """Run agent_manager.run() off the request path.
 
@@ -131,7 +140,7 @@ async def _spawn_followup_agent(
                 system_extra=system_extra,
                 mode=mode,
                 profile_id=profile_id,
-                resume=True,
+                resume=resume,
                 auto_approve_plan=auto_approve_plan,
                 store_slug=(
                     _store_slug(store.name, store.id) if store else None
@@ -288,6 +297,31 @@ async def send_task_message(
     # Determine if we can resume a CLI session (has full context)
     is_plan_feedback = task.status == TaskStatus.PLANNED
     has_resumable_session = bool(task.session_id) and not is_profile_switch
+    # Context-rot guard: past a certain transcript size, a resumed
+    # session carries more failed-attempt residue than signal — stale
+    # file paths, superseded conclusions, and old batch state dominate
+    # the context and the agent re-verifies dead artifacts (observed
+    # live: a reviewer "verified" a prior turn's report because its
+    # path was still in context). Beyond the threshold, start a FRESH
+    # CLI session seeded with the compact history summary the
+    # non-resumable branch below already builds (history file + recent
+    # messages + plan). The task workspace (files on disk) is unchanged.
+    if has_resumable_session:
+        n_msgs = await db.scalar(
+            select(func.count())
+            .select_from(TaskMessage)
+            .where(TaskMessage.task_id == task_id)
+        )
+        if (n_msgs or 0) > FRESH_SESSION_MSG_LIMIT:
+            has_resumable_session = False
+            logger.info(
+                'Task %s transcript has %d messages (> %d) — starting '
+                'a fresh session with compacted context instead of '
+                'resuming',
+                task_id,
+                n_msgs,
+                FRESH_SESSION_MSG_LIMIT,
+            )
 
     # Plan approval is a ONE-WAY exit from plan mode (like Claude Code:
     # an approved ExitPlanMode leaves the session in normal mode for
@@ -446,6 +480,7 @@ async def send_task_message(
                 mode='plan_then_execute',
                 profile_id=requested_profile_id,
                 auto_approve_plan=_follow_up_auto_approve(task),
+                resume=has_resumable_session,
                 revert_status=TaskStatus.PLANNED,
             )
         )
@@ -508,6 +543,7 @@ async def send_task_message(
                 mode=follow_up_mode,
                 profile_id=requested_profile_id,
                 auto_approve_plan=_follow_up_auto_approve(task),
+                resume=has_resumable_session,
                 revert_status=TaskStatus(prev_status),
                 revert_error=prev_error,
                 revert_error_category=prev_error_category,
@@ -554,6 +590,7 @@ async def send_task_message(
                 mode=follow_up_mode,
                 profile_id=requested_profile_id,
                 auto_approve_plan=_follow_up_auto_approve(task),
+                resume=has_resumable_session,
                 revert_status=TaskStatus(task.status),
             )
         )

--- a/app/routers/tasks_conversation.py
+++ b/app/routers/tasks_conversation.py
@@ -13,14 +13,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.claude_backend_manager import agent_manager
 from app.ai.compaction import build_history_prompt, dump_history_file
-from app.ai.external_config import (
-    ExternalConfigOverrideError,
-    assert_profile_compatible,
-)
 from app.ai.profiles import DEFAULT_PROFILE_ID
 from app.auth import get_current_user
-from app.browser.manager import browser_manager, store_slug as _store_slug
-from app.database import async_session, get_db
+from app.browser.manager import browser_manager
+from app.database import get_db
 from app.events.bus import event_bus
 from app.models.schedule import Schedule
 from app.models.store import Store
@@ -39,8 +35,11 @@ from app.task_runner import (
     get_store_emails,
     reopen_parent_if_child_active,
 )
-from app.task_runner_auto import auto_run_task, finalize_followup_session
+from app.task_runner_auto import auto_run_task
 from app.task_runner_exec import execute_planned_task
+from app.task_runner_followup import (
+    spawn_followup_agent as _spawn_followup_agent,
+)
 from app.task_states import (
     RETRIABLE,
     WAKEABLE,
@@ -74,112 +73,6 @@ def _follow_up_auto_approve(task: Task) -> bool:
     then wait forever for an approval that never arrives.
     """
     return bool(task.schedule_id) or not task.plan_mode
-
-
-async def _spawn_followup_agent(
-    task_id: str,
-    store: Store | None,
-    *,
-    prompt: str,
-    system_extra: str,
-    mode: str,
-    profile_id: str,
-    auto_approve_plan: bool,
-    revert_status: TaskStatus,
-    revert_error: str | None = None,
-    revert_error_category: str | None = None,
-    resume: bool = True,
-):
-    """Run agent_manager.run() off the request path.
-
-    The HTTP handler can't await the run because acquiring the
-    agent-concurrency semaphore can take seconds-to-minutes under
-    load (catalog-sync fanout, parallel e2e workers). Awaiting it
-    inline blocks the response past the client's read timeout.
-
-    On success, schedules ``finalize_followup_session`` so the
-    session still transitions out of RUNNING/DESIGNING when it
-    ends. On failure (started=False or exception), reverts the
-    task back to its prior terminal state via a fresh DB session
-    so the UI doesn't get stuck mid-transition.
-    """
-    started = False
-    try:
-        # cc-switch / external override may have appeared since the
-        # initial task ran — re-check before each follow-up spawn so
-        # the agent never silently routes to whatever endpoint the
-        # external tool configured. Treat as a normal launch failure
-        # so the existing revert path runs (task back to its prior
-        # terminal status, error surfaced on the task card).
-        try:
-            assert_profile_compatible(profile_id)
-        except ExternalConfigOverrideError as override_err:
-            # Expected, user-actionable condition — don't ``raise``
-            # into the outer ``except Exception`` (it would log a
-            # full stack trace via ``logger.exception``). Instead
-            # update the revert vars in-place and skip past the
-            # agent_manager.run call so the existing revert path
-            # below runs with the structured detail.
-            #
-            # JSON-encode so the frontend's
-            # ``ExternalConfigOverrideErrorCard`` renders the
-            # localized template (same shape as auto_run_task).
-            revert_error = json.dumps(override_err.to_api_detail())
-            revert_error_category = 'external_config_override'
-            logger.info(
-                'Follow-up for task %s blocked by external config '
-                'override (%s); will revert.',
-                task_id,
-                override_err.overriding_keys,
-            )
-            started = False
-        else:
-            started = await agent_manager.run(
-                task_id,
-                prompt,
-                system_extra=system_extra,
-                mode=mode,
-                profile_id=profile_id,
-                resume=resume,
-                auto_approve_plan=auto_approve_plan,
-                store_slug=(
-                    _store_slug(store.name, store.id) if store else None
-                ),
-                # Follow-up turns are conversational — reflection is
-                # for initial task knowledge capture. Re-running it
-                # on every follow-up forces a text-emitting
-                # reflection phase that overwrites the agent's
-                # actual response when the model put its answer
-                # only in a thinking block (e.g. GLM-4.7 on terse
-                # follow-ups). The initial task's reflection already
-                # captured any learnings; conversational turns have
-                # nothing new to learn from.
-                skip_reflection=True,
-            )
-    except Exception:
-        logger.exception(
-            'Background follow-up agent run failed for task %s', task_id
-        )
-    if started:
-        asyncio.create_task(finalize_followup_session(task_id, store))
-        return
-    # Revert to prior terminal state — the request handler already
-    # committed RUNNING/DESIGNING and emitted task_update; we need
-    # to roll that back so the UI doesn't sit on a phantom phase.
-    async with async_session() as db2:
-        task_obj = await db2.get(Task, task_id)
-        if task_obj is None:
-            return
-        task_obj.status = revert_status.value
-        if revert_error is not None or revert_error_category is not None:
-            task_obj.error = revert_error
-            task_obj.error_category = revert_error_category
-        task_obj.updated_at = datetime.now(UTC).isoformat()
-        await db2.commit()
-    await event_bus.emit(
-        'task_update',
-        {'task_id': task_id, 'status': revert_status.value},
-    )
 
 
 async def get_next_seq(db: AsyncSession, task_id: str) -> int:

--- a/app/skills_v2/MANIFEST.txt
+++ b/app/skills_v2/MANIFEST.txt
@@ -24,6 +24,9 @@ amazon-listing/scripts/listing_bulk.py
 amazon-listing/scripts/marketplace_ids.py
 amazon-listing/scripts/listing_schema.py
 amazon-listing/scripts/ocr_1688.py
+amazon-listing/scripts/bh_upload_flatfile.py
+amazon-listing/scripts/bh_fetch_report.py
+amazon-listing/scripts/bh_download_template.py
 amazon-listing/requirements.txt
 amazon-invoice/SKILL.md
 amazon-invoice/generate_invoice.py

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -394,6 +394,8 @@ MARKER_DIR="$PWD" browser-use < $S/bh_upload_flatfile.py
 SC_HOST=sellercentral.amazon.<tld> BATCH_ID=<id> DOWNLOADS_DIR=$DL \
 browser-use < $S/bh_fetch_report.py
 python3 $S/listing_bulk.py parse-feedback <report> --batch-id <id>
+# ^ run FROM the task workspace root: the verdict JSON is written to
+#   the current directory, which is where the completion gate reads it.
 ```
 
 The helpers encode the mechanics (decoy input, region stamp, two-click

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -367,6 +367,39 @@ shareable at all: when Amazon still `8560`s *after* a correct match,
 that region cannot share the catalog — report that (a new ASIN is
 unavoidable), don't silently fork the reviews.
 
+## Deterministic browser helpers (use these FIRST)
+
+Three env-parameterized harness scripts mechanize the finicky browser
+steps — run them through the store wrapper from the task workspace, read
+the single ``RESULT {json}`` line, and only fall back to hand-driving
+(screenshot → explore) when one reports ok=false:
+
+```bash
+S=.claude/skills/amazon-listing/scripts
+DL=~/.vibe-seller/downloads/<slug>
+
+# 1. Generate + download ONE marketplace's template (region-stamped by
+#    the ticked store — this does the ticking for you):
+SC_HOST=sellercentral.amazon.<tld> PRODUCT_TYPE=<keyword> \
+STORE_LABEL=Amazon.<tld> DOWNLOADS_DIR=$DL \
+browser-use < $S/bh_download_template.py
+
+# 2. Stage + submit the filled .txt (file-chooser intercept + Submit +
+#    batch id). Writes UPLOAD_BATCH_<id>.json to MARKER_DIR — the task
+#    CANNOT finish until that batch has a clean parse-feedback verdict:
+UPLOAD_FILE=$DL/out.txt SC_HOST=sellercentral.amazon.<tld> \
+MARKER_DIR="$PWD" browser-use < $S/bh_upload_flatfile.py
+
+# 3. Fetch THAT batch's processing report, then verdict it:
+SC_HOST=sellercentral.amazon.<tld> BATCH_ID=<id> DOWNLOADS_DIR=$DL \
+browser-use < $S/bh_fetch_report.py
+python3 $S/listing_bulk.py parse-feedback <report> --batch-id <id>
+```
+
+The helpers encode the mechanics (decoy input, region stamp, two-click
+submit, shadow-DOM rows); your judgment stays with the spec: which
+operation per row, which fields, and how to fix what the report names.
+
 ## The two scripts
 
 ```bash

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -334,17 +334,24 @@ for an `8560` to fix reactively:
      - **Shared catalog** (the ASIN resolves on the target marketplace):
        pin it + `operation: partialupdate` and add only this marketplace's
        offer — don't re-describe the product.
-     - **Separate catalog** (the target `/dp/<ASIN>` is "Page Not Found",
-       or the upload reports *"the offer cannot be added because the
-       product is not in the catalogue … listing a product from one
-       marketplace to another"* / an `8560`): the ASIN **cannot be
-       shared**. A match/partialupdate fails. You must **CREATE fresh** —
-       a new ASIN (GTIN-exempt) with the FULL required product data
-       (`item_name`, `color_name`, `variation_theme`, description,
-       bullets, …), exactly like the original create on the source
-       marketplace. Regional siblings (e.g. SA vs AE) are frequently
-       SEPARATE catalogs, so this is the common cross-region case — expect
-       to create, not just add an offer.
+     - **Not in the target catalog yet** (the target `/dp/<ASIN>` is
+       "Page Not Found", or the upload reports *"the offer cannot be
+       added because the product is not in the catalogue … listing a
+       product from one marketplace to another"*): an offer-only
+       partialupdate cannot work — but this is NOT a first-time
+       creation either. **CREATE on the target with the FULL product
+       data AND each row's existing ASIN pinned** (`asin: <existing>`
+       on the row): the product already has an ASIN on the source
+       marketplace, and pinning it lets the target link the SAME ASIN
+       so ratings/reviews pool internationally instead of forking.
+       Mint a NEW ASIN (GTIN-exempt, product id left blank) only when
+       the product exists on no marketplace yet, the user explicitly
+       wants a separate listing, or a pinned create irrecoverably
+       conflicts (fix what the report names first). Afterwards verify
+       each CHILD's ASIN on the target equals the source's — children
+       are the buyable entities whose reviews pool; if the parent
+       container minted a new ASIN despite matched children, say so in
+       the result rather than calling the families identical.
    - Supply the **complete offer** — `our_price` + `quantity` +
      `fulfillment_channel_code` — on each child. A fulfillment group needs
      a channel code together with its quantity, or Amazon rejects the

--- a/app/skills_v2/amazon-listing/scripts/bh_download_template.py
+++ b/app/skills_v2/amazon-listing/scripts/bh_download_template.py
@@ -1,0 +1,166 @@
+# ruff: noqa: F821 — browser-harness globals (new_tab, js, cdp, ...)
+"""Generate + download ONE marketplace's product-spreadsheet template.
+
+The generated template is REGION-STAMPED by the store checkboxes (they
+default to the account's home marketplace), so this drives the whole
+generator flow with the TARGET store ticked and the other leaf stores
+unticked. Run through the STORE WRAPPER:
+
+  SC_HOST=sellercentral.amazon.ae PRODUCT_TYPE=socks \
+  STORE_LABEL=Amazon.ae DOWNLOADS_DIR=~/.vibe-seller/downloads/<slug> \
+  browser-use < .claude/skills/amazon-listing/scripts/bh_download_template.py
+
+Prints exactly one ``RESULT {json}`` line:
+  ok / template (downloaded path) / picked (product type) / reason
+
+On any miss it screenshots and reports the step that failed — explore
+from the screenshot rather than blind-retrying.
+"""
+
+import glob
+import json
+import os
+import time
+
+HOST = os.environ['SC_HOST']
+PTYPE = os.environ['PRODUCT_TYPE']
+STORE = os.environ['STORE_LABEL']
+DL = os.path.expanduser(os.environ['DOWNLOADS_DIR'])
+out = {'ok': False, 'template': None, 'picked': None}
+
+_WALK = (
+    'function* w(r){for(const e of r.querySelectorAll("*")){yield e;'
+    'if(e.shadowRoot) yield* w(e.shadowRoot);}}'
+)
+
+
+def _click_text(pattern):
+    """Trusted-click the first element whose text matches *pattern*."""
+    box = js(
+        _WALK + 'for(const e of w(document)){'
+        'const t=(e.innerText||(e.getAttribute&&e.getAttribute("label"))'
+        '||"").trim();'
+        f'if(/{pattern}/i.test(t) && t.length<60){{'
+        'const r=e.getBoundingClientRect();'
+        'if(r.width) return JSON.stringify('
+        '{x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)});}}'
+        'return null;'
+    )
+    if not box:
+        return False
+    b = json.loads(box)
+    click_at_xy(b['x'], b['y'])
+    return True
+
+
+def _fail(reason):
+    capture_screenshot()
+    out['reason'] = reason
+    print('RESULT ' + json.dumps(out))
+
+
+t0 = time.time()
+new_tab(f'https://{HOST}/product-search/bulk/generate')
+time.sleep(13)
+if not _click_text('^download product spreadsheet$'):
+    _fail('Download Product Spreadsheet button not found')
+else:
+    time.sleep(7)
+    # Product-type search wants TRUSTED keystrokes (a JS value set does
+    # not stick on the kat predictive input).
+    sb = js(
+        _WALK + 'for(const e of w(document)){'
+        'const tag=(e.tagName||"").toLowerCase();'
+        'const ph=(e.placeholder||(e.getAttribute&&'
+        'e.getAttribute("placeholder"))||"");'
+        'if(tag==="input" && /product keyword/i.test(ph)){'
+        'const r=e.getBoundingClientRect();'
+        'return JSON.stringify({x:Math.round(r.x+r.width/2),'
+        'y:Math.round(r.y+r.height/2)});}}'
+        'return null;'
+    )
+    if not sb:
+        _fail('product-type search input not found')
+    else:
+        b = json.loads(sb)
+        click_at_xy(b['x'], b['y'])
+        time.sleep(1)
+        cdp('Input.insertText', text=PTYPE)
+        for t in ('keyDown', 'keyUp'):
+            cdp(
+                'Input.dispatchKeyEvent',
+                type=t,
+                key='Enter',
+                code='Enter',
+                windowsVirtualKeyCode=13,
+            )
+        time.sleep(6)
+        # First result's Select button (topmost).
+        sel = js(
+            _WALK + 'let best=null, label=null, prev=null;'
+            'for(const e of w(document)){'
+            'const t=(e.innerText||(e.getAttribute&&'
+            'e.getAttribute("label"))||"").trim();'
+            'if(/^select$/i.test(t)){const r=e.getBoundingClientRect();'
+            'if(r.width && (!best||r.y<best.y)){'
+            'best={x:Math.round(r.x+r.width/2),'
+            'y:Math.round(r.y+r.height/2)}; label=prev;}}'
+            'if(t && t.length<40) prev=t;}'
+            'return best?JSON.stringify({box:best,label:label}):null;'
+        )
+        if not sel:
+            _fail(f'no product-type result for {PTYPE!r}')
+        else:
+            info = json.loads(sel)
+            out['picked'] = info.get('label')
+            click_at_xy(info['box']['x'], info['box']['y'])
+            time.sleep(4)
+            # Store checkboxes: tick the TARGET leaf, untick other
+            # Amazon.* leaves (never touch region parents like Europe —
+            # unticking a parent clears all its children).
+            js(
+                _WALK + 'for(const e of w(document)){'
+                'if((e.tagName||"").toLowerCase()!=="kat-checkbox")'
+                'continue;'
+                'const lbl=(e.getAttribute("label")||e.textContent||"")'
+                '.trim();'
+                'if(!/^Amazon\\./i.test(lbl)) continue;'
+                'const on=e.hasAttribute("checked")&&'
+                'e.getAttribute("checked")!=="false";'
+                f'const want=(lbl.toLowerCase()==="{STORE.lower()}");'
+                'if(want!==on) e.click();}'
+                'return "stores set";'
+            )
+            time.sleep(2)
+            # Generate sits low in the modal — extend the viewport so
+            # the trusted click lands.
+            cdp(
+                'Emulation.setDeviceMetricsOverride',
+                width=1920,
+                height=1600,
+                deviceScaleFactor=1,
+                mobile=False,
+            )
+            time.sleep(1)
+            if not _click_text('^generate spreadsheet$'):
+                _fail('Generate Spreadsheet button not found')
+            else:
+                template = None
+                for _ in range(25):
+                    time.sleep(1)
+                    cands = [
+                        p
+                        for p in glob.glob(os.path.join(DL, '*.xlsm'))
+                        if os.path.getmtime(p) > t0
+                    ]
+                    if cands:
+                        template = max(cands, key=os.path.getmtime)
+                        break
+                out['template'] = template
+                out['ok'] = bool(template)
+                if not template:
+                    out['reason'] = (
+                        'Generate clicked but no new .xlsm landed in ' + DL
+                    )
+                    capture_screenshot()
+                print('RESULT ' + json.dumps(out))

--- a/app/skills_v2/amazon-listing/scripts/bh_fetch_report.py
+++ b/app/skills_v2/amazon-listing/scripts/bh_fetch_report.py
@@ -1,0 +1,101 @@
+# ruff: noqa: F821 — browser-harness globals (new_tab, js, cdp, ...)
+"""Fetch ONE batch's Processing Summary from Check Upload Status.
+
+Finds the row for BATCH_ID (shadow-DOM aware), reports its live status,
+and — when a Download Processing Summary button exists for it — clicks
+it and waits for the report to land in the store downloads dir. Run
+through the STORE WRAPPER:
+
+  SC_HOST=sellercentral.amazon.ae BATCH_ID=100000000001 \
+  DOWNLOADS_DIR=~/.vibe-seller/downloads/<slug> \
+  browser-use < .claude/skills/amazon-listing/scripts/bh_fetch_report.py
+
+Prints exactly one ``RESULT {json}`` line:
+  ok / row (status text) / report (downloaded path) / reason
+
+Then run ``listing_bulk.py parse-feedback <report> --batch-id <id>`` —
+that writes the verdict the completion gate checks.
+"""
+
+import glob
+import json
+import os
+import time
+
+HOST = os.environ['SC_HOST']
+BATCH = os.environ['BATCH_ID']
+DL = os.path.expanduser(os.environ['DOWNLOADS_DIR'])
+out = {'ok': False, 'batch_id': BATCH, 'row': None, 'report': None}
+
+
+def _newest_xlsm(after_ts):
+    cands = [
+        p
+        for p in glob.glob(os.path.join(DL, '*.xlsm'))
+        if os.path.getmtime(p) > after_ts
+    ]
+    return max(cands, key=os.path.getmtime) if cands else None
+
+
+new_tab(f'https://{HOST}/listing/status')
+time.sleep(15)
+row = js(
+    'function* w(r){for(const e of r.querySelectorAll("*")){yield e;'
+    'if(e.shadowRoot) yield* w(e.shadowRoot);}}'
+    'let seq=[];'
+    'for(const e of w(document)){if(e.children.length===0){'
+    'const t=(e.textContent||"").trim(); if(t) seq.push(t);}}'
+    f'let i=seq.findIndex(s=>s.includes("{BATCH}"));'
+    'return i>=0? seq.slice(Math.max(0,i-2), i+4).join(" | ") : null;'
+)
+out['row'] = row
+if not row:
+    capture_screenshot()
+    print(
+        'RESULT '
+        + json.dumps({**out, 'reason': 'batch id not found on this page'})
+    )
+else:
+    t0 = time.time()
+    clicked = js(
+        'function* w(r){for(const e of r.querySelectorAll("*")){yield e;'
+        'if(e.shadowRoot) yield* w(e.shadowRoot);}}'
+        'let anchor=null;'
+        'for(const e of w(document)){const t=(e.textContent||"").trim();'
+        f'if(t==="{BATCH}"){{anchor=e;break;}}}}'
+        'if(!anchor) return "no anchor";'
+        'let row=anchor;'
+        'for(let i=0;i<14&&row;i++){const tg=row.tagName||"";'
+        'if(/ROW|TR/.test(tg))break;'
+        'row=row.parentElement||(row.getRootNode&&row.getRootNode().host);}'
+        'const scope=row||document;'
+        'for(const b of w(scope)){'
+        'const bt=(b.innerText||(b.getAttribute&&b.getAttribute("label"))'
+        '||"").trim();'
+        'if(/download processing summary/i.test(bt)){'
+        'const r=b.getBoundingClientRect();'
+        'if(r.width) return JSON.stringify('
+        '{x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)});}}'
+        'return "no dl button";'
+    )
+    if clicked and clicked.startswith('{'):
+        # Trusted click — the kat-button ignores untrusted JS .click().
+        b = json.loads(clicked)
+        click_at_xy(b['x'], b['y'])
+        report = None
+        for _ in range(20):
+            time.sleep(1)
+            report = _newest_xlsm(t0)
+            if report:
+                break
+        out['report'] = report
+        out['ok'] = bool(report)
+        if not report:
+            out['reason'] = 'download clicked but no new .xlsm appeared'
+        print('RESULT ' + json.dumps(out))
+    else:
+        out['reason'] = (
+            'no Download Processing Summary for this batch yet '
+            '(still processing?) — row: ' + str(row)
+        )
+        print('RESULT ' + json.dumps(out))

--- a/app/skills_v2/amazon-listing/scripts/bh_upload_flatfile.py
+++ b/app/skills_v2/amazon-listing/scripts/bh_upload_flatfile.py
@@ -1,0 +1,134 @@
+# ruff: noqa: F821 — browser-harness globals (new_tab, js, cdp, ...)
+"""Stage + submit a listing flat-file on ONE marketplace's upload page.
+
+Deterministic fast path for the whole upload dance (the file-chooser
+intercept, the introspect wait, the Submit click, the batch id) so the
+agent never re-derives it. Run through the STORE WRAPPER with env
+parameters, from the task workspace:
+
+  UPLOAD_FILE=/abs/path/file.txt SC_HOST=sellercentral.amazon.ae \
+  MARKER_DIR="$PWD" browser-use < .claude/skills/amazon-listing/scripts/bh_upload_flatfile.py
+
+Prints exactly one ``RESULT {json}`` line:
+  ok / staged / detected / region_error / batch_id / reason
+
+On success it writes ``UPLOAD_BATCH_<id>.json`` into MARKER_DIR (pass
+your task workspace) — the completion gate then requires a parse-feedback
+verdict for that batch before the task may finish. On failure it takes a
+screenshot and reports the reason; explore from there, don't blind-retry.
+"""
+
+import json
+import os
+import time
+
+F = os.environ['UPLOAD_FILE']
+HOST = os.environ['SC_HOST']
+MARKER_DIR = os.environ.get('MARKER_DIR', '.')
+out = {
+    'ok': False,
+    'staged': False,
+    'detected': False,
+    'region_error': False,
+    'batch_id': None,
+    'host': HOST,
+    'file': F,
+}
+
+
+def _finish(reason=None):
+    if reason:
+        out['reason'] = reason
+    print('RESULT ' + json.dumps(out))
+
+
+new_tab(f'https://{HOST}/product-search/bulk')
+time.sleep(12)
+cdp('Page.enable')
+cdp('Page.setInterceptFileChooserDialog', enabled=True)
+drain_events()
+box = js(
+    "var u=document.querySelector('kat-file-upload');"
+    'if(!u) return null;'
+    "var b=u.shadowRoot.querySelector('#select-file')"
+    "||u.shadowRoot.querySelector('button');"
+    'var r=b.getBoundingClientRect();'
+    'return {x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)};'
+)
+if not box:
+    cdp('Page.setInterceptFileChooserDialog', enabled=False)
+    capture_screenshot()
+    _finish('upload widget (kat-file-upload) not found on the page')
+else:
+    # Trusted click opens the (suppressed) chooser; Chrome hands us the
+    # REAL input's backendNodeId. Setting the visible input is a no-op
+    # (it is a decoy) — this is the only reliable staging path.
+    click_at_xy(box['x'], box['y'])
+    bnid = None
+    for _ in range(12):
+        time.sleep(0.5)
+        for e in drain_events():
+            if 'fileChooserOpened' in str(e.get('method', '')):
+                bnid = e['params']['backendNodeId']
+        if bnid:
+            break
+    if not bnid:
+        cdp('Page.setInterceptFileChooserDialog', enabled=False)
+        capture_screenshot()
+        _finish('file chooser never opened (trusted click missed?)')
+    else:
+        cdp('DOM.setFileInputFiles', backendNodeId=bnid, files=[F])
+        cdp('Page.setInterceptFileChooserDialog', enabled=False)
+        time.sleep(10)  # introspect-feed runs
+        state = js(
+            'var t=document.body.innerText;'
+            'return {detected:/automatically detected/i.test(t),'
+            'region:/different region|MARKETPLACES_DIFFERENT/i.test(t),'
+            'notup:/file not uploaded/i.test(t)};'
+        )
+        out['staged'] = not state['notup']
+        out['detected'] = bool(state['detected'])
+        out['region_error'] = bool(state['region'])
+        if state['region']:
+            _finish(
+                'template region-stamp mismatch: regenerate the template '
+                'with THIS marketplace ticked (bh_download_template)'
+            )
+        elif not state['detected']:
+            capture_screenshot()
+            _finish(
+                'file staged but type not detected — read the screenshot '
+                'for the widget error before retrying'
+            )
+        else:
+            ref = None
+            for _ in range(2):  # some flows need a second Submit click
+                sb = js(
+                    'var els=[...document.querySelectorAll('
+                    "'kat-button,button')];"
+                    'var b=els.find(function(e){return /submit products/i'
+                    ".test(e.innerText||e.getAttribute('label')||'');});"
+                    'if(!b) return null;'
+                    'var r=b.getBoundingClientRect();'
+                    'return {x:Math.round(r.x+r.width/2),'
+                    'y:Math.round(r.y+r.height/2)};'
+                )
+                if sb:
+                    click_at_xy(sb['x'], sb['y'])
+                    time.sleep(8)
+                ref = js(
+                    'return (location.href.match(/reference_id=(\\d+)/)'
+                    '||[])[1]||null'
+                )
+                if ref:
+                    break
+            out['batch_id'] = ref
+            out['ok'] = bool(ref)
+            if ref:
+                marker = os.path.join(MARKER_DIR, f'UPLOAD_BATCH_{ref}.json')
+                with open(marker, 'w') as fh:
+                    json.dump({'batch_id': ref, 'host': HOST, 'file': F}, fh)
+                _finish()
+            else:
+                capture_screenshot()
+                _finish('submit clicked but no reference_id in the URL')

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -594,6 +594,35 @@ def _report_comment_errors(path):
     return out
 
 
+def _write_verdict(batch_id, n_err, n_warn, error_msgs):
+    """Write ``BATCH_<id>_VERDICT.json`` to CWD (the task workspace).
+
+    The machine-checkable verdict the completion gate matches against the
+    ``UPLOAD_BATCH_<id>.json`` marker bh_upload_flatfile wrote: the task
+    cannot finish while a batch has non-image errors. When the caller
+    could not extract per-error text, every error counts as non-image
+    (conservative -- never lets an unknown error pass as deferrable).
+    """
+    if not batch_id:
+        return
+    non_image = [
+        m
+        for m in error_msgs
+        if '18320' not in m and 'main image' not in m.lower()
+    ]
+    strict = error_msgs or n_err == 0
+    with open(f'BATCH_{batch_id}_VERDICT.json', 'w', encoding='utf-8') as fh:
+        json.dump(
+            {
+                'batch_id': batch_id,
+                'errors': n_err,
+                'warnings': n_warn,
+                'non_image_errors': len(non_image) if strict else n_err,
+            },
+            fh,
+        )
+
+
 def cmd_parse_feedback(args):
     """Summarise Amazon's processing report: per-SKU errors/warnings.
 
@@ -610,6 +639,12 @@ def cmd_parse_feedback(args):
         print(
             f'\n{n_err} error(s), {n_warn} warning(s) across '
             f'{len({s for s, *_ in comment_errs})} SKU(s).'
+        )
+        _write_verdict(
+            getattr(args, 'batch_id', None),
+            n_err,
+            n_warn,
+            [m for _s, _f, sev, m in comment_errs if sev == 'error'],
         )
         if n_err:
             print(
@@ -702,6 +737,12 @@ def cmd_parse_feedback(args):
             n_err, n_warn = c_err, c_warn
 
     print(f'\nsummary: {n_err} error(s), {n_warn} warning(s)')
+    _write_verdict(
+        getattr(args, 'batch_id', None),
+        n_err,
+        n_warn,
+        [m for _s, _f, m in cell_errs] if cell_errs else [],
+    )
     if n_err:
         sys.exit(1)
 
@@ -729,6 +770,10 @@ def main():
 
     p = sub.add_parser('parse-feedback', help='summarise a processing report')
     p.add_argument('file')
+    p.add_argument(
+        '--batch-id',
+        help='write BATCH_<id>_VERDICT.json for the completion gate',
+    )
     p.set_defaults(func=cmd_parse_feedback)
 
     args = ap.parse_args()

--- a/app/task_runner_followup.py
+++ b/app/task_runner_followup.py
@@ -1,0 +1,134 @@
+"""Follow-up agent spawn helper (off the request path).
+
+Extracted from ``routers/tasks_conversation.py`` (which owns the HTTP
+handlers and the fresh-session context-rot guard) so the router stays
+within the module line cap. Sibling of ``task_runner_auto`` /
+``task_runner_exec`` — this is the lifecycle piece for user-initiated
+follow-up turns.
+"""
+
+import asyncio
+from datetime import UTC, datetime
+import json
+import logging
+
+from app.ai.claude_backend_manager import agent_manager
+from app.ai.external_config import (
+    ExternalConfigOverrideError,
+    assert_profile_compatible,
+)
+from app.browser.manager import store_slug as _store_slug
+from app.database import async_session
+from app.events.bus import event_bus
+from app.models.store import Store
+from app.models.task import Task
+from app.task_runner_auto import finalize_followup_session
+from app.task_states import TaskStatus
+
+logger = logging.getLogger(__name__)
+
+
+async def spawn_followup_agent(
+    task_id: str,
+    store: Store | None,
+    *,
+    prompt: str,
+    system_extra: str,
+    mode: str,
+    profile_id: str,
+    auto_approve_plan: bool,
+    revert_status: TaskStatus,
+    revert_error: str | None = None,
+    revert_error_category: str | None = None,
+    resume: bool = True,
+):
+    """Run agent_manager.run() off the request path.
+
+    The HTTP handler can't await the run because acquiring the
+    agent-concurrency semaphore can take seconds-to-minutes under
+    load (catalog-sync fanout, parallel e2e workers). Awaiting it
+    inline blocks the response past the client's read timeout.
+
+    On success, schedules ``finalize_followup_session`` so the
+    session still transitions out of RUNNING/DESIGNING when it
+    ends. On failure (started=False or exception), reverts the
+    task back to its prior terminal state via a fresh DB session
+    so the UI doesn't get stuck mid-transition.
+    """
+    started = False
+    try:
+        # cc-switch / external override may have appeared since the
+        # initial task ran — re-check before each follow-up spawn so
+        # the agent never silently routes to whatever endpoint the
+        # external tool configured. Treat as a normal launch failure
+        # so the existing revert path runs (task back to its prior
+        # terminal status, error surfaced on the task card).
+        try:
+            assert_profile_compatible(profile_id)
+        except ExternalConfigOverrideError as override_err:
+            # Expected, user-actionable condition — don't ``raise``
+            # into the outer ``except Exception`` (it would log a
+            # full stack trace via ``logger.exception``). Instead
+            # update the revert vars in-place and skip past the
+            # agent_manager.run call so the existing revert path
+            # below runs with the structured detail.
+            #
+            # JSON-encode so the frontend's
+            # ``ExternalConfigOverrideErrorCard`` renders the
+            # localized template (same shape as auto_run_task).
+            revert_error = json.dumps(override_err.to_api_detail())
+            revert_error_category = 'external_config_override'
+            logger.info(
+                'Follow-up for task %s blocked by external config '
+                'override (%s); will revert.',
+                task_id,
+                override_err.overriding_keys,
+            )
+            started = False
+        else:
+            started = await agent_manager.run(
+                task_id,
+                prompt,
+                system_extra=system_extra,
+                mode=mode,
+                profile_id=profile_id,
+                resume=resume,
+                auto_approve_plan=auto_approve_plan,
+                store_slug=(
+                    _store_slug(store.name, store.id) if store else None
+                ),
+                # Follow-up turns are conversational — reflection is
+                # for initial task knowledge capture. Re-running it
+                # on every follow-up forces a text-emitting
+                # reflection phase that overwrites the agent's
+                # actual response when the model put its answer
+                # only in a thinking block (e.g. GLM-4.7 on terse
+                # follow-ups). The initial task's reflection already
+                # captured any learnings; conversational turns have
+                # nothing new to learn from.
+                skip_reflection=True,
+            )
+    except Exception:
+        logger.exception(
+            'Background follow-up agent run failed for task %s', task_id
+        )
+    if started:
+        asyncio.create_task(finalize_followup_session(task_id, store))
+        return
+    # Revert to prior terminal state — the request handler already
+    # committed RUNNING/DESIGNING and emitted task_update; we need
+    # to roll that back so the UI doesn't sit on a phantom phase.
+    async with async_session() as db2:
+        task_obj = await db2.get(Task, task_id)
+        if task_obj is None:
+            return
+        task_obj.status = revert_status.value
+        if revert_error is not None or revert_error_category is not None:
+            task_obj.error = revert_error
+            task_obj.error_category = revert_error_category
+        task_obj.updated_at = datetime.now(UTC).isoformat()
+        await db2.commit()
+    await event_bus.emit(
+        'task_update',
+        {'task_id': task_id, 'status': revert_status.value},
+    )

--- a/docs/skill-review-mechanism.md
+++ b/docs/skill-review-mechanism.md
@@ -76,9 +76,19 @@ for anything structurally verifiable:
   drill block; drill counts are **monotonic** across rounds (catches the
   compaction-clobber regression). *This is what an LLM judge cannot
   reproduce and must not replace.*
-- `listing_submitted` — a submission artifact exists for every attempted
-  SKU with a batch id and a processing report parsed to
-  `errors == 0`. ("Uploaded?" answered by the report, not the claim.)
+- `listing_submitted` — **implemented as the batch-marker gate**
+  (`stop_gates/listing_upload_gate.py`): the upload helper
+  (`amazon-listing/scripts/bh_upload_flatfile.py`) records every
+  submitted batch as an `UPLOAD_BATCH_<id>.json` marker in the task
+  workspace, and `listing_bulk.py parse-feedback --batch-id <id>` writes
+  the matching `BATCH_<id>_VERDICT.json` after reading THAT batch's
+  processing report. Completion is denied until every marker has a
+  verdict and the **latest** batch has zero non-image errors (earlier
+  batches are immutable history a later upload supersedes). Freshness is
+  keyed to the batch id the upload actually produced — a reviewer can't
+  pass the turn on a stale report. Markers/verdicts roll over with the
+  review files at each new turn (`rollover_reviews`). ("Uploaded?"
+  answered by the report, not the claim.)
 - `export_produced` — the requested export file exists, non-empty,
   row-count > 0.
 - `reviews_manifest` — the reviews manifest exists with the expected
@@ -95,6 +105,12 @@ against reality**, then loops until the bar is met. "Did the ads get
 fully drilled?" / "Did the listing actually get created and succeed?" are
 answered by **going and looking**, not by reading the writer's prose.
 
+- **Verdict authorship is enforced, not assumed.** The stream marks the
+  session when it observes a review/verify `Agent`/`Task` subagent spawn
+  (a tool_use the main agent cannot fabricate); `reviewer_verdict`
+  rejects an accepting `Status: ok`/terminal-`incomplete` verdict when
+  no reviewer subagent ran this turn — a verdict the writer wrote itself
+  does not count (`subagent_ran` in `stop_gates/report_reviewer.py`).
 - **Agent-spawned reviewer subagent with browser + tool access.** It runs
   in the task context (so it can drive the store's Ziniao `browser-use`
   wrapper and MCP tools) but in a **separate, adversarial context** whose
@@ -151,6 +167,14 @@ still improving). Accept the best result only after `STALL_CAP` rounds
 with **no net progress** (server tracks progress deterministically —
 coverage counts + result delta). A weak-but-progressing model is never
 trapped; a stalled-shallow one is never rubber-stamped.
+
+At the streaming end-of-turn path the same convergence is bounded by
+`REVIEW_REDRIVE_MAX` re-drives per session. Past the bound the gate
+**fails open coherently**: the Stop hook stands down and the result
+ships banner-marked **UNVERIFIED** (`partial_banner`) — never the
+previous failure mode of closing stdin while the Stop hook kept
+denying, which left the agent running against a dead approval channel
+with every tool call default-denied.
 
 ## 4. What changes vs. today
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -124,6 +124,28 @@ When a message is sent to a `completed` or `failed` task:
 
 This differs from the `waiting` → `queued` wake path: waiting tasks are explicitly paused by the agent for external events, while follow-ups are user-initiated continuation of finished work.
 
+### Fresh-session context-rot guard
+
+`resume=True` is a request, not a guarantee. When the task transcript
+exceeds `VIBE_FRESH_SESSION_MSG_LIMIT` (default 400 `task_messages`
+rows), the follow-up handler in `tasks_conversation.py` treats the
+session as **non-resumable** and starts a **fresh CLI session** seeded
+with the compacted context the non-resume branch already builds
+(`app/ai/compaction.py`: full raw history → a JSON file under
+`~/.vibe-seller/task_history/`, last 5 messages inline, plan inline,
+plus an instruction to read the file). The task workspace — files on
+disk, markers, reports — is unchanged.
+
+Why fresh instead of resuming-and-summarizing: the observed failure
+mode on long transcripts is context **rot**, not size — superseded
+conclusions and stale artifact paths persist as "facts" and the agent
+re-verifies dead state. A model-written summary *distills* that
+narrative; a fresh session re-grounds in current reality (disk state,
+live pages) and pulls raw history on demand. Division of labor:
+**Claude Code's native auto-compaction handles intra-turn context
+pressure inside a session; this guard handles inter-turn rot between
+sessions.** The limit is a row-count heuristic — tune via the env var.
+
 ### Plan Feedback
 
 Users send feedback via the unified chat input at the bottom of the conversation view — no separate design buttons or plan-editing UI. When a message is sent while the task is in `planned` status:

--- a/tests/unit/test_fake_agent_patch_coverage.py
+++ b/tests/unit/test_fake_agent_patch_coverage.py
@@ -1,0 +1,82 @@
+"""Every module that imports ``agent_manager`` must be accounted for in
+the workflow-test fake-agent patch list.
+
+``install_fake_agent`` (tests/workflow/conftest.py) patches
+``agent_manager`` per IMPORT SITE — a module that binds the manager at
+import time and is not in that list silently calls the REAL manager
+during workflow tests. This broke live: a new lifecycle module
+(``task_runner_followup``) was extracted, follow-ups routed through it,
+and every follow-up workflow test failed with an empty ``run_calls``
+because the fake never saw the call.
+
+This test moves the contract into code: any module importing
+``agent_manager`` must appear either in the conftest patch list or in
+the explicit allowlist below (modules whose manager use is not on any
+workflow-test path). Adding a new import site forces a conscious choice.
+"""
+
+from pathlib import Path
+import re
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Modules that import agent_manager but are deliberately NOT patched:
+# their manager use is not exercised by workflow tests (startup wiring,
+# background reapers, deletion cleanup, schedule planning fan-out).
+# If a workflow test starts exercising one of these, move it to the
+# conftest patch list instead of extending this allowlist.
+UNPATCHED_ALLOWLIST = {
+    'app.main',
+    'app.routers.schedule_planning',
+    'app.scheduler.plan_reaper',
+    'app.scheduler.stall_reaper',
+    'app.task_delete',
+    # Package facade re-export only — nothing on a workflow-test path
+    # imports the manager through it.
+    'app.ai.__init__',
+}
+
+
+def _import_sites() -> set[str]:
+    sites = set()
+    for py in (REPO / 'app').rglob('*.py'):
+        text = py.read_text(encoding='utf-8', errors='ignore')
+        # Match single-line AND parenthesized multiline import forms.
+        if re.search(
+            r'from app\.ai\.claude_backend_manager import '
+            r'(?:\([^)]*\bagent_manager\b[^)]*\)|[^\n]*\bagent_manager\b)',
+            text,
+        ):
+            rel = py.relative_to(REPO).with_suffix('')
+            sites.add('.'.join(rel.parts))
+    return sites
+
+
+def _patched_sites() -> set[str]:
+    conftest = (REPO / 'tests/workflow/conftest.py').read_text(encoding='utf-8')
+    return set(re.findall(r"setattr\(\s*'([\w.]+)\.agent_manager'", conftest))
+
+
+def test_all_agent_manager_import_sites_are_accounted_for():
+    sites = _import_sites()
+    assert sites, 'scanner found no import sites — regex broken?'
+    unaccounted = sites - _patched_sites() - UNPATCHED_ALLOWLIST
+    assert not unaccounted, (
+        f'Modules import agent_manager but are neither patched by '
+        f'install_fake_agent nor allowlisted: {sorted(unaccounted)}. '
+        'If the module is on a workflow-test path, add it to the '
+        'conftest patch list; otherwise add it to UNPATCHED_ALLOWLIST '
+        'with a reason.'
+    )
+
+
+def test_allowlist_has_no_stale_entries():
+    stale = UNPATCHED_ALLOWLIST - _import_sites()
+    assert not stale, (
+        f'Allowlist entries no longer import agent_manager: '
+        f'{sorted(stale)} — remove them.'
+    )

--- a/tests/unit/test_handle_event_result.py
+++ b/tests/unit/test_handle_event_result.py
@@ -295,8 +295,14 @@ class TestReviewGateRedrive:
                 'result': 'Final answer',
             })
 
-        # Bound hit → normal end-of-turn: result card emitted.
-        assert emitted == [('result', 'Final answer')]
+        # Bound hit → the turn still ends (no wedge), but the result is
+        # banner-marked UNVERIFIED so an unreviewed deliverable is never
+        # mistaken for a reviewed one.
+        assert len(emitted) == 1
+        role, content = emitted[0]
+        assert role == 'result'
+        assert content.endswith('Final answer')
+        assert 'Unverified result' in content
         assert session._first_result_emitted is True
 
     async def test_satisfied_gate_ends_turn_normally(self):

--- a/tests/unit/test_listing_upload_gate.py
+++ b/tests/unit/test_listing_upload_gate.py
@@ -1,0 +1,76 @@
+"""Batch-keyed upload-freshness gate (stop_gates.listing_upload_gate).
+
+A task that uploaded a listing batch (UPLOAD_BATCH marker present) may
+not finish until THAT batch has a parse-feedback verdict with zero
+non-image errors — report freshness by construction, not by prompt.
+"""
+
+import json
+
+import pytest
+
+from app.ai.stop_gates.listing_upload_gate import check_upload_verdicts
+from app.ai.stop_gates.report_reviewer import rollover_reviews
+
+pytestmark = pytest.mark.unit
+
+
+def _marker(d, batch='100000000001'):
+    (d / f'UPLOAD_BATCH_{batch}.json').write_text(
+        json.dumps({'batch_id': batch}), encoding='utf-8'
+    )
+    return batch
+
+
+def _verdict(d, batch, non_image):
+    (d / f'BATCH_{batch}_VERDICT.json').write_text(
+        json.dumps({
+            'batch_id': batch,
+            'errors': non_image,
+            'warnings': 0,
+            'non_image_errors': non_image,
+        }),
+        encoding='utf-8',
+    )
+
+
+class TestUploadVerdictGate:
+    def test_no_markers_is_quiet_noop(self, tmp_path):
+        assert check_upload_verdicts(tmp_path) is None
+        assert check_upload_verdicts(None) is None
+
+    def test_marker_without_verdict_denies(self, tmp_path):
+        batch = _marker(tmp_path)
+        deny = check_upload_verdicts(tmp_path)
+        assert deny is not None and batch in deny
+        assert 'parse-feedback' in deny
+
+    def test_verdict_with_non_image_errors_denies(self, tmp_path):
+        batch = _marker(tmp_path)
+        _verdict(tmp_path, batch, non_image=3)
+        deny = check_upload_verdicts(tmp_path)
+        assert deny is not None and '3 unresolved' in deny
+
+    def test_clean_verdict_passes(self, tmp_path):
+        batch = _marker(tmp_path)
+        _verdict(tmp_path, batch, non_image=0)
+        assert check_upload_verdicts(tmp_path) is None
+
+    def test_unreadable_verdict_fails_closed(self, tmp_path):
+        batch = _marker(tmp_path)
+        (tmp_path / f'BATCH_{batch}_VERDICT.json').write_text(
+            'not json', encoding='utf-8'
+        )
+        deny = check_upload_verdicts(tmp_path)
+        assert deny is not None and 're-run' in deny
+
+    def test_rollover_moves_markers_and_verdicts(self, tmp_path):
+        # A new turn must not be gated (or satisfied) by a prior
+        # turn's batches — rollover moves them aside with the reviews.
+        batch = _marker(tmp_path)
+        _verdict(tmp_path, batch, non_image=0)
+        rollover_reviews(tmp_path)
+        assert check_upload_verdicts(tmp_path) is None
+        assert not list(tmp_path.glob('UPLOAD_BATCH_*.json'))
+        moved = list(tmp_path.glob('.prev_turns/turn_*/UPLOAD_BATCH_*'))
+        assert moved

--- a/tests/unit/test_listing_upload_gate.py
+++ b/tests/unit/test_listing_upload_gate.py
@@ -51,6 +51,23 @@ class TestUploadVerdictGate:
         deny = check_upload_verdicts(tmp_path)
         assert deny is not None and '3 unresolved' in deny
 
+    def test_superseded_failed_batch_does_not_block(self, tmp_path):
+        # An intermediate failed batch is immutable history; only the
+        # LATEST batch must be clean (every batch still needs a verdict).
+        old_b = _marker(tmp_path, batch='100000000001')
+        _verdict(tmp_path, old_b, non_image=12)
+        new_b = _marker(tmp_path, batch='100000000002')
+        _verdict(tmp_path, new_b, non_image=0)
+        assert check_upload_verdicts(tmp_path) is None
+
+    def test_latest_failed_batch_blocks_despite_old_clean(self, tmp_path):
+        old_b = _marker(tmp_path, batch='100000000001')
+        _verdict(tmp_path, old_b, non_image=0)
+        new_b = _marker(tmp_path, batch='100000000002')
+        _verdict(tmp_path, new_b, non_image=2)
+        deny = check_upload_verdicts(tmp_path)
+        assert deny is not None and '100000000002' in deny
+
     def test_clean_verdict_passes(self, tmp_path):
         batch = _marker(tmp_path)
         _verdict(tmp_path, batch, non_image=0)

--- a/tests/workflow/conftest.py
+++ b/tests/workflow/conftest.py
@@ -152,6 +152,7 @@ def install_fake_agent(fake_agent, monkeypatch):
         'app.routers.tasks_conversation.agent_manager', fake_agent
     )
     monkeypatch.setattr('app.task_runner_auto.agent_manager', fake_agent)
+    monkeypatch.setattr('app.task_runner_followup.agent_manager', fake_agent)
     monkeypatch.setattr('app.task_runner_exec.agent_manager', fake_agent)
     monkeypatch.setattr('app.task_session_lifecycle.agent_manager', fake_agent)
     monkeypatch.setattr('app.routers.app_settings.agent_manager', fake_agent)


### PR DESCRIPTION
## Problem

Cross-marketplace listing tasks kept failing over multiple days of
herding — while the same steps, driven by a fresh Claude Code session,
one-shot. The gap wasn't model strength; it was three harness design
gaps (each observed live in task transcripts):

1. **Context rot.** Follow-ups always `--resume`d one ever-growing CLI
   session (2,600+ messages observed). Stale file paths, superseded
   conclusions, and old batch state dominated the context; agents
   re-verified dead artifacts and "concluded" from prior turns' residue.
2. **Mechanics lived as prose and decayed.** The browser recipes (file
   staging past a decoy input, the region-stamped template generator,
   per-batch report download) were documented in skills — and the agent
   still fell into every trap, because paragraph N of a skill loaded
   2,000 messages ago is not a mechanism.
3. **The harness fought recovery.** When the review-gate re-drive budget
   ran out, stdin closed while the Stop hook kept denying — the CLI kept
   running with a dead approval channel, every tool call default-denied
   mid-recovery. That selects for gate *escapes* (self-written verdicts)
   over gate satisfaction.

## Fix

**1. Fresh-context guard** (`tasks_conversation.py`): past
`VIBE_FRESH_SESSION_MSG_LIMIT` (default 400 task messages), a follow-up
starts a FRESH CLI session seeded with the existing compacted history
(history file + recent messages + plan) instead of resuming. The task
workspace (files on disk) is unchanged.

**2. Mechanized helpers** (`amazon-listing/scripts/bh_*.py`): three
env-parameterized browser-harness scripts encode the recipes as code
returning ground-truth JSON:
- `bh_download_template` — the generator flow with the TARGET store
  ticked (templates are region-stamped by the store checkboxes).
- `bh_upload_flatfile` — file-chooser-intercept staging (the visible
  input is a decoy), introspect wait, two-click submit, and the batch id
  from the URL; writes an `UPLOAD_BATCH_<id>.json` marker.
- `bh_fetch_report` — one batch's Processing Summary via shadow-DOM row
  lookup.
SKILL.md now leads with these as the fast path, with
explore-on-failure fallback (every helper screenshots + reports a
reason on ok=false).

**3. Structural gate freshness + coherent fail-open**:
- `listing_bulk.py parse-feedback --batch-id` writes a
  `BATCH_<id>_VERDICT.json`; a new stop gate
  (`stop_gates/listing_upload_gate.py`) denies completion until every
  uploaded batch has a verdict and the LATEST batch is clean (zero
  non-image errors). Report freshness is keyed to the batch id the
  upload actually produced — a reviewer can no longer pass on a stale
  report. Markers/verdicts roll over with reviews each turn.
- Past the re-drive budget the gate now FAILS OPEN coherently: the Stop
  hook stands down and the result ships banner-marked UNVERIFIED —
  never the tool-denial limbo.

## Verification (live e2e)

A **fresh task** ("list the existing family on the second marketplace")
ran end-to-end on the real store with all fixes deployed. The agent —
same model profile that failed for days — did the whole flow itself:

- `bh_download_template` → target-stamped template (ok:true)
- `bh_upload_flatfile` → staged, detected, **no region error**, batch id
  in the TARGET marketplace's own namespace
- full CREATE (separate catalog ⇒ new ASINs, GTIN-exempt, full product
  data), then iterated offers via the processing reports
- the gate denied completion until it parse-feedback'd EVERY batch
  (`review_gate_redrive` observed working live), and two real reviewer
  subagents ran
- final result honestly reported "listed, image-deferred" per child

Independently verified on the target marketplace's own console: the
family shows **Variations (6)** with a **new parent ASIN**, and a child
spot-check shows the intended price on that marketplace.

Unit tests: +8 for the upload gate (incl. superseded-batch and
latest-clean rules), redrive-bound test updated for the UNVERIFIED
banner; full unit suite green.

## Known follow-up

- Verdict files are agent-writable; the live run showed an agent editing
  a superseded batch's verdict (reasoning was correct — the latest-clean
  rule now removes that incentive — but hash-pinning verdicts to report
  files would close the forgery surface entirely).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
