### PR TITLE
fix(plan-mode): a planning-phase failure must resume PLANNING on follow-up

### DIFF
--- a/app/routers/tasks_conversation.py
+++ b/app/routers/tasks_conversation.py
@@ -226,12 +226,25 @@ async def send_task_message(
     # never re-plan. (Bug: approved plan tasks sit in DESIGNING/COMPLETED
     # between turns and used to re-plan every turn.) ``is_plan_only``
     # schedule tasks only ever plan; PLANNED plan-feedback routes above.
+    # FAILED is included ONLY together with ``started_at is None``: a
+    # plan-mode task that failed BEFORE any plan was approved died in
+    # the planning phase, so a follow-up must resume PLANNING — without
+    # this it fell through to auto mode and executed the review-first
+    # task unreviewed under bypassPermissions. A COMPLETED task with no
+    # ``started_at`` (the plan-skip path: agent delivered a result
+    # without ExitPlanMode) stays auto — its work is already done and
+    # accepted as-is by the plan-skip contract.
     plan_phase_active = task.plan_mode and (
         task.is_plan_only
         or (
             task.started_at is None
             and task.status
-            in (TaskStatus.PENDING, TaskStatus.QUEUED, TaskStatus.DESIGNING)
+            in (
+                TaskStatus.PENDING,
+                TaskStatus.QUEUED,
+                TaskStatus.DESIGNING,
+                TaskStatus.FAILED,
+            )
         )
     )
 

--- a/tests/workflow/test_wf_followup_mode.py
+++ b/tests/workflow/test_wf_followup_mode.py
@@ -127,6 +127,56 @@ class TestFollowUpMode:
         run_calls = install_fake_agent.get_calls(task_id=task_id, action='run')
         assert run_calls and run_calls[-1].mode == 'execute'
 
+    async def test_failed_during_planning_followup_resumes_planning(
+        self, admin_client, install_fake_agent
+    ):
+        """A plan-mode task that FAILED before any plan was approved
+        (``started_at`` is None — it is stamped at approval) died in the
+        PLANNING phase. A follow-up must resume planning, not silently
+        execute the review-first task unreviewed in auto mode (the bug:
+        FAILED fell outside the plan-phase status set, so the follow-up
+        ran with mode='auto' under bypassPermissions)."""
+        install_fake_agent.default_scenario = FakeAgentScenario(
+            plan='## replanned'
+        )
+        task_id = await _seed_task(
+            status='failed', plan_mode=True, started_at=None
+        )
+        r = await admin_client.post(
+            f'/api/tasks/{task_id}/messages',
+            json={'content': 'continue please'},
+        )
+        assert r.status_code == 200
+        run_calls = install_fake_agent.get_calls(task_id=task_id, action='run')
+        assert run_calls, 'FakeAgent.run was not invoked'
+        assert run_calls[-1].mode == 'plan_then_execute', (
+            f'Follow-up mode was {run_calls[-1].mode!r}; a review-first '
+            'task whose planning failed must resume PLANNING, not '
+            'execute unreviewed.'
+        )
+
+    async def test_failed_after_approval_followup_is_auto(
+        self, admin_client, install_fake_agent
+    ):
+        """Counterpart: a plan-mode task that failed AFTER approval
+        (``started_at`` set) continues in auto — approval is one-way;
+        the plan must NOT pop again on Continue."""
+        install_fake_agent.default_scenario = FakeAgentScenario(
+            result='resumed'
+        )
+        task_id = await _seed_task(
+            status='failed',
+            plan_mode=True,
+            started_at='2026-07-03T03:41:46+00:00',
+        )
+        r = await admin_client.post(
+            f'/api/tasks/{task_id}/messages',
+            json={'content': 'continue please'},
+        )
+        assert r.status_code == 200
+        run_calls = install_fake_agent.get_calls(task_id=task_id, action='run')
+        assert run_calls and run_calls[-1].mode == 'auto'
+
     async def test_auto_mode_followup_is_auto(
         self, admin_client, install_fake_agent
     ):


### PR DESCRIPTION
## Problem

Scenario review of the review-first (plan mode) lifecycle found a contract violation: a plan-mode task that **fails during planning** — before any plan was approved (`started_at` is stamped at approval) — got its follow-ups dispatched in `mode='auto'`. The task the user explicitly chose to review-first then executed unreviewed under `bypassPermissions`.

Root cause: `plan_phase_active` treated FAILED as "past the plan phase" unconditionally; only PENDING/QUEUED/DESIGNING counted as planning states.

## Fix

Include FAILED in the planning-phase status set, **gated on `started_at is None`** so the deliberate one-way-approval semantics are untouched:

- fail **during planning** → follow-up resumes `plan_then_execute` (plan pops for review again) ✅
- fail **after approval** → follow-up continues in `auto`, plan does not pop again (approval is one-way, matching Claude Code's ExitPlanMode) ✅ pinned by a counterpart test
- COMPLETED with no `started_at` (the plan-skip path) deliberately stays `auto` — its work is already delivered under the plan-skip contract

## Verification

+2 workflow tests (`test_failed_during_planning_followup_resumes_planning`, `test_failed_after_approval_followup_is_auto`); full follow-up/conversation/continue-vs-retry/review-plan workflow suites green (69 tests), ruff + line-limit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)