### PR TITLE
fix(email-sync): init_email_db must add received_epoch before indexing it

### DIFF
--- a/app/email/db.py
+++ b/app/email/db.py
@@ -42,7 +42,12 @@ CREATE TABLE IF NOT EXISTS emails (
 CREATE INDEX IF NOT EXISTS idx_emails_sender ON emails(sender);
 CREATE INDEX IF NOT EXISTS idx_emails_date   ON emails(date);
 CREATE INDEX IF NOT EXISTS idx_emails_folder ON emails(folder);
-CREATE INDEX IF NOT EXISTS idx_emails_recv   ON emails(received_epoch);
+-- NOTE: the index on received_epoch is created in init_email_db, NOT
+-- here. On a DB predating the column, `CREATE TABLE IF NOT EXISTS` is a
+-- no-op (won't add the column), so indexing received_epoch in this same
+-- script throws "no such column" and aborts the whole sync before any
+-- mail is fetched. init_email_db guarantees the column exists first,
+-- then creates the index.
 
 CREATE TABLE IF NOT EXISTS sync_state (
     folder            TEXT PRIMARY KEY,
@@ -81,20 +86,26 @@ def init_email_db(account_id: str) -> Path:
     conn = sqlite3.connect(str(path))
     try:
         conn.execute('PRAGMA journal_mode=WAL')
+        # Base schema: tables + indexes that only reference columns
+        # present since the first release. Deliberately omits the
+        # received_epoch index (see _SCHEMA_SQL note) so this call cannot
+        # throw on a legacy DB lacking that column.
         conn.executescript(_SCHEMA_SQL)
-        # Migrate DBs created before received_epoch existed: add the
-        # column + index, then backfill from the same axis the sweep
-        # filter uses. Idempotent — ADD COLUMN throws once the column
-        # exists, so we probe pragma first.
+        # Bring a legacy (pre-received_epoch) DB up to the current schema
+        # BEFORE anything references the column. Idempotent: probe pragma,
+        # ALTER only when the column is missing.
         cols = {
             r[1] for r in conn.execute('PRAGMA table_info(emails)').fetchall()
         }
         if 'received_epoch' not in cols:
             conn.execute('ALTER TABLE emails ADD COLUMN received_epoch INTEGER')
-            conn.execute(
-                'CREATE INDEX IF NOT EXISTS idx_emails_recv '
-                'ON emails(received_epoch)'
-            )
+        # Column is now guaranteed on both fresh and legacy DBs, so the
+        # index is safe to create here for every DB.
+        conn.execute(
+            'CREATE INDEX IF NOT EXISTS idx_emails_recv '
+            'ON emails(received_epoch)'
+        )
+        # Backfill from the same axis the sweep filter uses.
         conn.execute(
             'UPDATE emails SET received_epoch = '
             "CAST(strftime('%s', COALESCE(fetched_at, date)) AS INTEGER) "

--- a/tests/unit/test_email_db.py
+++ b/tests/unit/test_email_db.py
@@ -270,6 +270,83 @@ class TestReceivedEpochWatermark:
         conn.close()
         assert nulls == 0
 
+    def test_init_upgrades_db_missing_received_epoch_column(
+        self, account_id, tmp_path
+    ):
+        """The real legacy case: an ``emails`` table created before the
+        ``received_epoch`` column existed at all (column absent, not just
+        NULL). ``init_email_db`` must add the column + index and backfill
+        WITHOUT throwing.
+
+        Regression for the production incident where every account's sync
+        failed with ``sqlite3.OperationalError: no such column:
+        received_epoch`` — the received_epoch index in the schema script
+        ran against a legacy table before the migration could add the
+        column, aborting the sync before any mail was fetched.
+        """
+        path = db_path_for_account(account_id)
+        conn = sqlite3.connect(str(path))
+        # Exactly the pre-received_epoch schema shipped to clients.
+        conn.executescript(
+            """
+            CREATE TABLE emails (
+                message_id    TEXT NOT NULL,
+                folder        TEXT NOT NULL DEFAULT 'INBOX',
+                subject       TEXT,
+                sender        TEXT,
+                recipient     TEXT,
+                date          TEXT,
+                body_text     TEXT,
+                body_html     TEXT,
+                raw_headers   TEXT,
+                attachments   TEXT,
+                flags         TEXT,
+                fetched_at    TEXT,
+                email_account TEXT,
+                PRIMARY KEY (message_id, folder)
+            );
+            CREATE INDEX idx_emails_date ON emails(date);
+            CREATE TABLE sync_state (
+                folder TEXT PRIMARY KEY, watermark_date TEXT,
+                last_polled_at TEXT, seen_message_ids TEXT
+            );
+            """
+        )
+        conn.execute(
+            'INSERT INTO emails(message_id, folder, subject, fetched_at, '
+            'date) VALUES(?,?,?,?,?)',
+            ('<otp@ex.com>', 'INBOX', 'OTP', self.NEW, self.NEW),
+        )
+        conn.commit()
+        conn.close()
+
+        # Must not raise (the incident was an uncaught OperationalError).
+        init_email_db(account_id)
+
+        conn = sqlite3.connect(str(path))
+        try:
+            cols = {r[1] for r in conn.execute('PRAGMA table_info(emails)')}
+            indexes = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index'"
+                )
+            }
+            epoch = conn.execute(
+                "SELECT received_epoch FROM emails WHERE message_id='<otp@ex.com>'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        assert 'received_epoch' in cols  # column added
+        assert 'idx_emails_recv' in indexes  # index created after column
+        # Pre-existing row backfilled onto the epoch axis.
+        assert epoch == int(datetime.fromisoformat(self.NEW).timestamp())
+
+        # And the watermark filter now works on the upgraded DB.
+        emails, _ = get_new_emails_since(account_id, 0)
+        assert {e['message_id'] for e in emails} == {'<otp@ex.com>'}
+
 
 class TestSyncState:
     def test_round_trip(self, account_id, initialized_db):


### PR DESCRIPTION
## Summary

Email sync had been **dead for all accounts** on a customer deployment for ~6 days. The `init_email_db()` function threw on every account, every 5-minute tick, fetching zero mail — which silently starved the OTP-from-email login flow (an ad-audit task read a stale 6-day-old noon OTP, then couldn't get the re-sent code because it never synced, and fell back to asking the user).

## Root cause

`received_epoch` + its index landed in #69. `_SCHEMA_SQL` ran `CREATE INDEX ... ON emails(received_epoch)`, but on a DB created **before** that column existed, `CREATE TABLE IF NOT EXISTS` is a no-op (never adds the column). So the index statement threw:

```
sqlite3.OperationalError: no such column: received_epoch   (db.py, in conn.executescript)
```

...and `executescript` aborted **before** the `ALTER TABLE ... ADD COLUMN` migration a few lines below could add the column. The migration was dead code for exactly the DBs it was written for. Because `init_email_db()` is the first call in every account's sync (`email_sync.py → maybe_seed_sync_state → init_email_db`), the whole sync aborted for every account — background job **and** the on-demand `sync-now` path.

## Fix

Guarantee the column exists **before** anything references it:
- Removed the `received_epoch` index from `_SCHEMA_SQL`.
- After the schema script runs: probe `PRAGMA table_info`, `ALTER TABLE ADD COLUMN` when missing, then `CREATE INDEX IF NOT EXISTS` unconditionally (safe for both fresh and legacy DBs), then backfill.

## Tests

The existing "migration" test only nulled `received_epoch` on a DB that **already had** the column — it never exercised a table lacking it. Added `test_init_upgrades_db_missing_received_epoch_column`, which builds the true pre-`received_epoch` schema and asserts init adds the column + index, backfills, and the watermark filter works. It **reproduces the exact production error on the old code** and passes on the fix.

- `ruff check` / `ruff format` clean
- 19/19 `tests/unit/test_email_db.py` pass

## Deployment note

The affected deployment was **recovered in place** by adding the column + index + backfill to the 516 legacy DBs — the running server's sync resumed on the next tick with no restart. Other deployments on code ≥ #69 with pre-#69 DBs likely have the same latent breakage and should be migrated (this fix makes it self-healing on next boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)