### PR TITLE
feat(vision): AI product-image generation with user confirm gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,10 @@ jobs:
           MAX_AGENT_CONCURRENCY: 9
           AGENT_DEBUG: '1'
           VIBE_SELLER_TELEMETRY: '0'
+          # Vision e2e must be offline + deterministic: fake image
+          # generation. The vision test module skips itself unless the
+          # server reports fake mode.
+          VISION_FAKE: '1'
         run: |
           source .venv/bin/activate
           echo "=== Starting server via vibe-seller CLI ==="

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,7 @@ pytest --e2e tests/e2e        # E2E only (requires running server)
 - [docs/browser.md](docs/browser.md) — browser backends, Ziniao, WSL, CDP proxy
 - [docs/ziniao-concurrency.md](docs/ziniao-concurrency.md) — Ziniao WebDriver mechanism, multi-store concurrency, the "browsers kill each other" root cause + per-store-recovery fix
 - [docs/events.md](docs/events.md) — SSE event bus, event types, business events
+- [docs/vision.md](docs/vision.md) — AI product-image generation (kie.ai/Nano Banana): Settings→AI→Vision key, `vibe_seller_generate_image` MCP tool, the user confirm-gate flow, inline image display
 - [docs/windows-setup.md](docs/windows-setup.md) — Windows+WSL2 deployment: SSH bootstrap, WSL2 mirrored networking (MUST be Win 11 25H2/build 26200+ for external port access), `winchrome` native-Chrome backend, systemd service, Tailscale, auto-start, full troubleshooting cheatsheet
 - [docs/macos-setup.md](docs/macos-setup.md) — macOS deployment: `launchd` LaunchAgent for auto-start on login + crash-restart, the `EX_CONFIG`/TCC/PATH gotchas, deploy flow, troubleshooting cheatsheet
 - [docker/E2E_TESTING.md](docker/E2E_TESTING.md) — local E2E testing with Docker, iterative debugging

--- a/app/main.py
+++ b/app/main.py
@@ -61,6 +61,7 @@ from app.routers.tasks_schedule_state import (
 )
 from app.routers.telemetry import router as telemetry_router
 from app.routers.users import router as users_router
+from app.routers.vision import router as vision_router
 from app.routers.wecom_bots import router as wecom_bots_router
 from app.routers.workspace import router as workspace_router
 from app.routers.workspace_assistant import router as ws_assistant_router
@@ -300,6 +301,7 @@ app.include_router(dida365_oauth_router)
 app.include_router(ws_assistant_router)
 app.include_router(wecom_bots_router)
 app.include_router(system_router)
+app.include_router(vision_router)
 
 
 @app.get('/api/health')

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -40,14 +40,24 @@ _config: dict[str, str | None] = {
 }
 
 
-async def call_api(method: str, path: str, body: dict | None = None) -> dict:
-    """Call the vibe-seller API."""
+async def call_api(
+    method: str,
+    path: str,
+    body: dict | None = None,
+    timeout: float | None = 60,
+) -> dict:
+    """Call the vibe-seller API.
+
+    ``timeout`` defaults to 60s; image generation passes ``None`` (no
+    timeout) because that endpoint blocks awaiting a human confirmation
+    before it calls out to the image model.
+    """
     url = f'{_config["api_base"]}{path}'
     headers: dict[str, str] = {}
     cookies: dict[str, str] = {}
     if _config['auth_token']:
         cookies['auth_token'] = _config['auth_token']
-    async with httpx.AsyncClient(timeout=60) as client:
+    async with httpx.AsyncClient(timeout=timeout) as client:
         if method == 'GET':
             resp = await client.get(url, headers=headers, cookies=cookies)
         elif method == 'POST':
@@ -214,6 +224,22 @@ async def handle_tool_call(name: str, arguments: dict) -> str:
                 'POST',
                 f'/api/tasks/{_config["task_id"]}/result',
                 {'result': arguments['result']},
+            )
+        elif name == 'vibe_seller_generate_image':
+            # Blocks server-side awaiting the user's confirm/edit, then
+            # generates. NO timeout — like AskUserQuestion, it waits for
+            # the user however long they take.
+            result = await call_api(
+                'POST',
+                f'/api/tasks/{_config["task_id"]}/image/generate',
+                {
+                    'prompt': arguments['prompt'],
+                    'model': arguments.get('model'),
+                    'reference_images': arguments.get('reference_images', []),
+                    'output_name': arguments.get('output_name'),
+                    'kind': arguments.get('kind'),
+                },
+                timeout=None,
             )
         elif name == 'vibe_seller_list_skills':
             result = await call_api('GET', '/api/workspace/skills')

--- a/app/mcp_tool_schemas.py
+++ b/app/mcp_tool_schemas.py
@@ -550,26 +550,29 @@ TOOLS = [
     {
         'name': 'vibe_seller_generate_image',
         'description': (
-            'Generate a product image (Amazon main image, infographic, '
-            'lifestyle, or variant shot) from a text prompt plus optional '
-            'reference images, using the configured vision model '
-            '(kie.ai / Nano Banana). Use this whenever the user wants you '
-            'to CREATE or EDIT a product photo — e.g. "参考我的店铺作图风格, '
-            '这个1688链接产品, 生成一个主图及一个描述图". '
-            "IMPORTANT contract: (1) Write the `prompt` in the USER's "
-            'language (Chinese task → Chinese prompt). (2) NEVER describe '
-            "the product's material/texture/knit in words — pass the "
-            'supplier/1688 photo and the brand-style photo as '
-            '`reference_images` and instruct the model to replicate the '
-            'references faithfully; do not invent features not present in '
-            'them. (3) This call PAUSES for the user to review and edit '
-            'the prompt/model before anything is generated — that is '
-            'expected; wait for the result. (4) It fails immediately if '
-            'no vision key is configured — tell the user to set it in '
-            'Settings → AI → Vision. On success it returns the saved '
-            'workspace `path`; view it to self-audit against the '
-            'reference (colour, shape, texture, wording) and regenerate '
-            'with a corrected prompt if it differs.'
+            'Generate an image from a text prompt plus optional '
+            'reference images, using the configured vision model. '
+            'General-purpose: product photos, marketplace listing '
+            'images, infographics, banners, illustrations, or an image '
+            'the user just wants for fun — any platform, any purpose. '
+            'For platform-specific image work (e.g. Amazon listing '
+            'images), load the matching skill first if one exists; it '
+            "carries that platform's requirements and workflows. "
+            "Contract: (1) Write the `prompt` in the USER's language. "
+            '(2) When the image must depict a REAL product or person, '
+            'pass photos of it as `reference_images` and instruct the '
+            'model to replicate them faithfully — never describe its '
+            'appearance (material/texture/shape) in words, and state '
+            "each reference image's role by position in the prompt "
+            '("image 1 is the style reference; images 2-3 are the '
+            'product"). (3) This call PAUSES for the user to review and '
+            'edit the prompt/model before anything is generated — that '
+            'is expected; wait for the result. (4) It fails immediately '
+            'if no vision key is configured — tell the user to set it '
+            'in Settings → AI → Vision. On success it returns the saved '
+            'workspace `path`; view the file to self-audit against the '
+            'references and the requested text, and regenerate with a '
+            'corrected prompt if anything differs.'
         ),
         'inputSchema': {
             'type': 'object',
@@ -578,11 +581,11 @@ TOOLS = [
                     'type': 'string',
                     'description': (
                         "Image prompt in the user's language. Describe "
-                        'layout, background (pure white RGB 255 for a '
-                        'main image), any on-image text (infographic '
-                        'only, spelled exactly), and compliance — but '
-                        "NOT the product's material/texture (that comes "
-                        'from the reference images).'
+                        'composition, background, style, and any '
+                        'on-image text (spelled exactly). If reference '
+                        'images are passed, assign each a role by '
+                        'position and do NOT describe the referenced '
+                        "subject's appearance in words."
                     ),
                     'minLength': 1,
                 },
@@ -590,34 +593,35 @@ TOOLS = [
                     'type': 'array',
                     'items': {'type': 'string'},
                     'description': (
-                        'Reference image URLs (e.g. a 1688 product photo, '
-                        'an existing store listing image) and/or '
-                        "workspace-relative file paths. The product's "
-                        'true appearance is taken from these.'
+                        'Reference image URLs and/or workspace-relative '
+                        'file paths, in the order the prompt refers to '
+                        "them. Up to 14. The referenced subject's true "
+                        'appearance is taken from these.'
                     ),
                 },
                 'model': {
                     'type': 'string',
                     'enum': ['nano-banana-pro', 'nano-banana-2'],
                     'description': (
-                        'nano-banana-pro (default) for infographics and '
-                        'anything with on-image text; nano-banana-2 for '
-                        'cheaper/faster main and variant shots.'
+                        'nano-banana-pro (default): highest quality and '
+                        'reliable on-image text rendering. '
+                        'nano-banana-2: cheaper/faster, good for images '
+                        'without text.'
                     ),
                 },
                 'output_name': {
                     'type': 'string',
                     'description': (
-                        'Output file name, e.g. "main.png" or '
-                        '"infographic-1.png". Saved under the task '
-                        'workspace and shown inline.'
+                        'Output file name, e.g. "banner.png". Saved '
+                        'under the task workspace and shown inline to '
+                        'the user.'
                     ),
                 },
                 'kind': {
                     'type': 'string',
                     'description': (
-                        'Optional label: "main", "infographic", '
-                        '"lifestyle", "variant".'
+                        'Optional short label shown on the confirm card '
+                        '(e.g. "main", "infographic", "banner", "fun").'
                     ),
                 },
             },

--- a/app/mcp_tool_schemas.py
+++ b/app/mcp_tool_schemas.py
@@ -547,4 +547,81 @@ TOOLS = [
             'required': ['slug', 'skill_md'],
         },
     },
+    {
+        'name': 'vibe_seller_generate_image',
+        'description': (
+            'Generate a product image (Amazon main image, infographic, '
+            'lifestyle, or variant shot) from a text prompt plus optional '
+            'reference images, using the configured vision model '
+            '(kie.ai / Nano Banana). Use this whenever the user wants you '
+            'to CREATE or EDIT a product photo — e.g. "参考我的店铺作图风格, '
+            '这个1688链接产品, 生成一个主图及一个描述图". '
+            "IMPORTANT contract: (1) Write the `prompt` in the USER's "
+            'language (Chinese task → Chinese prompt). (2) NEVER describe '
+            "the product's material/texture/knit in words — pass the "
+            'supplier/1688 photo and the brand-style photo as '
+            '`reference_images` and instruct the model to replicate the '
+            'references faithfully; do not invent features not present in '
+            'them. (3) This call PAUSES for the user to review and edit '
+            'the prompt/model before anything is generated — that is '
+            'expected; wait for the result. (4) It fails immediately if '
+            'no vision key is configured — tell the user to set it in '
+            'Settings → AI → Vision. On success it returns the saved '
+            'workspace `path`; view it to self-audit against the '
+            'reference (colour, shape, texture, wording) and regenerate '
+            'with a corrected prompt if it differs.'
+        ),
+        'inputSchema': {
+            'type': 'object',
+            'properties': {
+                'prompt': {
+                    'type': 'string',
+                    'description': (
+                        "Image prompt in the user's language. Describe "
+                        'layout, background (pure white RGB 255 for a '
+                        'main image), any on-image text (infographic '
+                        'only, spelled exactly), and compliance — but '
+                        "NOT the product's material/texture (that comes "
+                        'from the reference images).'
+                    ),
+                    'minLength': 1,
+                },
+                'reference_images': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                    'description': (
+                        'Reference image URLs (e.g. a 1688 product photo, '
+                        'an existing store listing image) and/or '
+                        "workspace-relative file paths. The product's "
+                        'true appearance is taken from these.'
+                    ),
+                },
+                'model': {
+                    'type': 'string',
+                    'enum': ['nano-banana-pro', 'nano-banana-2'],
+                    'description': (
+                        'nano-banana-pro (default) for infographics and '
+                        'anything with on-image text; nano-banana-2 for '
+                        'cheaper/faster main and variant shots.'
+                    ),
+                },
+                'output_name': {
+                    'type': 'string',
+                    'description': (
+                        'Output file name, e.g. "main.png" or '
+                        '"infographic-1.png". Saved under the task '
+                        'workspace and shown inline.'
+                    ),
+                },
+                'kind': {
+                    'type': 'string',
+                    'description': (
+                        'Optional label: "main", "infographic", '
+                        '"lifestyle", "variant".'
+                    ),
+                },
+            },
+            'required': ['prompt'],
+        },
+    },
 ]

--- a/app/routers/tasks_files.py
+++ b/app/routers/tasks_files.py
@@ -6,10 +6,12 @@ import logging
 import mimetypes
 import os
 from pathlib import Path
+import re
 import tempfile
+import uuid
 import zipfile
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 from starlette.background import BackgroundTask
 
@@ -323,3 +325,61 @@ async def download_task_file(
         filename=resolved.name,
         media_type=mime or 'application/octet-stream',
     )
+
+
+_UPLOAD_ALLOWED_TYPES = {
+    'image/png',
+    'image/jpeg',
+    'image/gif',
+    'image/webp',
+    'application/pdf',
+}
+_UPLOAD_MAX_SIZE = 15 * 1024 * 1024  # 15MB
+
+
+@router.post('/{task_id}/files/upload')
+async def upload_task_file(
+    task_id: str,
+    file: UploadFile,
+    _user: User = Depends(get_current_user),
+):
+    """Save a user-supplied file into the task workspace ``uploads/``.
+
+    This is how chat attachments reach the AGENT: the file lands inside
+    the task workspace (the agent's cwd), and the returned ``abs_path``
+    is inserted into the user's message text, so the agent can Read it
+    directly (images included — the model reads them as vision input).
+    Unlike ``/api/attachments`` (DB-tracked blobs under the data dir,
+    invisible to the agent), this path is agent-first by design.
+    """
+    task_dir = _validate_task_id(task_id)
+    task_dir.mkdir(parents=True, exist_ok=True)
+    if file.content_type not in _UPLOAD_ALLOWED_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f'File type not allowed: {file.content_type}',
+        )
+    data = await file.read()
+    if not data:
+        raise HTTPException(status_code=400, detail='Empty file')
+    if len(data) > _UPLOAD_MAX_SIZE:
+        raise HTTPException(status_code=413, detail='File too large (max 15MB)')
+
+    raw = Path(file.filename or 'upload').name
+    stem = re.sub(r'[^A-Za-z0-9._-]', '_', Path(raw).stem) or 'upload'
+    ext = Path(raw).suffix.lower()
+    if ext not in ('.png', '.jpg', '.jpeg', '.gif', '.webp', '.pdf'):
+        ext = mimetypes.guess_extension(file.content_type or '') or '.bin'
+    out_dir = task_dir / 'uploads'
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f'{stem}{ext}'
+    if out_path.exists():
+        out_path = out_dir / f'{stem}-{uuid.uuid4().hex[:6]}{ext}'
+    out_path.write_bytes(data)
+
+    rel_path = f'uploads/{out_path.name}'
+    return {
+        'path': rel_path,
+        'abs_path': str(out_path),
+        'url': f'/api/tasks/{task_id}/files/{rel_path}',
+    }

--- a/app/routers/vision.py
+++ b/app/routers/vision.py
@@ -1,0 +1,347 @@
+"""Vision image-generation endpoints.
+
+Three routes:
+  - GET  /api/vision/config           — is a key set? (masked; any user)
+  - PUT  /api/vision/config           — set the kie.ai key (admin only)
+  - POST /api/tasks/{id}/image/generate — MCP-tool entry; the confirm gate
+  - POST /api/tasks/{id}/image/confirm  — user's approve/edit/cancel
+
+The generate route is the confirmation gate AND the generator. It fails
+immediately with 400 if no key is configured (so the agent's tool call
+errors out at once), otherwise it emits an ``image_request`` SSE event
+and blocks on a per-request future until the user confirms (with a
+possibly edited prompt/model) or cancels. Only on confirm does it call
+kie.ai, save the PNG into the task workspace, emit an ``image_generated``
+event, and return the saved path to the agent.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+from pathlib import Path
+import re
+import socket
+from urllib.parse import urlparse
+import uuid
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi.responses import Response
+import httpx
+
+from app import vision
+from app.auth import get_current_user
+from app.events.bus import event_bus
+from app.models.user import User
+from app.workspace.manager import VIBE_SELLER_DIR
+
+router = APIRouter(prefix='/api', tags=['vision'])
+
+logger = logging.getLogger(__name__)
+
+_TASKS_DIR = VIBE_SELLER_DIR / 'tasks'
+_GEN_SUBDIR = 'generated_images'
+_REF_SUBDIR = 'generated_images/refs'
+_MAX_UPLOAD = 15 * 1024 * 1024  # 15 MB
+
+
+def _safe_name(name: str) -> str:
+    """Sanitise an agent-supplied output filename to a .png basename."""
+    base = Path(name or '').name or 'image.png'
+    base = re.sub(r'[^A-Za-z0-9._-]', '_', base)
+    if not base.lower().endswith('.png'):
+        base = base + '.png'
+    return base
+
+
+# ─────────────────────────── config ───────────────────────────
+
+
+@router.get('/vision/config')
+async def get_vision_config(current_user: User = Depends(get_current_user)):
+    key = vision.get_kie_api_key()
+    return {
+        'kie_api_key_set': bool(key),
+        'kie_api_key_masked': vision.mask_key(key),
+        'models': list(vision.MODELS.keys()),
+        'default_model': vision.DEFAULT_MODEL,
+    }
+
+
+@router.put('/vision/config')
+async def put_vision_config(
+    body: dict,
+    current_user: User = Depends(get_current_user),
+):
+    if current_user.role != 'admin':
+        raise HTTPException(status_code=403, detail='Admin access required')
+    vision.save_vision_config(body.get('kie_api_key', ''))
+    key = vision.get_kie_api_key()
+    return {
+        'kie_api_key_set': bool(key),
+        'kie_api_key_masked': vision.mask_key(key),
+    }
+
+
+# ─────────────────────── generate (MCP) ───────────────────────
+
+
+@router.post('/tasks/{task_id}/image/generate')
+async def generate_task_image(
+    task_id: str,
+    body: dict,
+    current_user: User = Depends(get_current_user),
+):
+    """Confirm-gated image generation. Called by the MCP tool.
+
+    Fails at once if no kie.ai key is configured. Otherwise emits an
+    ``image_request`` event, waits for the user to confirm/edit/cancel,
+    then generates + saves the image and returns its workspace path.
+    """
+    if not vision.get_kie_api_key() and not vision.is_fake():
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                'kie.ai API key not configured. Ask the user to set it in '
+                'Settings → AI → Vision before generating images.'
+            ),
+        )
+
+    task_dir = (_TASKS_DIR / task_id).resolve()
+    if not task_dir.is_relative_to(_TASKS_DIR.resolve()):
+        raise HTTPException(status_code=400, detail='Invalid task id')
+
+    prompt = (body.get('prompt') or '').strip()
+    if not prompt:
+        raise HTTPException(status_code=400, detail='prompt is required')
+    model = body.get('model') or vision.DEFAULT_MODEL
+    if model not in vision.MODELS:
+        model = vision.DEFAULT_MODEL
+    reference_images = body.get('reference_images') or []
+    output_name = _safe_name(body.get('output_name') or 'image.png')
+    kind = body.get('kind') or ''  # optional label e.g. "main"/"infographic"
+
+    # Single-pending-per-task: a new request kills any older live card
+    # for this task (agent retry, task retry) so the UI never shows two
+    # actionable confirms at once.
+    superseded = vision.supersede_pending(task_id)
+    if superseded:
+        await event_bus.emit(
+            'image_request_expired',
+            {'task_id': task_id, 'request_id': superseded},
+        )
+
+    request_id = uuid.uuid4().hex
+    fut = vision.create_confirm(request_id, task_id)
+    await event_bus.emit(
+        'image_request',
+        {
+            'task_id': task_id,
+            'request_id': request_id,
+            'prompt': prompt,
+            'model': model,
+            'models': list(vision.MODELS.keys()),
+            'reference_images': reference_images,
+            'output_name': output_name,
+            'kind': kind,
+        },
+    )
+
+    # NO timeout — mirror AskUserQuestion: the tool call simply waits
+    # for the user, however long they take.
+    try:
+        decision = await fut
+    finally:
+        vision.discard_confirm(request_id, task_id)
+
+    if decision.get('action') == 'superseded':
+        return {
+            'status': 'superseded',
+            'message': (
+                'This request was replaced by a newer image request. '
+                'Do NOT retry it — the newer request is the live one.'
+            ),
+        }
+    if decision.get('action') != 'confirm':
+        return {
+            'status': 'cancelled',
+            'message': 'User cancelled this image generation.',
+        }
+
+    # User-edited values win over the agent's proposal.
+    final_prompt = (decision.get('prompt') or prompt).strip()
+    final_model = decision.get('model') or model
+    if final_model not in vision.MODELS:
+        final_model = model
+    # References the user added in the confirm card (uploaded files →
+    # workspace-relative paths, or pasted URLs) are appended.
+    added = [r for r in (decision.get('added_references') or []) if r]
+    final_refs = list(reference_images) + added
+
+    try:
+        png = await vision.generate_image(
+            prompt=final_prompt,
+            model=final_model,
+            reference_images=final_refs,
+            task_dir=task_dir,
+        )
+    except Exception as e:  # noqa: BLE001 — relay any kie.ai failure
+        logger.warning('Image generation failed for task %s: %s', task_id, e)
+        raise HTTPException(status_code=502, detail=f'Generation failed: {e}')
+
+    out_dir = task_dir / _GEN_SUBDIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / output_name
+    if out_path.exists():
+        stem = out_path.stem
+        out_path = out_dir / f'{stem}-{request_id[:6]}.png'
+    out_path.write_bytes(png)
+
+    rel_path = f'{_GEN_SUBDIR}/{out_path.name}'
+    file_url = f'/api/tasks/{task_id}/files/{rel_path}'
+    await event_bus.emit(
+        'image_generated',
+        {
+            'task_id': task_id,
+            'request_id': request_id,
+            'path': rel_path,
+            'url': file_url,
+            'prompt': final_prompt,
+            'model': final_model,
+            'kind': kind,
+        },
+    )
+    return {
+        'status': 'ok',
+        'path': rel_path,
+        'url': file_url,
+        'prompt': final_prompt,
+        'model': final_model,
+    }
+
+
+# ─────────────────────── confirm (user) ───────────────────────
+
+
+@router.post('/tasks/{task_id}/image/confirm')
+async def confirm_task_image(
+    task_id: str,
+    body: dict,
+    current_user: User = Depends(get_current_user),
+):
+    """Resolve a pending image request (confirm/edit/cancel)."""
+    request_id = body.get('request_id')
+    action = body.get('action')
+    if not request_id or action not in ('confirm', 'cancel'):
+        raise HTTPException(
+            status_code=400, detail='request_id and action required'
+        )
+    payload = {
+        'action': action,
+        'prompt': body.get('prompt'),
+        'model': body.get('model'),
+        'added_references': body.get('added_references') or [],
+    }
+    if not vision.resolve_confirm(request_id, payload):
+        raise HTTPException(
+            status_code=404,
+            detail='No pending image request (expired or already handled)',
+        )
+    return {'ok': True}
+
+
+# ─────────────────── upload a reference image ─────────────────
+
+
+@router.post('/tasks/{task_id}/image/upload-reference')
+async def upload_reference(
+    task_id: str,
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+):
+    """Save a user-supplied reference image into the task workspace.
+
+    Returns the workspace-relative ``path`` (to pass back on confirm as
+    an added reference) and the ``url`` that serves it for preview.
+    """
+    task_dir = (_TASKS_DIR / task_id).resolve()
+    if not task_dir.is_relative_to(_TASKS_DIR.resolve()):
+        raise HTTPException(status_code=400, detail='Invalid task id')
+    data = await file.read()
+    if not data:
+        raise HTTPException(status_code=400, detail='Empty file')
+    if len(data) > _MAX_UPLOAD:
+        raise HTTPException(status_code=413, detail='File too large (max 15MB)')
+
+    name = _safe_name(file.filename or 'ref.png')
+    # _safe_name forces .png; keep the real extension for non-png images.
+    orig_ext = Path(file.filename or '').suffix.lower()
+    if orig_ext in ('.jpg', '.jpeg', '.webp', '.gif'):
+        name = re.sub(r'\.png$', orig_ext, name)
+    out_dir = task_dir / _REF_SUBDIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / name
+    if out_path.exists():
+        out_path = (
+            out_dir / f'{out_path.stem}-{uuid.uuid4().hex[:6]}{out_path.suffix}'
+        )
+    out_path.write_bytes(data)
+
+    rel_path = f'{_REF_SUBDIR}/{out_path.name}'
+    return {
+        'path': rel_path,
+        'url': f'/api/tasks/{task_id}/files/{rel_path}',
+    }
+
+
+# ──────────── preview proxy for remote reference images ───────
+
+
+def _is_public_host(host: str) -> bool:
+    """Reject loopback/private/link-local hosts (basic SSRF guard)."""
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except OSError:
+        return False
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+        ):
+            return False
+    return True
+
+
+@router.get('/vision/ref-proxy')
+async def ref_proxy(url: str, current_user: User = Depends(get_current_user)):
+    """Fetch a remote reference image server-side for preview.
+
+    The confirm card can't always load supplier CDNs cross-origin (1688
+    images fail in the browser but fetch fine server-side). Proxying
+    makes previews render same-origin. Does not affect generation —
+    the model fetches originals itself.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ('http', 'https') or not parsed.hostname:
+        raise HTTPException(status_code=400, detail='Invalid url')
+    if not _is_public_host(parsed.hostname):
+        raise HTTPException(status_code=400, detail='Host not allowed')
+    try:
+        async with httpx.AsyncClient(timeout=20, follow_redirects=True) as c:
+            resp = await c.get(url, headers={'User-Agent': 'Mozilla/5.0'})
+    except httpx.HTTPError:
+        raise HTTPException(status_code=502, detail='Fetch failed')
+    ctype = resp.headers.get('content-type', '')
+    if resp.status_code != 200 or not ctype.startswith('image/'):
+        raise HTTPException(status_code=502, detail='Not an image')
+    if len(resp.content) > _MAX_UPLOAD:
+        raise HTTPException(status_code=413, detail='Image too large')
+    return Response(
+        content=resp.content,
+        media_type=ctype,
+        headers={'Cache-Control': 'private, max-age=300'},
+    )

--- a/app/routers/vision.py
+++ b/app/routers/vision.py
@@ -65,6 +65,9 @@ async def get_vision_config(current_user: User = Depends(get_current_user)):
         'kie_api_key_masked': vision.mask_key(key),
         'models': list(vision.MODELS.keys()),
         'default_model': vision.DEFAULT_MODEL,
+        # Surfaced so e2e tests can refuse to run against a server that
+        # would hit the real image API (they must be offline-only).
+        'fake': vision.is_fake(),
     }
 
 

--- a/app/skills_v2/MANIFEST.txt
+++ b/app/skills_v2/MANIFEST.txt
@@ -28,6 +28,7 @@ amazon-listing/scripts/bh_upload_flatfile.py
 amazon-listing/scripts/bh_fetch_report.py
 amazon-listing/scripts/bh_download_template.py
 amazon-listing/requirements.txt
+amazon-image-studio/SKILL.md
 amazon-invoice/SKILL.md
 amazon-invoice/generate_invoice.py
 amazon-invoice/requirements.txt

--- a/app/skills_v2/amazon-image-studio/SKILL.md
+++ b/app/skills_v2/amazon-image-studio/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: amazon-image-studio
+description: "Generate Amazon-ready product images (main image, 5-point-description infographics, lifestyle, colour-variant shots) from supplier photos (e.g. a 1688 link) plus the store's existing image style, using the vibe_seller_generate_image tool (kie.ai / Nano Banana). Load this whenever the task is to CREATE or EDIT product photos from a product link and/or the store's own style — e.g. 'match my store's image style; generate a main image and an infographic for this supplier link' (in any language). Covers: gathering reference images, writing generality-safe prompts in the user's language, the human confirm step, and the mandatory view-and-self-audit-against-the-reference loop."
+allowed-tools: Bash(browser-use:*)
+requires: [amazon-shared]
+---
+
+# Amazon Image Studio
+
+Turn supplier photos + your store's look into Amazon-compliant images.
+The generator is the `vibe_seller_generate_image` MCP tool. It **pauses
+for the user to review and edit your prompt/model before anything is
+generated** — that pause is expected; wait for the result. It **fails
+immediately if no vision key is configured** — if so, tell the user to
+set it in Settings → AI → Vision, then stop.
+
+## The one rule that makes this work for ANY product
+
+**The product's true appearance comes ONLY from the reference images,
+never from your words.** Do not describe the material, texture, knit,
+weave, colour, or shape in the prompt — pass the supplier photo and let
+the model replicate it. Your prompt describes only:
+
+- **layout / composition** (e.g. "worn on a model up top, a fan of the
+  colourways below" — mirror the store's existing main-image layout),
+- **background** (main image: pure white, RGB 255,255,255; product fills
+  ~85% of the frame; no text, logo, props, borders),
+- **on-image text** — infographics only, spelled EXACTLY, in the user's
+  language,
+- **compliance** (Amazon main-image rules above).
+
+The only negative constraint is generic: **"replicate the references
+faithfully; do not invent elements that aren't in them (text, logos,
+patterns, pockets, accessories)."** Never write product-specific
+negatives like "no ribbing" — that hardcodes one product and breaks the
+next. A ribbed sock, a smooth sock, a lantern, a cable: same prompt
+skeleton, the reference carries the truth.
+
+**Declare each image's ROLE by position — always.** Images reach the
+model in the exact order of `reference_images`, and Google's own prompt
+templates address them by position ("the dress from the first image…").
+Open the prompt by assigning roles, e.g. (in the user's language):
+"Image 1 is the layout/style reference — take only its composition,
+palette and typography, never its product. Images 2–5 are the product
+photos; the product's appearance comes solely from them."
+Without this the model guesses which image is fact and
+which is style, and a style image's product can bleed into yours. Note
+for the confirm popup: any image the user adds there is APPENDED after
+yours — if you expect the user to add a style reference, say in the
+prompt that "the last image (if present) is the style reference".
+
+## Write the prompt in the user's language
+
+Chinese task → Chinese prompt; English task → English prompt. The model
+handles both, and the user reviews the prompt in their own language in
+the confirm popup. Do not translate.
+
+## Workflow
+
+1. **Gather references.**
+   - Supplier photo(s): the 1688 (or other) product image URL(s). Pass
+     URLs directly — the tool accepts them.
+   - Store style: open a representative existing listing on the store
+     and grab its main image + one infographic (their layout, colour
+     palette, headline style, bottom feature-chip band). Pass these as
+     additional `reference_images` so the output matches the shop's look.
+   - **Verify every style reference is a REAL live product image before
+     using it.** Listings whose images were never uploaded show a
+     "No image available" placeholder, and lazy-loading pages serve tiny
+     GIF stand-ins (e.g. a 60×40 pixel image) until scrolled — passing
+     either poisons the generation. Judge what you actually fetched: is
+     it a full-resolution product photo? Never pass a placeholder
+     "just in case".
+   - **Style-reference search order — fully autonomous, never wait for
+     the user to supply images:**
+     1. A live-imaged listing of the SAME product type on this store.
+     2. Otherwise ANY live-imaged listing on this store, even another
+        category — brand style (white-background hero look, layout,
+        palette, chip band) carries across categories; you reference
+        its composition, never its product.
+     3. If the whole store has no live images at all, ASK the user once
+        (AskUserQuestion, in their language): would they like to provide
+        a style image — they can drag/upload it in the confirmation
+        popup's reference-image area — or proceed with supplier photos only? A
+        user-provided style reference gives a better result, but it is
+        OPTIONAL: if they decline or choose to proceed directly, continue
+        immediately with supplier photos alone. Never stall waiting for
+        an upload without having asked.
+2. **Main image** — call `vibe_seller_generate_image` with
+   `kind: "main"`, `model: "nano-banana-pro"` (or `nano-banana-2` for a
+   cheaper no-text shot), the supplier + style references, and a prompt
+   that only sets layout/background/compliance.
+3. **Infographic(s)** — for a 5-point description, generate one
+   infographic per theme (or one that lists the points). Use
+   `nano-banana-pro` (best in-image text). Put the store's infographic
+   as a style reference and spell every headline/label EXACTLY.
+4. **Self-audit — mandatory.** After each image is saved, VIEW it (read
+   the returned workspace `path`) and compare it against the ORIGINAL
+   supplier photo item by item: texture, colour, shape, cuff/opening,
+   proportions; for infographics, proofread every character. If anything
+   differs, regenerate with a prompt that names the specific fix (e.g.
+   "the toe seam should match the reference exactly") — keep the layout,
+   add the correction. Do not hand a wrong image to the user as final.
+
+## Model choice
+
+- `nano-banana-pro` — infographics and anything with on-image text
+  (industry-best multilingual text rendering); premium main images.
+- `nano-banana-2` — cheaper/faster main and colour-variant shots with no
+  text.
+
+## After generation
+
+The images are saved in the task workspace and shown inline to the user.
+To put them on a listing, hand off to the `amazon-listing` flow (Manage
+Images) — this skill only produces the images.

--- a/app/skills_v2/amazon-image-studio/SKILL.md
+++ b/app/skills_v2/amazon-image-studio/SKILL.md
@@ -1,116 +1,72 @@
 ---
 name: amazon-image-studio
-description: "Generate Amazon-ready product images (main image, 5-point-description infographics, lifestyle, colour-variant shots) from supplier photos (e.g. a 1688 link) plus the store's existing image style, using the vibe_seller_generate_image tool (kie.ai / Nano Banana). Load this whenever the task is to CREATE or EDIT product photos from a product link and/or the store's own style — e.g. 'match my store's image style; generate a main image and an infographic for this supplier link' (in any language). Covers: gathering reference images, writing generality-safe prompts in the user's language, the human confirm step, and the mandatory view-and-self-audit-against-the-reference loop."
+description: "Amazon listing-image knowledge for the general vibe_seller_generate_image tool: Amazon's image requirements (main/secondary), how to collect reference images from Amazon listings and supplier pages (e.g. 1688), and how to avoid poisoning generation with placeholder/blank images. Load this ONLY when the image work is FOR Amazon — creating or editing listing images (main image, gallery, infographic/A+), or when the user asks to match an Amazon listing's image style or meet Amazon requirements. Do NOT load it for generic image requests with no Amazon connection ('edit this picture', 'make me a fun image') — the vibe_seller_generate_image tool alone handles those."
 allowed-tools: Bash(browser-use:*)
 requires: [amazon-shared]
 ---
 
 # Amazon Image Studio
 
-Turn supplier photos + your store's look into Amazon-compliant images.
-The generator is the `vibe_seller_generate_image` MCP tool. It **pauses
-for the user to review and edit your prompt/model before anything is
-generated** — that pause is expected; wait for the result. It **fails
-immediately if no vision key is configured** — if so, tell the user to
-set it in Settings → AI → Vision, then stop.
+Amazon-specific knowledge for generating listing images with the
+general `vibe_seller_generate_image` tool. The tool itself documents
+the generic contract (user-language prompt, references carry a real
+subject's appearance, roles by position, the user-confirm pause) — this
+skill adds only what is Amazon:
 
-## The one rule that makes this work for ANY product
+## 1. Amazon image requirements
 
-**The product's true appearance comes ONLY from the reference images,
-never from your words.** Do not describe the material, texture, knit,
-weave, colour, or shape in the prompt — pass the supplier photo and let
-the model replicate it. Your prompt describes only:
+**MAIN image** (the one search results show — strictest):
+- Pure white background, exactly RGB (255,255,255) — off-white fails
+  Amazon's automated scan.
+- Product fills ~85% of the frame, fully visible, not cropped.
+- NO text, logos, badges, watermarks, borders, props, or accessories
+  not included in the purchase. Product only, as the buyer receives it.
+- ≥1000px on the longest side; ≥1600px recommended (enables zoom).
+  Square (1:1) displays best. JPEG/PNG.
+- Category variations exist (e.g. adult apparel is usually shown on a
+  model; shoes as a single shoe at an angle). When in doubt, mirror
+  what the store's own live listings of the same category do.
 
-- **layout / composition** (e.g. "worn on a model up top, a fan of the
-  colourways below" — mirror the store's existing main-image layout),
-- **background** (main image: pure white, RGB 255,255,255; product fills
-  ~85% of the frame; no text, logo, props, borders),
-- **on-image text** — infographics only, spelled EXACTLY, in the user's
-  language,
-- **compliance** (Amazon main-image rules above).
+**Secondary images** (gallery slots 2-7+): lifestyle shots,
+infographics with feature callouts, dimension/scale charts and
+comparison tables are all allowed and convert well. On-image text is
+fine HERE (never on the main image) — spell every word exactly in the
+prompt and proofread the result character by character.
 
-The only negative constraint is generic: **"replicate the references
-faithfully; do not invent elements that aren't in them (text, logos,
-patterns, pockets, accessories)."** Never write product-specific
-negatives like "no ribbing" — that hardcodes one product and breaks the
-next. A ribbed sock, a smooth sock, a lantern, a cable: same prompt
-skeleton, the reference carries the truth.
+## 2. Collecting reference images
 
-**Declare each image's ROLE by position — always.** Images reach the
-model in the exact order of `reference_images`, and Google's own prompt
-templates address them by position ("the dress from the first image…").
-Open the prompt by assigning roles, e.g. (in the user's language):
-"Image 1 is the layout/style reference — take only its composition,
-palette and typography, never its product. Images 2–5 are the product
-photos; the product's appearance comes solely from them."
-Without this the model guesses which image is fact and
-which is style, and a style image's product can bleed into yours. Note
-for the confirm popup: any image the user adds there is APPENDED after
-yours — if you expect the user to add a style reference, say in the
-prompt that "the last image (if present) is the style reference".
+- **Supplier page (e.g. 1688)**: extract the original gallery image
+  URLs from the page (full-size, not thumbnails) and pass them as
+  `reference_images` directly — the generator fetches URLs itself.
+- **Amazon listing** (style reference): open the listing's dp page and
+  take the hi-res image URLs (`m.media-amazon.com/images/I/…`, request
+  the large `_SL1600_` variant). These carry the store's composition,
+  palette and infographic layout.
+- **Never pass a blank/placeholder image.** Two traps produce them:
+  - listings whose images were never uploaded show a "No image
+    available" placeholder;
+  - lazy-loading pages serve tiny stand-in GIFs (e.g. 60×40px) until
+    the image scrolls into view.
+  Judge what you actually fetched — is it a full-resolution product
+  photo? A placeholder passed "just in case" poisons the generation.
+- **Style-reference search order** (autonomous, never stall):
+  1. a live-imaged listing of the same product type on this store;
+  2. otherwise ANY live-imaged listing on this store (brand style —
+     hero look, palette, chip band — carries across categories; you
+     reference its composition, never its product);
+  3. if the whole store has no live images, ask the user once
+     (AskUserQuestion): provide a style image (they can drag one into
+     the confirmation popup's reference area) or proceed with supplier
+     photos only — optional; proceed immediately if declined.
 
-## Write the prompt in the user's language
+## 3. Generate, audit, hand off
 
-Chinese task → Chinese prompt; English task → English prompt. The model
-handles both, and the user reviews the prompt in their own language in
-the confirm popup. Do not translate.
-
-## Workflow
-
-1. **Gather references.**
-   - Supplier photo(s): the 1688 (or other) product image URL(s). Pass
-     URLs directly — the tool accepts them.
-   - Store style: open a representative existing listing on the store
-     and grab its main image + one infographic (their layout, colour
-     palette, headline style, bottom feature-chip band). Pass these as
-     additional `reference_images` so the output matches the shop's look.
-   - **Verify every style reference is a REAL live product image before
-     using it.** Listings whose images were never uploaded show a
-     "No image available" placeholder, and lazy-loading pages serve tiny
-     GIF stand-ins (e.g. a 60×40 pixel image) until scrolled — passing
-     either poisons the generation. Judge what you actually fetched: is
-     it a full-resolution product photo? Never pass a placeholder
-     "just in case".
-   - **Style-reference search order — fully autonomous, never wait for
-     the user to supply images:**
-     1. A live-imaged listing of the SAME product type on this store.
-     2. Otherwise ANY live-imaged listing on this store, even another
-        category — brand style (white-background hero look, layout,
-        palette, chip band) carries across categories; you reference
-        its composition, never its product.
-     3. If the whole store has no live images at all, ASK the user once
-        (AskUserQuestion, in their language): would they like to provide
-        a style image — they can drag/upload it in the confirmation
-        popup's reference-image area — or proceed with supplier photos only? A
-        user-provided style reference gives a better result, but it is
-        OPTIONAL: if they decline or choose to proceed directly, continue
-        immediately with supplier photos alone. Never stall waiting for
-        an upload without having asked.
-2. **Main image** — call `vibe_seller_generate_image` with
-   `kind: "main"`, `model: "nano-banana-pro"` (or `nano-banana-2` for a
-   cheaper no-text shot), the supplier + style references, and a prompt
-   that only sets layout/background/compliance.
-3. **Infographic(s)** — for a 5-point description, generate one
-   infographic per theme (or one that lists the points). Use
-   `nano-banana-pro` (best in-image text). Put the store's infographic
-   as a style reference and spell every headline/label EXACTLY.
-4. **Self-audit — mandatory.** After each image is saved, VIEW it (read
-   the returned workspace `path`) and compare it against the ORIGINAL
-   supplier photo item by item: texture, colour, shape, cuff/opening,
-   proportions; for infographics, proofread every character. If anything
-   differs, regenerate with a prompt that names the specific fix (e.g.
-   "the toe seam should match the reference exactly") — keep the layout,
-   add the correction. Do not hand a wrong image to the user as final.
-
-## Model choice
-
-- `nano-banana-pro` — infographics and anything with on-image text
-  (industry-best multilingual text rendering); premium main images.
-- `nano-banana-2` — cheaper/faster main and colour-variant shots with no
+- One `vibe_seller_generate_image` call per image (`kind`: "main",
+  "infographic", …). Use `nano-banana-pro` for anything with on-image
   text.
-
-## After generation
-
-The images are saved in the task workspace and shown inline to the user.
-To put them on a listing, hand off to the `amazon-listing` flow (Manage
-Images) — this skill only produces the images.
+- After each image is saved, view the returned workspace `path` and
+  compare against the ORIGINAL supplier photo item by item (shape,
+  colour, texture, proportions; infographic wording). Regenerate with a
+  prompt naming the specific fix if anything differs.
+- Putting the images ON a listing is the `amazon-listing` flow (Manage
+  Images / flat file) — this skill only produces the files.

--- a/app/vision.py
+++ b/app/vision.py
@@ -1,0 +1,284 @@
+"""Vision image-generation config + kie.ai client + confirm registry.
+
+Three concerns live here, deliberately together because they are small
+and only ever used as a unit by ``app/routers/vision.py``:
+
+1. **Config** — the kie.ai API key. Stored in ``~/.vibe-seller/vision.json``
+   (mirrors ``profiles.json``: a secret, so NOT the DB), read back masked.
+2. **kie.ai client** — create a generation job, poll it, download the
+   result. A ``VISION_FAKE`` env switch short-circuits the network so
+   e2e/CI can exercise the whole confirm→save→display path for free and
+   deterministically.
+3. **Confirm registry** — an in-process ``request_id -> asyncio.Future``
+   map. The generate endpoint (called by the MCP tool) parks on the
+   future after emitting an ``image_request`` SSE event; the confirm
+   endpoint (called by the user's browser) resolves it with the possibly
+   edited prompt/model. Both endpoints run in the one backend process,
+   so a module-level dict is the whole mechanism.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+from pathlib import Path
+
+import httpx
+
+from app.config import VIBE_SELLER_DIR
+
+VISION_CONFIG_PATH = VIBE_SELLER_DIR / 'vision.json'
+
+# kie.ai endpoints (verified live 2026-07).
+_KIE_BASE = 'https://api.kie.ai'
+_KIE_UPLOAD_BASE = 'https://kieai.redpandaai.co'
+
+# Models we expose in the confirm dropdown. Keys are the values the
+# frontend/agent pass; values are the exact kie.ai model identifiers.
+# Kept small on purpose — a quality lane and a fast/cheap lane.
+MODELS: dict[str, str] = {
+    'nano-banana-pro': 'nano-banana-pro',
+    'nano-banana-2': 'nano-banana-2',
+}
+DEFAULT_MODEL = 'nano-banana-pro'
+
+
+# ─────────────────────────── config ───────────────────────────
+
+
+def load_vision_config() -> dict:
+    """Return the raw config dict (``{}`` if unset/unreadable)."""
+    try:
+        return json.loads(VISION_CONFIG_PATH.read_text(encoding='utf-8'))
+    except (OSError, ValueError):
+        return {}
+
+
+def save_vision_config(kie_api_key: str) -> None:
+    """Persist the kie.ai key (0600). Empty string clears it."""
+    cfg = load_vision_config()
+    cfg['kie_api_key'] = (kie_api_key or '').strip()
+    VISION_CONFIG_PATH.write_text(json.dumps(cfg, indent=2), encoding='utf-8')
+    try:
+        VISION_CONFIG_PATH.chmod(0o600)
+    except OSError:
+        pass
+
+
+def get_kie_api_key() -> str | None:
+    """The configured kie.ai key, or None. Env var wins (for CI)."""
+    env = os.environ.get('KIE_API_KEY', '').strip()
+    if env:
+        return env
+    key = (load_vision_config().get('kie_api_key') or '').strip()
+    return key or None
+
+
+def mask_key(key: str | None) -> str:
+    """Last-4 mask for display; never returns the full secret."""
+    if not key:
+        return ''
+    if len(key) <= 4:
+        return '••••'
+    return '••••' + key[-4:]
+
+
+def is_fake() -> bool:
+    """True when the network should be skipped (e2e/CI)."""
+    return os.environ.get('VISION_FAKE', '').lower() in ('1', 'true', 'yes')
+
+
+# ─────────────────────── confirm registry ─────────────────────
+#
+# Confirms NEVER time out — like AskUserQuestion, the tool call simply
+# waits for the user. The one invariant is single-pending-per-task: a
+# new request for the same task supersedes (resolves) the old one, so
+# the UI can never show two live cards for one task.
+
+_pending_confirms: dict[str, asyncio.Future] = {}
+_pending_by_task: dict[str, str] = {}  # task_id -> request_id
+
+
+def create_confirm(request_id: str, task_id: str) -> asyncio.Future:
+    """Register a pending confirmation and return its future.
+
+    Returns the request_id of a superseded prior request via
+    ``supersede_pending`` — call that first (it needs the event loop
+    running) if you want to notify the frontend.
+    """
+    fut: asyncio.Future = asyncio.get_event_loop().create_future()
+    _pending_confirms[request_id] = fut
+    _pending_by_task[task_id] = request_id
+    return fut
+
+
+def supersede_pending(task_id: str) -> str | None:
+    """Resolve any pending confirm for this task as superseded.
+
+    Returns the superseded request_id (for an expiry event) or None.
+    """
+    old_id = _pending_by_task.get(task_id)
+    if not old_id:
+        return None
+    fut = _pending_confirms.get(old_id)
+    if fut is not None and not fut.done():
+        fut.set_result({'action': 'superseded'})
+        return old_id
+    return None
+
+
+def resolve_confirm(request_id: str, payload: dict) -> bool:
+    """Resolve a pending confirmation. Returns False if unknown/done."""
+    fut = _pending_confirms.get(request_id)
+    if fut is None or fut.done():
+        return False
+    fut.set_result(payload)
+    return True
+
+
+def discard_confirm(request_id: str, task_id: str | None = None) -> None:
+    _pending_confirms.pop(request_id, None)
+    if task_id and _pending_by_task.get(task_id) == request_id:
+        _pending_by_task.pop(task_id, None)
+
+
+# ───────────────────────── kie.ai client ──────────────────────
+
+
+async def _upload_local_file(
+    client: httpx.AsyncClient, path: Path, api_key: str
+) -> str:
+    """Base64-upload a local image to kie.ai, return its temp URL."""
+    data = base64.b64encode(path.read_bytes()).decode('ascii')
+    ext = path.suffix.lstrip('.').lower() or 'png'
+    resp = await client.post(
+        f'{_KIE_UPLOAD_BASE}/api/file-base64-upload',
+        headers={'Authorization': f'Bearer {api_key}'},
+        json={
+            'base64Data': f'data:image/{ext};base64,{data}',
+            'uploadPath': 'images',
+            'fileName': path.name,
+        },
+    )
+    body = resp.json()
+    url = (body.get('data') or {}).get('downloadUrl') or (
+        body.get('data') or {}
+    ).get('url')
+    if not url:
+        raise RuntimeError(f'kie.ai upload failed: {body}')
+    return url
+
+
+async def _resolve_reference(
+    client: httpx.AsyncClient, ref: str, task_dir: Path, api_key: str
+) -> str | None:
+    """Turn a reference (URL or workspace path) into a kie.ai URL."""
+    if ref.startswith(('http://', 'https://')):
+        return ref
+    local = (task_dir / ref).resolve()
+    if not local.is_file() or not local.is_relative_to(task_dir.resolve()):
+        return None
+    return await _upload_local_file(client, local, api_key)
+
+
+async def generate_image(
+    *,
+    prompt: str,
+    model: str,
+    reference_images: list[str],
+    task_dir: Path,
+    aspect_ratio: str = '1:1',
+    resolution: str = '2K',
+) -> bytes:
+    """Generate one image via kie.ai and return the PNG bytes.
+
+    Raises RuntimeError on any kie.ai failure. Honours ``VISION_FAKE``.
+    """
+    if is_fake():
+        return _fake_png(prompt, model)
+
+    api_key = get_kie_api_key()
+    if not api_key:
+        raise RuntimeError('kie.ai API key not configured')
+    kie_model = MODELS.get(model, MODELS[DEFAULT_MODEL])
+
+    async with httpx.AsyncClient(timeout=120) as client:
+        image_input: list[str] = []
+        for ref in reference_images or []:
+            url = await _resolve_reference(client, ref, task_dir, api_key)
+            if url:
+                image_input.append(url)
+
+        create = await client.post(
+            f'{_KIE_BASE}/api/v1/jobs/createTask',
+            headers={'Authorization': f'Bearer {api_key}'},
+            json={
+                'model': kie_model,
+                'input': {
+                    'prompt': prompt,
+                    'image_input': image_input,
+                    'aspect_ratio': aspect_ratio,
+                    'resolution': resolution,
+                    'output_format': 'png',
+                },
+            },
+        )
+        cbody = create.json()
+        task_id = (cbody.get('data') or {}).get('taskId')
+        if not task_id:
+            raise RuntimeError(f'kie.ai createTask failed: {cbody}')
+
+        # Poll recordInfo until success/fail (Pro 2K ~ 60s).
+        result_url = None
+        for _ in range(60):
+            await asyncio.sleep(4)
+            info = await client.get(
+                f'{_KIE_BASE}/api/v1/jobs/recordInfo',
+                params={'taskId': task_id},
+                headers={'Authorization': f'Bearer {api_key}'},
+            )
+            data = info.json().get('data') or {}
+            state = data.get('state')
+            if state == 'success':
+                result_json = json.loads(data.get('resultJson') or '{}')
+                urls = result_json.get('resultUrls') or []
+                if urls:
+                    result_url = urls[0]
+                break
+            if state == 'fail':
+                raise RuntimeError(
+                    f'kie.ai generation failed: {data.get("failMsg")}'
+                )
+        if not result_url:
+            raise RuntimeError('kie.ai generation timed out')
+
+        img = await client.get(result_url)
+        return img.content
+
+
+def _fake_png(prompt: str, model: str) -> bytes:
+    """A deterministic placeholder PNG for VISION_FAKE mode.
+
+    Uses Pillow when present for a legible tile; otherwise a bundled
+    1x1 PNG so the display path still renders an ``<img>``.
+    """
+    try:
+        import io  # noqa: PLC0415 — lazy: Pillow is optional
+
+        from PIL import Image, ImageDraw  # noqa: PLC0415
+
+        img = Image.new('RGB', (512, 512), (240, 240, 245))
+        draw = ImageDraw.Draw(img)
+        draw.rectangle([8, 8, 503, 503], outline=(30, 41, 82), width=4)
+        draw.text((20, 20), f'FAKE\n{model}', fill=(30, 41, 82))
+        draw.text((20, 470), (prompt or '')[:60], fill=(90, 90, 100))
+        buf = io.BytesIO()
+        img.save(buf, format='PNG')
+        return buf.getvalue()
+    except Exception:
+        return base64.b64decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42m'
+            'NkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=='
+        )

--- a/docs/api.md
+++ b/docs/api.md
@@ -275,6 +275,18 @@ Note: SSE endpoint was renamed from `/api/events` to `/api/sse` to free up `/api
 | GET | `/api/ziniao-accounts/{id}/browsers` | List browser profiles (returns structured status JSON on error) |
 | POST | `/api/ziniao-accounts/{id}/restart` | Kill + relaunch Ziniao in WebDriver mode (Mac only, requires `running_normal` state) |
 
+## `vision.py` — Vision (AI image generation)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/vision/config` | kie.ai key status (masked), available models |
+| PUT | `/api/vision/config` | Set the kie.ai key (admin only) |
+| POST | `/api/tasks/{id}/image/generate` | MCP-tool entry; confirm-gated generation |
+| POST | `/api/tasks/{id}/image/confirm` | Resolve a pending image request (confirm/edit/cancel) |
+
+See [vision.md](vision.md) for the confirm-gate flow and SSE events
+(`image_request`, `image_generated`).
+
 ## `main.py` — App-level Endpoints
 
 | Method | Path | Description |

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,81 @@
+# Vision — AI product-image generation
+
+Generate Amazon-ready product images (main image, 5-point infographics,
+lifestyle, colour-variant shots) from supplier photos plus the store's
+own image style, using kie.ai (Nano Banana Pro / Nano Banana 2). The
+agent proposes; the **user confirms and can edit** the prompt/model
+before anything is generated; the result renders inline in the task
+stream and is saved in the task workspace.
+
+## Pieces
+
+| Concern | Where |
+|---|---|
+| Config + kie.ai client + confirm registry | `app/vision.py` |
+| HTTP endpoints | `app/routers/vision.py` |
+| MCP tool `vibe_seller_generate_image` | `app/mcp_tool_schemas.py` + `app/mcp_server.py` |
+| Settings UI | `frontend/src/components/settings/VisionPanel.tsx` (Settings → AI → Vision) |
+| Confirm card + inline image | `frontend/src/components/conversation/ImageRequestCard.tsx`, `GeneratedImageCard.tsx` |
+| Skill | `app/skills_v2/amazon-image-studio/SKILL.md` |
+
+## Config / secret
+
+The kie.ai key lives in `~/.vibe-seller/vision.json` (mode 0600) — a
+secret, so **not** the DB, mirroring `profiles.json`. It is read back
+masked (last-4). Admin-only to set. The `KIE_API_KEY` env var overrides
+the file (for CI). See `app/vision.py`.
+
+## Routes
+
+| Method | Path | Notes |
+|---|---|---|
+| GET | `/api/vision/config` | `{kie_api_key_set, kie_api_key_masked, models, default_model}` — never the raw key |
+| PUT | `/api/vision/config` | Set the key (admin only) |
+| POST | `/api/tasks/{id}/image/generate` | MCP-tool entry + confirm gate (see below) |
+| POST | `/api/tasks/{id}/image/confirm` | User's approve/edit/cancel |
+
+## Confirm-gate flow
+
+The confirmation is a **server-side block**, not a permission hook — so
+it works regardless of the agent's permission mode (auto/bypass or plan):
+
+1. The agent calls `vibe_seller_generate_image`. The MCP proxy forwards
+   it to `POST /api/tasks/{id}/image/generate` with a long httpx timeout.
+2. The endpoint **fails immediately with 400 if no key is configured**.
+3. Otherwise it registers a per-request `asyncio.Future`, emits an
+   `image_request` SSE event `{task_id, request_id, prompt, model,
+   models, reference_images, ...}`, and awaits the future.
+4. The frontend renders `ImageRequestCard` — an editable prompt textarea
+   + model dropdown + Confirm/Cancel — and on submit calls
+   `POST /api/tasks/{id}/image/confirm {request_id, action, prompt, model}`,
+   which resolves the future.
+5. On confirm the endpoint calls kie.ai (create → poll → download), saves
+   the PNG to `~/.vibe-seller/tasks/{id}/generated_images/<name>.png`,
+   emits `image_generated {task_id, request_id, path, url}`, and returns
+   the workspace path to the agent. On cancel it returns a `cancelled`
+   status and writes nothing.
+
+The user's edited prompt/model win over the agent's proposal. The saved
+image is served by the existing `GET /api/tasks/{id}/files/{path}`
+endpoint and shown inline via `GeneratedImageCard` (distinct from the
+finished-task file explorer).
+
+## Prompt-generality contract (baked into the tool + skill)
+
+The product's appearance comes **only from the reference images**, never
+from prompt words — so the same prompt skeleton works for any product
+(a ribbed sock, a smooth sock, a lantern). The prompt sets only layout,
+background, on-image text (infographics, spelled exactly, in the user's
+language), and compliance. The one negative constraint is generic: "do
+not invent elements not in the references." The agent writes the prompt
+in the user's language and self-audits each result against the original
+supplier photo, regenerating with a specific correction if it differs.
+
+## Testing / VISION_FAKE
+
+`VISION_FAKE=1` short-circuits the kie.ai network and returns a
+deterministic placeholder PNG, so the whole confirm→save→display path is
+exercised offline and for free. Used by the workflow tests
+(`tests/workflow/test_wf_vision_image.py`) and the Playwright e2e
+(`tests/e2e/test_vision_image_ui.py`). Unit tests:
+`tests/unit/test_vision.py`.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,11 +1,17 @@
-# Vision — AI product-image generation
+# Vision — AI image generation
 
-Generate Amazon-ready product images (main image, 5-point infographics,
-lifestyle, colour-variant shots) from supplier photos plus the store's
-own image style, using kie.ai (Nano Banana Pro / Nano Banana 2). The
-agent proposes; the **user confirms and can edit** the prompt/model
-before anything is generated; the result renders inline in the task
-stream and is saved in the task workspace.
+General-purpose image generation for tasks: product photos, marketplace
+listing images, infographics, banners, or an image the user just wants,
+via kie.ai (Nano Banana Pro / Nano Banana 2). The agent proposes; the
+**user confirms and can edit** the prompt/model before anything is
+generated; the result renders inline in the task stream and is saved in
+the task workspace.
+
+**Layering**: the MCP tool is platform-agnostic infrastructure. Platform
+knowledge lives in skills — `amazon-image-studio` (Amazon image
+requirements, gathering references from Amazon/1688, placeholder
+pitfalls) is the first; other marketplaces (noon, MercadoLibre, …) add
+their own skills on top of the same tool.
 
 ## Pieces
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -485,6 +485,19 @@ export default function App() {
   const toggleOtherInput = (questionText: string) => { setShowOtherInput(prev => { const show = !prev[questionText]; if (show) { setSelectedAnswers(p => { const n = { ...p }; delete n[questionText]; return n }) } else { setOtherInputs(p => ({ ...p, [questionText]: '' })); setSelectedAnswers(p => { const n = { ...p }; delete n[questionText]; return n }) } return { ...prev, [questionText]: show } }) }
   const setOtherAnswer = (questionText: string, text: string) => { setOtherInputs(prev => ({ ...prev, [questionText]: text })); if (text.trim()) { setSelectedAnswers(prev => ({ ...prev, [questionText]: text.trim() })) } else { setSelectedAnswers(prev => { const n = { ...prev }; delete n[questionText]; return n }) } }
   const submitAllAnswers = async (overrideAnswers?: Record<string, string>) => { if (!selectedTask || !pendingQuestions) return; const answers = overrideAnswers || selectedAnswers; await api.post(`/api/tasks/${selectedTask.id}/questions/answer`, { request_id: pendingQuestions.request_id, answers }); setPendingQuestions(null); setSelectedAnswers({}); setOtherInputs({}); setShowOtherInput({}) }
+  const submitImageDecision = async (requestId: string, action: 'confirm' | 'cancel', prompt: string, model: string, addedReferences: string[] = []) => {
+    if (!selectedTask) return
+    // Optimistically mark the card resolved so its controls disable at
+    // once; a confirm also gets the inline image via the image_generated
+    // SSE event.
+    setConversationItems(items => items.map(it =>
+      it.type === 'image_request' && it.imageRequest?.requestId === requestId
+        ? { ...it, imageRequest: { ...it.imageRequest!, resolved: true } }
+        : it))
+    try {
+      await api.post(`/api/tasks/${selectedTask.id}/image/confirm`, { request_id: requestId, action, prompt, model, added_references: addedReferences })
+    } catch { /* the tool call will time out server-side if unresolved */ }
+  }
   const sendingRef = useRef(false)
   const sendChatMessage = () =>
     sendChatMessageHandler({
@@ -641,7 +654,7 @@ export default function App() {
           openCreateModal={() => setShowCreateTask(true)} selectTask={selectTask}
           stopAgent={stopAgent} retryTask={retryTask} continueTask={continueTask} deleteTask={deleteTask}
           selectAnswer={selectAnswer} toggleOtherInput={toggleOtherInput}
-          setOtherAnswer={setOtherAnswer} submitAllAnswers={submitAllAnswers} sendChatMessage={sendChatMessage}
+          setOtherAnswer={setOtherAnswer} submitAllAnswers={submitAllAnswers} submitImageDecision={submitImageDecision} sendChatMessage={sendChatMessage}
           setSelectedTask={setSelectedTask} setTasks={setTasks} setCurrentUser={setCurrentUser}
           setEditingProfile={setEditingProfile} setShowProfileModal={setShowProfileModal}
           questionBannerRef={questionBannerRef}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -162,7 +162,7 @@ export function Sidebar(props: SidebarProps) {
           <div className="flex items-center gap-1">
             <LanguageSwitcher />
             {currentUser.role === 'admin' && (
-              <button onClick={() => { sendEvent(FrontendEvent.VIEW_CHANGED, { view: 'settings' }); setAppView('settings') }} className="p-1 text-gray-400 hover:text-gray-700" title={t('settings.title')}>
+              <button data-testid="nav-settings" onClick={() => { sendEvent(FrontendEvent.VIEW_CHANGED, { view: 'settings' }); setAppView('settings') }} className="p-1 text-gray-400 hover:text-gray-700" title={t('settings.title')}>
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
               </button>
             )}

--- a/frontend/src/components/conversation/ChatAttachButton.tsx
+++ b/frontend/src/components/conversation/ChatAttachButton.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from 'react-i18next'
+
+interface ChatAttachButtonProps {
+  fileInputRef: React.RefObject<HTMLInputElement | null>
+  uploading: boolean
+  disabled: boolean
+  onFiles: (files: FileList) => void
+}
+
+/** Paperclip button + hidden file input for chat attachments. */
+export function ChatAttachButton({
+  fileInputRef,
+  uploading,
+  disabled,
+  onFiles,
+}: ChatAttachButtonProps) {
+  const { t } = useTranslation()
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        data-testid="chat-file-input"
+        type="file"
+        accept="image/*,.pdf"
+        multiple
+        className="hidden"
+        onChange={e => {
+          if (e.target.files?.length) onFiles(e.target.files)
+          e.target.value = ''
+        }}
+      />
+      <button
+        data-testid="chat-attach-btn"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={disabled || uploading}
+        title={t('tasks.attachImage')}
+        className="px-2.5 py-2 text-gray-400 hover:text-indigo-600 border border-gray-300 rounded-lg disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+      >
+        {uploading ? (
+          <span className="block w-4 h-4 rounded-full border-2 border-indigo-500 border-t-transparent animate-spin" />
+        ) : (
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
+        )}
+      </button>
+    </>
+  )
+}

--- a/frontend/src/components/conversation/ConversationStream.tsx
+++ b/frontend/src/components/conversation/ConversationStream.tsx
@@ -10,6 +10,8 @@ import { ExecutionSeparator } from './ExecutionSeparator'
 import { ToolCallGroup } from './ToolCallCard'
 import { ThinkingBlock, WorkingIndicator } from './ThinkingBlock'
 import { QuestionBanner } from '../QuestionBanner'
+import { ImageRequestCard } from './ImageRequestCard'
+import { GeneratedImageCard } from './GeneratedImageCard'
 import { StepIcon } from '../ui'
 import type { ConversationItem, TodoItem, TaskStep, Task } from '../../types'
 
@@ -251,6 +253,13 @@ interface ConversationStreamProps {
   onSubmitAll: (overrideAnswers?: Record<string, string>) => void
   onConfirmPlan: () => void
   onRequestChanges?: () => void
+  onImageDecision?: (
+    requestId: string,
+    action: 'confirm' | 'cancel',
+    prompt: string,
+    model: string,
+    addedReferences: string[],
+  ) => void
   questionBannerRef: React.RefObject<HTMLDivElement | null>
   isActive: boolean
   userNearBottom?: React.RefObject<boolean>
@@ -272,6 +281,7 @@ export function ConversationStream({
   onSubmitAll,
   onConfirmPlan,
   onRequestChanges,
+  onImageDecision,
   questionBannerRef,
   isActive,
   userNearBottom,
@@ -398,6 +408,33 @@ export function ConversationStream({
               />
             )
           }
+          case 'image_request':
+            return (
+              <ImageRequestCard
+                key={item.id}
+                taskId={task.id}
+                requestId={item.imageRequest!.requestId}
+                prompt={item.imageRequest!.prompt}
+                model={item.imageRequest!.model}
+                models={item.imageRequest!.models}
+                referenceImages={item.imageRequest!.referenceImages}
+                kind={item.imageRequest!.kind}
+                resolved={item.imageRequest!.resolved}
+                expired={item.imageRequest!.expired}
+                onDecision={onImageDecision || (() => {})}
+              />
+            )
+          case 'generated_image':
+            return (
+              <GeneratedImageCard
+                key={item.id}
+                url={item.generatedImage!.url}
+                path={item.generatedImage!.path}
+                prompt={item.generatedImage!.prompt}
+                model={item.generatedImage!.model}
+                kind={item.generatedImage!.kind}
+              />
+            )
           default:
             return null
         }

--- a/frontend/src/components/conversation/GeneratedImageCard.tsx
+++ b/frontend/src/components/conversation/GeneratedImageCard.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next'
+
+interface GeneratedImageCardProps {
+  url: string
+  path: string
+  prompt?: string
+  model?: string
+  kind?: string
+}
+
+/** Inline display of an AI-generated image saved in the task workspace.
+ *  Distinct from the finished-task file explorer — the image renders
+ *  right where it was produced in the conversation. */
+export function GeneratedImageCard({
+  url,
+  path,
+  prompt,
+  model,
+  kind,
+}: GeneratedImageCardProps) {
+  const { t } = useTranslation()
+  return (
+    <div
+      data-testid="generated-image-card"
+      className="mb-4 bg-white rounded-2xl border border-gray-200 shadow-sm p-4"
+    >
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-sm font-semibold text-gray-700">
+          {t('vision.generatedTitle')}
+        </span>
+        {kind && (
+          <span className="px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded text-[10px] font-semibold uppercase tracking-wide">
+            {kind}
+          </span>
+        )}
+        {model && (
+          <span className="text-[11px] text-gray-400">{model}</span>
+        )}
+      </div>
+      <a href={url} target="_blank" rel="noreferrer" className="block">
+        <img
+          data-testid="generated-image"
+          src={url}
+          alt={prompt || path}
+          className="max-w-full rounded-lg border border-gray-100 shadow-sm"
+        />
+      </a>
+      <div className="mt-2 text-[11px] text-gray-400 break-all">{path}</div>
+    </div>
+  )
+}

--- a/frontend/src/components/conversation/ImageRequestCard.tsx
+++ b/frontend/src/components/conversation/ImageRequestCard.tsx
@@ -1,0 +1,220 @@
+import { useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface AddedRef { path: string; url: string }
+
+interface ImageRequestCardProps {
+  taskId: string
+  requestId: string
+  prompt: string
+  model: string
+  models: string[]
+  referenceImages: string[]
+  kind?: string
+  resolved?: boolean
+  expired?: boolean
+  onDecision: (
+    requestId: string,
+    action: 'confirm' | 'cancel',
+    prompt: string,
+    model: string,
+    addedReferences: string[],
+  ) => void
+}
+
+/** Preview URL for a reference: remote URLs go through the backend
+ *  proxy (supplier CDNs like 1688 fail to load cross-origin in the
+ *  browser); workspace paths are served by the task-files endpoint. */
+function previewUrl(taskId: string, ref: string): string {
+  if (ref.startsWith('http')) {
+    return `/api/vision/ref-proxy?url=${encodeURIComponent(ref)}`
+  }
+  return `/api/tasks/${taskId}/files/${ref}`
+}
+
+/** Inline confirm card: the agent proposed an image; the user reviews
+ *  and edits the prompt/model and can add their own reference image,
+ *  before anything is generated. */
+export function ImageRequestCard({
+  taskId,
+  requestId,
+  prompt,
+  model,
+  models,
+  referenceImages,
+  kind,
+  resolved,
+  expired,
+  onDecision,
+}: ImageRequestCardProps) {
+  const { t } = useTranslation()
+  const [editedPrompt, setEditedPrompt] = useState(prompt)
+  const [editedModel, setEditedModel] = useState(model)
+  const [added, setAdded] = useState<AddedRef[]>([])
+  const [busy, setBusy] = useState(false)
+  const [uploading, setUploading] = useState(false)
+  const [dragOver, setDragOver] = useState(false)
+  const fileInput = useRef<HTMLInputElement>(null)
+
+  const decide = (action: 'confirm' | 'cancel') => {
+    setBusy(true)
+    onDecision(
+      requestId, action, editedPrompt, editedModel,
+      added.map(a => a.path),
+    )
+  }
+
+  const uploadFiles = async (files: FileList | File[]) => {
+    setUploading(true)
+    try {
+      for (const f of Array.from(files)) {
+        if (!f.type.startsWith('image/')) continue
+        const fd = new FormData()
+        fd.append('file', f)
+        const resp = await fetch(
+          `/api/tasks/${taskId}/image/upload-reference`,
+          { method: 'POST', body: fd, credentials: 'include' },
+        )
+        if (resp.ok) {
+          const data = await resp.json()
+          setAdded(prev => [...prev, { path: data.path, url: data.url }])
+        }
+      }
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const modelOptions = models.length ? models : [model]
+  const thumbClass =
+    'h-28 w-28 object-contain rounded border border-gray-200 bg-white'
+
+  return (
+    <div
+      data-testid="image-request-card"
+      className="mb-4 rounded-xl border border-indigo-200 bg-gradient-to-b from-indigo-50 to-white overflow-hidden shadow-sm"
+    >
+      <div className="px-4 py-3 border-b border-indigo-100 flex items-center gap-2">
+        <span className="text-base font-semibold text-indigo-800">
+          {t('vision.confirmTitle')}
+        </span>
+        {kind && (
+          <span className="px-1.5 py-0.5 bg-indigo-200/80 text-indigo-800 rounded text-[10px] font-semibold uppercase tracking-wide">
+            {kind}
+          </span>
+        )}
+      </div>
+      <div className="px-4 py-4 space-y-4">
+        <div className="space-y-1">
+          <label className="text-sm font-medium text-gray-700">
+            {t('vision.promptLabel')}
+          </label>
+          <textarea
+            data-testid="image-prompt-input"
+            value={editedPrompt}
+            onChange={e => setEditedPrompt(e.target.value)}
+            disabled={resolved || busy}
+            className="w-full min-h-[160px] px-3 py-2 text-sm leading-relaxed border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent resize-y disabled:bg-gray-50 disabled:text-gray-400"
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-sm font-medium text-gray-700">
+            {t('vision.modelLabel')}
+          </label>
+          <select
+            data-testid="image-model-select"
+            value={editedModel}
+            onChange={e => setEditedModel(e.target.value)}
+            disabled={resolved || busy}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white disabled:bg-gray-50 disabled:text-gray-400"
+          >
+            {modelOptions.map(m => (
+              <option key={m} value={m}>{m}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-gray-700">
+            {t('vision.referencesLabel')} ({referenceImages.length + added.length})
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {referenceImages.map((ref, i) => (
+              <a
+                key={`r-${i}`}
+                href={ref.startsWith('http') ? ref : previewUrl(taskId, ref)}
+                target="_blank"
+                rel="noreferrer"
+                title={ref}
+              >
+                <img src={previewUrl(taskId, ref)} alt="" className={thumbClass} />
+              </a>
+            ))}
+            {added.map((a, i) => (
+              <a key={`a-${i}`} href={a.url} target="_blank" rel="noreferrer" title={a.path}>
+                <img src={a.url} alt="" className={`${thumbClass} ring-2 ring-indigo-300`} />
+              </a>
+            ))}
+          </div>
+
+          {!resolved && (
+            <div
+              data-testid="image-ref-dropzone"
+              onDragOver={e => { e.preventDefault(); setDragOver(true) }}
+              onDragLeave={() => setDragOver(false)}
+              onDrop={e => {
+                e.preventDefault(); setDragOver(false)
+                if (e.dataTransfer.files?.length) uploadFiles(e.dataTransfer.files)
+              }}
+              onClick={() => fileInput.current?.click()}
+              className={`mt-1 flex items-center justify-center gap-2 px-3 py-4 text-xs rounded-lg border-2 border-dashed cursor-pointer transition-colors ${
+                dragOver
+                  ? 'border-indigo-400 bg-indigo-50 text-indigo-700'
+                  : 'border-gray-300 text-gray-500 hover:border-indigo-300 hover:text-indigo-600'
+              }`}
+            >
+              <input
+                ref={fileInput}
+                data-testid="image-ref-file-input"
+                type="file"
+                accept="image/*"
+                multiple
+                className="hidden"
+                onChange={e => { if (e.target.files?.length) uploadFiles(e.target.files) }}
+              />
+              {uploading ? t('vision.uploading') : t('vision.dropHint')}
+            </div>
+          )}
+        </div>
+      </div>
+      {!resolved && (
+        <div className="px-4 py-3 bg-indigo-50/50 border-t border-indigo-100 flex items-center gap-2">
+          <button
+            data-testid="image-confirm-btn"
+            onClick={() => decide('confirm')}
+            disabled={busy || uploading || !editedPrompt.trim()}
+            className="px-5 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors shadow-sm"
+          >
+            {t('vision.confirmGenerate')}
+          </button>
+          <button
+            data-testid="image-cancel-btn"
+            onClick={() => decide('cancel')}
+            disabled={busy}
+            className="px-4 py-2 text-sm font-medium text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200 disabled:opacity-40 transition-colors"
+          >
+            {t('vision.cancel')}
+          </button>
+        </div>
+      )}
+      {resolved && (
+        <div
+          data-testid="image-card-footer"
+          className="px-4 py-2 bg-gray-50 border-t border-gray-100 text-xs text-gray-400"
+        >
+          {expired ? t('vision.expired') : t('vision.handled')}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/settings/VisionPanel.tsx
+++ b/frontend/src/components/settings/VisionPanel.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { api } from '../../api'
+
+interface VisionConfig {
+  kie_api_key_set: boolean
+  kie_api_key_masked: string
+  models?: string[]
+  default_model?: string
+}
+
+interface VisionPanelProps {
+  isAdmin: boolean
+}
+
+/** Settings → AI → Vision. Configure the kie.ai image-generation key.
+ *  Self-contained (own fetch/save), mirroring the other settings panels. */
+export function VisionPanel({ isAdmin }: VisionPanelProps) {
+  const { t } = useTranslation()
+  const [config, setConfig] = useState<VisionConfig | null>(null)
+  const [keyInput, setKeyInput] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+
+  const load = async () => {
+    try {
+      setConfig(await api.get('/api/vision/config'))
+    } catch { /* not configured / no access */ }
+  }
+  useEffect(() => { load() }, [])
+
+  const save = async () => {
+    setSaving(true)
+    setSaved(false)
+    try {
+      await api.put('/api/vision/config', { kie_api_key: keyInput.trim() })
+      setKeyInput('')
+      setSaved(true)
+      await load()
+    } catch { /* 403 for non-admins; leave UI unchanged */ } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      data-testid="vision-panel"
+      className="bg-white rounded-lg border border-gray-200 p-4"
+    >
+      <div className="flex items-center justify-between mb-1">
+        <h3 className="font-semibold text-sm">{t('settings.visionConfig')}</h3>
+        <span
+          data-testid="vision-key-status"
+          className={`px-2 py-1 text-xs rounded-full ${
+            config?.kie_api_key_set
+              ? 'bg-green-100 text-green-700'
+              : 'bg-gray-100 text-gray-500'
+          }`}
+        >
+          {config?.kie_api_key_set
+            ? `${t('settings.visionKeySet')} ${config.kie_api_key_masked}`
+            : t('settings.visionKeyMissing')}
+        </span>
+      </div>
+      <p className="text-xs text-gray-500 mb-3">{t('settings.visionHint')}</p>
+
+      {isAdmin ? (
+        <div className="flex gap-2">
+          <input
+            data-testid="vision-key-input"
+            type="password"
+            value={keyInput}
+            onChange={e => setKeyInput(e.target.value)}
+            placeholder={t('settings.visionKeyPlaceholder')}
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+          />
+          <button
+            data-testid="vision-key-save"
+            onClick={save}
+            disabled={saving || !keyInput.trim()}
+            className="px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700 disabled:opacity-40"
+          >
+            {t('common.save')}
+          </button>
+        </div>
+      ) : (
+        <p className="text-xs text-gray-400">{t('settings.visionAdminOnly')}</p>
+      )}
+      {saved && (
+        <p data-testid="vision-saved" className="text-xs text-green-600 mt-2">
+          {t('settings.visionSaved')}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useChatUploads.ts
+++ b/frontend/src/hooks/useChatUploads.ts
@@ -1,0 +1,47 @@
+import { useRef, useState } from 'react'
+import type { Task } from '../types'
+
+/** Chat attachments: upload files into the task workspace and insert
+ *  each returned absolute path into the message text, so the agent can
+ *  Read the file directly (images become vision input). Drag, paste
+ *  and click-upload in the send bar all land here. */
+export function useChatUploads(
+  selectedTask: Task | null,
+  chatInput: string,
+  setChatInput: (v: string) => void,
+  chatInputRef: React.RefObject<HTMLTextAreaElement | null>,
+  attachedLabel: string,
+) {
+  const chatFileInputRef = useRef<HTMLInputElement>(null)
+  const [chatUploading, setChatUploading] = useState(false)
+
+  const uploadChatFiles = async (files: FileList | File[]) => {
+    if (!selectedTask) return
+    setChatUploading(true)
+    try {
+      const paths: string[] = []
+      for (const f of Array.from(files)) {
+        const fd = new FormData()
+        fd.append('file', f)
+        const resp = await fetch(
+          `/api/tasks/${selectedTask.id}/files/upload`,
+          { method: 'POST', body: fd, credentials: 'include' },
+        )
+        if (resp.ok) {
+          const data = await resp.json()
+          paths.push(data.abs_path)
+        }
+      }
+      if (paths.length) {
+        const cur = chatInput.trim()
+        const insert = paths.map(p => `${attachedLabel}: ${p}`).join('\n')
+        setChatInput(cur ? `${cur}\n${insert}` : insert)
+        chatInputRef.current?.focus()
+      }
+    } finally {
+      setChatUploading(false)
+    }
+  }
+
+  return { chatFileInputRef, chatUploading, uploadChatFiles }
+}

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -362,6 +362,62 @@ export function useSSE({
             return prev
           })
         }
+        // Image generation: the agent's tool call is paused server-side
+        // waiting for the user to review/edit the prompt+model. Append a
+        // confirm card; when the generated image arrives, mark the card
+        // resolved and append the image inline.
+        if (data.type === 'image_request') {
+          if (selectedTaskIdRef.current === data.task_id) {
+            setConversationItems(items => [...items, {
+              id: `imgreq-${data.request_id}`,
+              type: 'image_request' as const,
+              timestamp: new Date().toISOString(),
+              imageRequest: {
+                requestId: data.request_id,
+                prompt: data.prompt || '',
+                model: data.model || 'nano-banana-pro',
+                models: data.models || [],
+                referenceImages: data.reference_images || [],
+                outputName: data.output_name,
+                kind: data.kind,
+                resolved: false,
+              },
+            }])
+          }
+        }
+        // A newer request superseded this card (single-pending-per-task
+        // invariant) — kill its controls so a late click can't 404.
+        if (data.type === 'image_request_expired') {
+          if (selectedTaskIdRef.current === data.task_id) {
+            setConversationItems(items => items.map(it =>
+              it.type === 'image_request' && it.imageRequest?.requestId === data.request_id
+                ? { ...it, imageRequest: { ...it.imageRequest!, resolved: true, expired: true } }
+                : it))
+          }
+        }
+        if (data.type === 'image_generated') {
+          if (selectedTaskIdRef.current === data.task_id) {
+            setConversationItems(items => {
+              const marked = items.map(it =>
+                it.type === 'image_request' && it.imageRequest?.requestId === data.request_id
+                  ? { ...it, imageRequest: { ...it.imageRequest!, resolved: true } }
+                  : it)
+              return [...marked, {
+                id: `imggen-${data.request_id}`,
+                type: 'generated_image' as const,
+                timestamp: new Date().toISOString(),
+                generatedImage: {
+                  requestId: data.request_id,
+                  path: data.path,
+                  url: data.url,
+                  prompt: data.prompt,
+                  model: data.model,
+                  kind: data.kind,
+                },
+              }]
+            })
+          }
+        }
         if (data.type === 'schedule_triggered') {
           loadSchedulesRef.current?.()
           loadScheduleTasksRef.current?.()

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -167,7 +167,12 @@
     "executePlan": "Execute Plan",
     "approvePlan": "Approve & Execute",
     "planReadyConfirm": "Plan is ready. Review above, then approve or edit.",
-    "collapsibleSectionKeywords": ["assumption", "issue", "potential", "note"],
+    "collapsibleSectionKeywords": [
+      "assumption",
+      "issue",
+      "potential",
+      "note"
+    ],
     "planTab": "Plan",
     "executeTab": "Execute",
     "planRevising": "Revising plan based on your feedback...",
@@ -190,7 +195,9 @@
     "planFeedbackHint": "Send feedback to revise the plan, or confirm to execute",
     "planFeedbackPlaceholder": "Suggest changes...",
     "wakeMessagePlaceholder": "Send a message to resume...",
-    "followupPlaceholder": "Send a follow-up message..."
+    "followupPlaceholder": "Send a follow-up message...",
+    "attachImage": "Attach image/file",
+    "attachedImage": "Image"
   },
   "events": {
     "title": "Events",
@@ -485,7 +492,14 @@
     "needProxy": "Use proxy",
     "proxyHint": "Route browser traffic through a proxy",
     "tab_stores": "Stores",
-    "tab_integrations": "Integrations"
+    "tab_integrations": "Integrations",
+    "visionConfig": "Vision (Image Generation)",
+    "visionHint": "kie.ai API key for AI product-image generation (Nano Banana). Required before the agent can generate main images or infographics.",
+    "visionKeySet": "Key set",
+    "visionKeyMissing": "Not configured",
+    "visionKeyPlaceholder": "kie.ai API key",
+    "visionAdminOnly": "Only an admin can set the Vision API key.",
+    "visionSaved": "Saved."
   },
   "integrations": {
     "gws": {
@@ -700,7 +714,6 @@
     "minuteSuffix": "m",
     "scheduleType": "Schedule Type",
     "description": "Description",
-    "editSchedule": "Edit Schedule",
     "editScheduleFor": "Edit Schedule for {{storeName}}",
     "mode": "Mode",
     "fanoutMode": "Fan out (one task per store)",
@@ -772,5 +785,18 @@
     "noReleaseNotes": "No release notes provided.",
     "viewFullChangelog": "View full changelog on GitHub",
     "remindLater": "Remind me later"
+  },
+  "vision": {
+    "confirmTitle": "Review image generation",
+    "promptLabel": "Prompt (edit before generating)",
+    "modelLabel": "Model",
+    "referencesLabel": "Reference images",
+    "confirmGenerate": "Generate",
+    "cancel": "Cancel",
+    "handled": "Handled.",
+    "generatedTitle": "Generated image",
+    "uploading": "Uploading…",
+    "dropHint": "Drag an image here or click to add a reference",
+    "expired": "Expired — replaced by a newer request below"
   }
 }

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -167,7 +167,14 @@
     "executePlan": "执行计划",
     "approvePlan": "确认执行",
     "planReadyConfirm": "计划已就绪，请审核后确认执行或编辑修改。",
-    "collapsibleSectionKeywords": ["假设", "风险", "问题", "潜在", "备注", "注意"],
+    "collapsibleSectionKeywords": [
+      "假设",
+      "风险",
+      "问题",
+      "潜在",
+      "备注",
+      "注意"
+    ],
     "planTab": "计划",
     "executeTab": "执行",
     "planRevising": "正在根据您的反馈修改计划...",
@@ -190,7 +197,9 @@
     "planFeedbackHint": "发送反馈修改计划，或确认执行",
     "planFeedbackPlaceholder": "建议修改...",
     "wakeMessagePlaceholder": "发送消息以恢复任务...",
-    "followupPlaceholder": "发送后续消息..."
+    "followupPlaceholder": "发送后续消息...",
+    "attachImage": "上传图片/文件",
+    "attachedImage": "图片"
   },
   "events": {
     "title": "事件",
@@ -485,7 +494,14 @@
     "needProxy": "使用代理",
     "proxyHint": "通过代理转发浏览器流量",
     "tab_stores": "店铺",
-    "tab_integrations": "集成"
+    "tab_integrations": "集成",
+    "visionConfig": "视觉（图片生成）",
+    "visionHint": "kie.ai API 密钥，用于 AI 商品图生成（Nano Banana）。配置后 agent 才能生成主图或信息图。",
+    "visionKeySet": "已配置",
+    "visionKeyMissing": "未配置",
+    "visionKeyPlaceholder": "kie.ai API 密钥",
+    "visionAdminOnly": "仅管理员可设置视觉 API 密钥。",
+    "visionSaved": "已保存。"
   },
   "integrations": {
     "gws": {
@@ -700,7 +716,6 @@
     "minuteSuffix": "分",
     "scheduleType": "执行频率",
     "description": "描述",
-    "editSchedule": "编辑定时任务",
     "editScheduleFor": "编辑 {{storeName}} 的定时任务",
     "mode": "执行模式",
     "fanoutMode": "分发（每个店铺一个任务）",
@@ -772,5 +787,18 @@
     "noReleaseNotes": "本次发布未提供说明。",
     "viewFullChangelog": "在 GitHub 查看完整更新日志",
     "remindLater": "稍后提醒"
+  },
+  "vision": {
+    "confirmTitle": "确认图片生成",
+    "promptLabel": "提示词（生成前可编辑）",
+    "modelLabel": "模型",
+    "referencesLabel": "参考图",
+    "confirmGenerate": "生成",
+    "cancel": "取消",
+    "handled": "已处理。",
+    "generatedTitle": "生成的图片",
+    "uploading": "上传中…",
+    "dropHint": "拖拽图片到此处，或点击上传参考图",
+    "expired": "已过期——已被下方更新的请求替代"
   }
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -125,6 +125,7 @@ export type ConversationItemType =
   | 'plan' | 'user_message' | 'agent_message'
   | 'streaming' | 'question' | 'execution_separator'
   | 'result' | 'tool_call' | 'thinking'
+  | 'image_request' | 'generated_image'
 
 export interface PlanVersion {
   version: number
@@ -142,6 +143,25 @@ export interface ConversationItem {
   result?: string
   toolCall?: { tool: string; input?: Record<string, unknown> }
   thinking?: { content: string; isStreaming: boolean }
+  imageRequest?: {
+    requestId: string
+    prompt: string
+    model: string
+    models: string[]
+    referenceImages: string[]
+    outputName?: string
+    kind?: string
+    resolved?: boolean
+    expired?: boolean
+  }
+  generatedImage?: {
+    requestId: string
+    path: string
+    url: string
+    prompt?: string
+    model?: string
+    kind?: string
+  }
 }
 
 export type AppView = 'tasks' | 'workspace' | 'settings'

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -6,6 +6,7 @@ import { GeneralPanel } from '../components/settings/GeneralPanel'
 import { StoresPanel } from '../components/settings/StoresPanel'
 import { EmailAccountsPanel } from '../components/settings/EmailAccountsPanel'
 import { IntegrationsPanel } from '../components/settings/IntegrationsPanel'
+import { VisionPanel } from '../components/settings/VisionPanel'
 import { ExternalConfigOverrideModal } from '../components/ExternalConfigOverrideModal'
 import {
   isExternalConfigOverrideDetail,
@@ -99,6 +100,7 @@ export function SettingsView({
         {tabs.map(tab => (
           <button
             key={tab}
+            data-testid={`settings-tab-${tab}`}
             onClick={() => setSettingsTab(tab)}
             className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors whitespace-nowrap flex-shrink-0 ${
               settingsTab === tab
@@ -243,6 +245,8 @@ export function SettingsView({
               <p className="text-sm text-gray-500 text-center py-4">{t('profiles.noProfiles')}</p>
             )}
           </div>
+
+          <VisionPanel isAdmin={currentUser?.role === 'admin'} />
         </div>
       ) : settingsTab === 'integrations' ? (
         <IntegrationsPanel />

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -6,6 +6,8 @@ import { FrontendEvent } from '../lib/telemetryEvents'
 import { formatScheduleBadge } from '../lib/scheduleBadge'
 import { StatusBadge } from '../components/ui'
 import { ConversationStream } from '../components/conversation/ConversationStream'
+import { useChatUploads } from '../hooks/useChatUploads'
+import { ChatAttachButton } from '../components/conversation/ChatAttachButton'
 import { ScheduleList } from '../components/ScheduleList'
 import { ScheduleDetailView } from '../components/ScheduleDetailView'
 import { EditScheduleModal } from '../components/EditScheduleModal'
@@ -60,6 +62,7 @@ interface TasksViewProps {
   toggleOtherInput: (questionText: string) => void
   setOtherAnswer: (questionText: string, text: string) => void
   submitAllAnswers: (overrideAnswers?: Record<string, string>) => void
+  submitImageDecision: (requestId: string, action: 'confirm' | 'cancel', prompt: string, model: string, addedReferences: string[]) => void
   sendChatMessage: () => void
   setSelectedTask: React.Dispatch<React.SetStateAction<Task | null>>
   setTasks: React.Dispatch<React.SetStateAction<Task[]>>
@@ -123,6 +126,7 @@ export function TasksView({
   toggleOtherInput,
   setOtherAnswer,
   submitAllAnswers,
+  submitImageDecision,
   sendChatMessage,
   setSelectedTask,
   setTasks,
@@ -179,6 +183,9 @@ export function TasksView({
     el.style.height = 'auto'
     el.style.height = `${Math.min(el.scrollHeight, 192)}px`
   }, [chatInput, selectedTask?.id])
+
+  const { chatFileInputRef, chatUploading, uploadChatFiles } = useChatUploads(
+    selectedTask, chatInput, setChatInput, chatInputRef, t('tasks.attachedImage'))
 
   // Phase helpers — driven by centralized UI config
   const taskCfg = selectedTask ? getUI(selectedTask.status) : null
@@ -567,6 +574,7 @@ export function TasksView({
                   onSetOtherAnswer={setOtherAnswer}
                   onSubmitAll={submitAllAnswers}
                   onConfirmPlan={handleConfirmPlan}
+                  onImageDecision={submitImageDecision}
                   onRequestChanges={() => {
                     const input = chatInputRef.current
                     if (input) { input.focus(); input.placeholder = t('tasks.planFeedbackPlaceholder') }
@@ -701,12 +709,30 @@ export function TasksView({
 
               {/* Unified send bar */}
               <div className="flex gap-2 items-end">
+                <ChatAttachButton
+                  fileInputRef={chatFileInputRef}
+                  uploading={chatUploading}
+                  disabled={!canSend && !isActive}
+                  onFiles={uploadChatFiles}
+                />
                 <textarea
                   ref={chatInputRef}
                   data-testid="chat-input"
                   rows={1}
                   value={chatInput}
                   onChange={e => setChatInput(e.target.value)}
+                  onDragOver={e => e.preventDefault()}
+                  onDrop={e => {
+                    e.preventDefault()
+                    if (e.dataTransfer.files?.length) uploadChatFiles(e.dataTransfer.files)
+                  }}
+                  onPaste={e => {
+                    const imgs = Array.from(e.clipboardData?.items || [])
+                      .filter(i => i.kind === 'file' && i.type.startsWith('image/'))
+                      .map(i => i.getAsFile())
+                      .filter((f): f is File => !!f)
+                    if (imgs.length) { e.preventDefault(); uploadChatFiles(imgs) }
+                  }}
                   onKeyDown={e => {
                     // Bail on IME composition keystrokes. Chinese /
                     // Japanese / Korean IMEs dispatch an Enter

--- a/tests/e2e/test_vision_image_ui.py
+++ b/tests/e2e/test_vision_image_ui.py
@@ -1,0 +1,150 @@
+"""E2E browser test for the Vision image-generation UI.
+
+Verifies the interactive path the user cares about:
+  - Settings → AI → Vision renders and saves a key
+  - when the image tool runs, a confirm card pops up with the prompt +
+    model; the user can edit the prompt and pick the model
+  - after Confirm, the generated image renders INLINE in the stream
+
+The agent's tool call is simulated by POSTing the same endpoint the MCP
+tool hits (``/api/tasks/{id}/image/generate``) from a background thread;
+that call blocks awaiting the user's confirmation, exactly as in
+production. The server must run with ``VISION_FAKE=1`` so generation is
+deterministic and offline.
+
+Run:
+  VISION_FAKE=1 MOCK_CLI=tests/e2e/mock_cli.py PORT=7799 \
+    VIBE_HOME=~/.vibe-seller-vision-e2e ./start.sh --dev
+  E2E_BASE_URL=http://127.0.0.1:7799 \
+    .venv/bin/python -m pytest --e2e tests/e2e/test_vision_image_ui.py
+"""
+
+import threading
+import time
+
+import httpx
+from playwright.sync_api import expect
+import pytest
+
+from tests.e2e.conftest import BASE_URL
+
+pytestmark = [pytest.mark.e2e]
+
+
+def _login_api() -> httpx.Client:
+    client = httpx.Client(timeout=30)
+    client.post(
+        f'{BASE_URL}/api/auth/login',
+        json={'identifier': 'admin@vibe-seller.local', 'password': 'admin'},
+    )
+    return client
+
+
+# Skip the whole module unless the server is up AND carries the new
+# vision route (so we fail loudly on a stale build, not silently).
+try:
+    _probe = _login_api()
+    _ok = _probe.get(f'{BASE_URL}/api/vision/config').status_code == 200
+    _probe.close()
+except Exception:
+    _ok = False
+if not _ok:
+    pytest.skip(
+        'server not up or vision route missing — start the dev server '
+        'with VISION_FAKE=1 first',
+        allow_module_level=True,
+    )
+
+
+def _create_task(client: httpx.Client, title: str) -> str:
+    r = client.post(f'{BASE_URL}/api/tasks', json={'title': title})
+    r.raise_for_status()
+    return r.json()['id']
+
+
+def _select_task(page, title: str):
+    page.reload()
+    page.wait_for_selector('h1', timeout=10000)
+    all_stores = page.locator('button', has_text='All Stores')
+    if all_stores.count() > 0:
+        all_stores.first.click()
+    task_btn = page.locator('button', has_text=title).first
+    task_btn.wait_for(timeout=10000)
+    task_btn.click()
+    page.locator('h2', has_text=title).wait_for(timeout=10000)
+
+
+def test_vision_settings_panel_saves_key(authenticated_page):
+    page = authenticated_page
+    page.reload()
+    page.wait_for_selector('h1', timeout=10000)
+    # Open Settings, then the AI tab (via stable testids, locale-agnostic).
+    page.locator('[data-testid="nav-settings"]').click()
+    page.locator('[data-testid="settings-tab-aiAgent"]').click()
+    panel = page.locator('[data-testid="vision-panel"]')
+    panel.wait_for(timeout=10000)
+    page.locator('[data-testid="vision-key-input"]').fill('sk-e2e-test-4242')
+    page.locator('[data-testid="vision-key-save"]').click()
+    status = page.locator('[data-testid="vision-key-status"]')
+    expect(status).to_contain_text('4242', timeout=10000)
+
+
+def test_confirm_card_edit_and_inline_image(authenticated_page):
+    page = authenticated_page
+    api = _login_api()
+    try:
+        title = f'Vision image e2e {int(time.time())}'
+        task_id = _create_task(api, title)
+        _select_task(page, title)
+
+        # Simulate the agent's MCP tool call — it blocks awaiting confirm.
+        result: dict = {}
+
+        def _fire():
+            c = _login_api()
+            try:
+                resp = c.post(
+                    f'{BASE_URL}/api/tasks/{task_id}/image/generate',
+                    json={
+                        'prompt': '主图：白色棉袜，纯白背景',
+                        'model': 'nano-banana-pro',
+                        'output_name': 'main.png',
+                        'kind': 'main',
+                    },
+                    timeout=120,
+                )
+                result['body'] = resp.json()
+            finally:
+                c.close()
+
+        t = threading.Thread(target=_fire, daemon=True)
+        t.start()
+
+        # The confirm card pops up with the proposed prompt.
+        card = page.locator('[data-testid="image-request-card"]')
+        card.wait_for(timeout=15000)
+        prompt_box = page.locator('[data-testid="image-prompt-input"]')
+        expect(prompt_box).to_have_value(
+            '主图：白色棉袜，纯白背景', timeout=5000
+        )
+
+        # User edits the prompt and switches the model.
+        prompt_box.fill('主图：白色棉袜，纯白背景，产品占85%')
+        page.locator('[data-testid="image-model-select"]').select_option(
+            'nano-banana-2'
+        )
+        page.locator('[data-testid="image-confirm-btn"]').click()
+
+        # The generated image renders inline.
+        img = page.locator('[data-testid="generated-image"]')
+        img.wait_for(timeout=20000)
+        src = img.get_attribute('src')
+        assert src and '/files/generated_images/' in src
+
+        t.join(timeout=20)
+        assert result.get('body', {}).get('status') == 'ok'
+        # The user's edits won.
+        assert result['body']['prompt'] == '主图：白色棉袜，纯白背景，产品占85%'
+        assert result['body']['model'] == 'nano-banana-2'
+    finally:
+        api.close()

--- a/tests/e2e/test_vision_image_ui.py
+++ b/tests/e2e/test_vision_image_ui.py
@@ -40,18 +40,24 @@ def _login_api() -> httpx.Client:
     return client
 
 
-# Skip the whole module unless the server is up AND carries the new
-# vision route (so we fail loudly on a stale build, not silently).
+# Skip the whole module unless the server is up, carries the vision
+# route, AND runs in VISION_FAKE mode. The fake-mode gate is the
+# contract, not a convenience: against a real server these tests would
+# (a) hit the real image API with a bogus key — the confirm flow then
+# never emits image_generated and times out (seen live on CI), and
+# (b) the settings test would overwrite a real user's configured key.
 try:
     _probe = _login_api()
-    _ok = _probe.get(f'{BASE_URL}/api/vision/config').status_code == 200
+    _resp = _probe.get(f'{BASE_URL}/api/vision/config')
+    _cfg = _resp.json() if _resp.status_code == 200 else {}
     _probe.close()
 except Exception:
-    _ok = False
-if not _ok:
+    _cfg = {}
+if not _cfg.get('fake'):
     pytest.skip(
-        'server not up or vision route missing — start the dev server '
-        'with VISION_FAKE=1 first',
+        'vision e2e requires a VISION_FAKE=1 server (offline, '
+        'deterministic, and safe to write test keys) — start it with '
+        'VISION_FAKE=1 ./start.sh',
         allow_module_level=True,
     )
 

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -1,0 +1,98 @@
+"""Unit tests for the vision image-gen config + confirm registry."""
+
+import pytest
+
+from app import vision
+
+pytestmark = pytest.mark.unit
+
+
+def test_save_load_mask(tmp_path, monkeypatch):
+    monkeypatch.setattr(vision, 'VISION_CONFIG_PATH', tmp_path / 'vision.json')
+    monkeypatch.delenv('KIE_API_KEY', raising=False)
+
+    assert vision.get_kie_api_key() is None
+    assert vision.mask_key(None) == ''
+
+    vision.save_vision_config('sk-abcdef1234')
+    assert vision.get_kie_api_key() == 'sk-abcdef1234'
+    masked = vision.mask_key(vision.get_kie_api_key())
+    assert masked.endswith('1234')
+    assert 'abcdef' not in masked  # never leaks the body
+
+    # Empty string clears it.
+    vision.save_vision_config('')
+    assert vision.get_kie_api_key() is None
+
+
+def test_env_key_wins(tmp_path, monkeypatch):
+    monkeypatch.setattr(vision, 'VISION_CONFIG_PATH', tmp_path / 'vision.json')
+    vision.save_vision_config('file-key')
+    monkeypatch.setenv('KIE_API_KEY', 'env-key')
+    assert vision.get_kie_api_key() == 'env-key'
+
+
+def test_is_fake(monkeypatch):
+    monkeypatch.setenv('VISION_FAKE', '1')
+    assert vision.is_fake() is True
+    monkeypatch.setenv('VISION_FAKE', '0')
+    assert vision.is_fake() is False
+    monkeypatch.delenv('VISION_FAKE', raising=False)
+    assert vision.is_fake() is False
+
+
+def test_models_registry():
+    assert vision.DEFAULT_MODEL in vision.MODELS
+    assert 'nano-banana-pro' in vision.MODELS
+    assert 'nano-banana-2' in vision.MODELS
+
+
+async def test_confirm_registry_resolve():
+    req = 'req-1'
+    fut = vision.create_confirm(req, 'task-1')
+    assert not fut.done()
+    ok = vision.resolve_confirm(req, {'action': 'confirm', 'prompt': 'p'})
+    assert ok is True
+    assert (await fut) == {'action': 'confirm', 'prompt': 'p'}
+    # Second resolve is a no-op (already done).
+    assert vision.resolve_confirm(req, {'action': 'cancel'}) is False
+    vision.discard_confirm(req, 'task-1')
+
+
+async def test_confirm_registry_unknown():
+    assert vision.resolve_confirm('nope', {'action': 'confirm'}) is False
+
+
+async def test_confirm_discard():
+    req = 'req-2'
+    vision.create_confirm(req, 'task-2')
+    vision.discard_confirm(req, 'task-2')
+    assert vision.resolve_confirm(req, {'action': 'confirm'}) is False
+
+
+async def test_supersede_pending():
+    """A new request for the same task resolves the old one as
+    superseded; other tasks are untouched."""
+    fut_a = vision.create_confirm('req-a', 'task-s')
+    fut_other = vision.create_confirm('req-o', 'task-other')
+
+    old = vision.supersede_pending('task-s')
+    assert old == 'req-a'
+    assert (await fut_a) == {'action': 'superseded'}
+    assert not fut_other.done()
+
+    # Nothing pending anymore for task-s after discard.
+    vision.discard_confirm('req-a', 'task-s')
+    assert vision.supersede_pending('task-s') is None
+    vision.discard_confirm('req-o', 'task-other')
+
+
+async def test_fake_png_is_png(monkeypatch):
+    monkeypatch.setenv('VISION_FAKE', '1')
+    data = await vision.generate_image(
+        prompt='test',
+        model='nano-banana-pro',
+        reference_images=[],
+        task_dir=None,  # unused in fake mode
+    )
+    assert data[:8] == b'\x89PNG\r\n\x1a\n'

--- a/tests/workflow/test_wf_vision_image.py
+++ b/tests/workflow/test_wf_vision_image.py
@@ -1,0 +1,297 @@
+"""Workflow tests for the confirm-gated image generation flow.
+
+Exercises the real API + event bus (kie.ai stubbed via VISION_FAKE):
+  - config PUT (admin) then GET returns masked, never the secret
+  - generate fails immediately (400) when no key is configured
+  - the full gate: generate emits image_request, blocks; confirm with an
+    edited prompt resolves it; the PNG is saved and image_generated fires
+  - cancel returns a cancelled status and writes nothing
+"""
+
+import asyncio
+import json
+import shutil
+import uuid
+
+import pytest
+
+from app import vision
+from app.events.bus import event_bus
+from app.workspace.manager import VIBE_SELLER_DIR
+
+pytestmark = pytest.mark.workflow
+
+_TASKS_DIR = VIBE_SELLER_DIR / 'tasks'
+
+
+async def _drain_until(queue, event_type, timeout=5.0):
+    """Return the first bus payload of ``event_type`` within timeout."""
+
+    async def _loop():
+        while True:
+            raw = await queue.get()
+            data = json.loads(raw)
+            if data.get('type') == event_type:
+                return data
+
+    return await asyncio.wait_for(_loop(), timeout)
+
+
+async def test_config_put_get_masked(admin_client, tmp_path, monkeypatch):
+    monkeypatch.setattr(vision, 'VISION_CONFIG_PATH', tmp_path / 'vision.json')
+    monkeypatch.delenv('KIE_API_KEY', raising=False)
+
+    r = await admin_client.put(
+        '/api/vision/config', json={'kie_api_key': 'sk-secret-9876'}
+    )
+    assert r.status_code == 200
+    assert r.json()['kie_api_key_set'] is True
+
+    g = await admin_client.get('/api/vision/config')
+    body = g.json()
+    assert body['kie_api_key_set'] is True
+    assert body['kie_api_key_masked'].endswith('9876')
+    assert 'secret' not in body['kie_api_key_masked']  # body never leaks
+    assert 'nano-banana-pro' in body['models']
+
+
+async def test_generate_fails_without_key(admin_client, monkeypatch):
+    monkeypatch.delenv('KIE_API_KEY', raising=False)
+    monkeypatch.delenv('VISION_FAKE', raising=False)
+    monkeypatch.setattr(vision, 'load_vision_config', lambda: {})
+
+    tid = str(uuid.uuid4())
+    r = await admin_client.post(
+        f'/api/tasks/{tid}/image/generate',
+        json={'prompt': 'a main image', 'model': 'nano-banana-pro'},
+    )
+    assert r.status_code == 400
+    assert 'not configured' in r.json()['detail']
+
+
+async def test_confirm_flow_saves_and_emits(admin_client, monkeypatch):
+    monkeypatch.setenv('VISION_FAKE', '1')  # no network
+    tid = str(uuid.uuid4())
+    task_dir = _TASKS_DIR / tid
+    queue = event_bus.subscribe()
+    try:
+        gen = asyncio.create_task(
+            admin_client.post(
+                f'/api/tasks/{tid}/image/generate',
+                json={
+                    'prompt': '主图：纯白背景',
+                    'model': 'nano-banana-pro',
+                    'output_name': 'main.png',
+                    'kind': 'main',
+                },
+            )
+        )
+        req = await _drain_until(queue, 'image_request')
+        assert req['task_id'] == tid
+        assert req['prompt'] == '主图：纯白背景'
+        request_id = req['request_id']
+
+        # User edits the prompt, then confirms.
+        c = await admin_client.post(
+            f'/api/tasks/{tid}/image/confirm',
+            json={
+                'request_id': request_id,
+                'action': 'confirm',
+                'prompt': '主图：纯白背景，产品占85%',
+                'model': 'nano-banana-pro',
+            },
+        )
+        assert c.json()['ok'] is True
+
+        gen_resp = await asyncio.wait_for(gen, timeout=10)
+        body = gen_resp.json()
+        assert body['status'] == 'ok'
+        assert body['prompt'] == '主图：纯白背景，产品占85%'  # edit won
+        assert body['path'] == 'generated_images/main.png'
+
+        saved = task_dir / 'generated_images' / 'main.png'
+        assert saved.is_file()
+        assert saved.read_bytes()[:8] == b'\x89PNG\r\n\x1a\n'
+
+        gen_evt = await _drain_until(queue, 'image_generated')
+        assert gen_evt['request_id'] == request_id
+        assert (
+            gen_evt['url']
+            == f'/api/tasks/{tid}/files/generated_images/main.png'
+        )
+    finally:
+        event_bus.unsubscribe(queue)
+        shutil.rmtree(task_dir, ignore_errors=True)
+
+
+async def test_upload_reference_saves_file(admin_client):
+    tid = str(uuid.uuid4())
+    task_dir = _TASKS_DIR / tid
+    try:
+        r = await admin_client.post(
+            f'/api/tasks/{tid}/image/upload-reference',
+            files={
+                'file': ('my ref.png', b'\x89PNG\r\n\x1a\nfake', 'image/png')
+            },
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body['path'].startswith('generated_images/refs/')
+        assert (task_dir / body['path']).is_file()
+        assert body['url'] == f'/api/tasks/{tid}/files/{body["path"]}'
+    finally:
+        shutil.rmtree(task_dir, ignore_errors=True)
+
+
+async def test_added_references_merged_into_generation(
+    admin_client, monkeypatch
+):
+    monkeypatch.setenv('VISION_FAKE', '1')
+    captured = {}
+
+    async def _fake_gen(*, prompt, model, reference_images, task_dir, **kw):
+        captured['refs'] = reference_images
+        return b'\x89PNG\r\n\x1a\nx'
+
+    monkeypatch.setattr(vision, 'generate_image', _fake_gen)
+
+    tid = str(uuid.uuid4())
+    task_dir = _TASKS_DIR / tid
+    queue = event_bus.subscribe()
+    try:
+        gen = asyncio.create_task(
+            admin_client.post(
+                f'/api/tasks/{tid}/image/generate',
+                json={
+                    'prompt': 'p',
+                    'model': 'nano-banana-pro',
+                    'reference_images': ['https://example.com/a.jpg'],
+                },
+            )
+        )
+        req = await _drain_until(queue, 'image_request')
+        await admin_client.post(
+            f'/api/tasks/{tid}/image/confirm',
+            json={
+                'request_id': req['request_id'],
+                'action': 'confirm',
+                'added_references': ['generated_images/refs/mine.png'],
+            },
+        )
+        await asyncio.wait_for(gen, timeout=10)
+        # Agent's reference plus the user-added one both reach generation.
+        assert captured['refs'] == [
+            'https://example.com/a.jpg',
+            'generated_images/refs/mine.png',
+        ]
+    finally:
+        event_bus.unsubscribe(queue)
+        shutil.rmtree(task_dir, ignore_errors=True)
+
+
+async def test_new_request_supersedes_pending(admin_client, monkeypatch):
+    """Single-pending-per-task: a second generate for the same task
+    resolves the first as 'superseded' and emits image_request_expired
+    for the old card. Confirms never time out otherwise."""
+    monkeypatch.setenv('VISION_FAKE', '1')
+    tid = str(uuid.uuid4())
+    task_dir = _TASKS_DIR / tid
+    queue = event_bus.subscribe()
+    try:
+        gen1 = asyncio.create_task(
+            admin_client.post(
+                f'/api/tasks/{tid}/image/generate',
+                json={'prompt': 'first', 'model': 'nano-banana-pro'},
+            )
+        )
+        req1 = await _drain_until(queue, 'image_request')
+
+        gen2 = asyncio.create_task(
+            admin_client.post(
+                f'/api/tasks/{tid}/image/generate',
+                json={'prompt': 'second', 'model': 'nano-banana-pro'},
+            )
+        )
+        expired = await _drain_until(queue, 'image_request_expired')
+        assert expired['request_id'] == req1['request_id']
+
+        body1 = (await asyncio.wait_for(gen1, timeout=10)).json()
+        assert body1['status'] == 'superseded'
+
+        req2 = await _drain_until(queue, 'image_request')
+        assert req2['prompt'] == 'second'
+        await admin_client.post(
+            f'/api/tasks/{tid}/image/confirm',
+            json={'request_id': req2['request_id'], 'action': 'confirm'},
+        )
+        body2 = (await asyncio.wait_for(gen2, timeout=10)).json()
+        assert body2['status'] == 'ok'
+    finally:
+        event_bus.unsubscribe(queue)
+        shutil.rmtree(task_dir, ignore_errors=True)
+
+
+async def test_chat_upload_returns_abs_path(admin_client):
+    """Chat attachments land in the workspace and return an abs path
+    (inserted into the message so the agent can Read the image)."""
+    tid = str(uuid.uuid4())
+    task_dir = _TASKS_DIR / tid
+    try:
+        r = await admin_client.post(
+            f'/api/tasks/{tid}/files/upload',
+            files={'file': ('样图 1.png', b'\x89PNG\r\n\x1a\nx', 'image/png')},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body['path'].startswith('uploads/')
+        abs_path = body['abs_path']
+        assert abs_path.startswith(str(task_dir))
+        assert (task_dir / body['path']).read_bytes().startswith(b'\x89PNG')
+        # Unsupported type fails fast.
+        r2 = await admin_client.post(
+            f'/api/tasks/{tid}/files/upload',
+            files={'file': ('x.sh', b'#!/bin/sh', 'text/x-sh')},
+        )
+        assert r2.status_code == 400
+    finally:
+        shutil.rmtree(task_dir, ignore_errors=True)
+
+
+async def test_ref_proxy_rejects_bad_and_private_urls(admin_client):
+    # Non-http scheme is rejected.
+    r = await admin_client.get(
+        '/api/vision/ref-proxy', params={'url': 'ftp://x/y'}
+    )
+    assert r.status_code == 400
+    # SSRF guard: loopback/private hosts are rejected.
+    for host in ('127.0.0.1', 'localhost', '10.0.0.5', '169.254.1.1'):
+        rp = await admin_client.get(
+            '/api/vision/ref-proxy',
+            params={'url': f'http://{host}/x.png'},
+        )
+        assert rp.status_code == 400, host
+
+
+async def test_cancel_flow_writes_nothing(admin_client, monkeypatch):
+    monkeypatch.setenv('VISION_FAKE', '1')
+    tid = str(uuid.uuid4())
+    task_dir = _TASKS_DIR / tid
+    queue = event_bus.subscribe()
+    try:
+        gen = asyncio.create_task(
+            admin_client.post(
+                f'/api/tasks/{tid}/image/generate',
+                json={'prompt': 'x', 'model': 'nano-banana-pro'},
+            )
+        )
+        req = await _drain_until(queue, 'image_request')
+        await admin_client.post(
+            f'/api/tasks/{tid}/image/confirm',
+            json={'request_id': req['request_id'], 'action': 'cancel'},
+        )
+        body = (await asyncio.wait_for(gen, timeout=10)).json()
+        assert body['status'] == 'cancelled'
+        assert not (task_dir / 'generated_images').exists()
+    finally:
+        event_bus.unsubscribe(queue)
+        shutil.rmtree(task_dir, ignore_errors=True)


### PR DESCRIPTION
## What

**General-purpose AI image generation for tasks**, with a human confirm gate. The agent can generate any image — product photos, marketplace listing images (any platform), infographics, banners, or something the user just wants for fun — via kie.ai (Nano Banana Pro / Nano Banana 2). Before every generation the user reviews and can **edit the prompt, switch the model, and add reference images** in an inline card; the result renders inline in the conversation stream and is saved in the task workspace.

**Layering** (platform knowledge does not live in infrastructure):
- `vibe_seller_generate_image` MCP tool — platform-agnostic. Generic contracts only: prompt in the user's language; a real subject's appearance comes from `reference_images`, never from prompt words; reference roles declared by position; pauses for user confirm; fails fast if no key.
- `amazon-image-studio` skill (amazon family, requires amazon-shared) — the Amazon layer: main-image compliance rules, gathering references from Amazon listings / 1688 supplier pages, live-image verification (placeholder/no-image pitfalls), style-reference search order, then calls the general tool. Other marketplaces (noon, MercadoLibre, …) add their own skills on top of the same tool.

## Design

**Confirm gate = server-side block, not a permission hook.** The MCP tool forwards to `POST /api/tasks/{id}/image/generate`, which registers a per-request future, emits an `image_request` SSE event, and awaits the user's decision with **no timeout** — the same semantics as AskUserQuestion (just wait). Works in every permission mode (auto/bypass included).

- **Fail fast**: 400 immediately if no vision key is configured (Settings → AI → Vision).
- **Single-pending-per-task invariant**: a new request supersedes any older pending one — the old tool call returns `superseded` and the frontend greys the old card via `image_request_expired`. A timeout-based first design produced two identical live cards and a dead click; this invariant makes that state unrepresentable.
- **User edits win**: the confirm payload's prompt/model (and any references dragged into the card) override/extend the agent's proposal server-side.
- **Secret handling**: key in `~/.vibe-seller/vision.json` (0600), never the DB; GET returns a last-4 mask; `KIE_API_KEY` env override for CI; admin-only write.
- **Reference previews**: supplier-CDN images often fail cross-origin in the browser while fetching fine server-side — `/api/vision/ref-proxy` (SSRF-guarded) renders them same-origin. Display-only.
- **Chat attachments the agent can actually see**: `POST /api/tasks/{id}/files/upload` saves into the task workspace and the send bar inserts the returned **absolute path** into the message text, so the agent Reads the file directly (images become vision input). Paths are built with `pathlib` under the runtime home — portable to native-Windows installs.

## Tests

- 9 unit (config masking, env override, fake mode, confirm registry incl. supersede)
- 9 workflow (real API + event bus with `VISION_FAKE=1`: masked config, fail-without-key, full confirm flow with edited prompt, cancel writes nothing, supersede race, card-added reference merge, chat upload abs-path contract, ref-proxy SSRF rejections)
- Playwright e2e (settings save; confirm card on a live blocked tool call → prompt edit + model switch → inline image). **Offline-only by contract**: `/api/vision/config` reports fake mode and the module skips itself unless the server runs `VISION_FAKE=1` (CI server now sets it) — running against a real server would hit the real image API and could overwrite a configured key.

## Verified live

Full end-to-end on a real store: agent gathered supplier images, found a live-imaged listing for style, declared image roles by position, the confirm card popped with editable prompt/model + reference previews, and both a main image and an infographic were generated, displayed inline, and saved in the task workspace.

## Known follow-ups

- Pre-existing `/api/attachments` (task-creation modal) stores files outside the agent's view — migrate onto the workspace-upload path.
- CN-domestic model lane (e.g. Volcano/Seedream) as a second backend behind the same confirm flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9p1mvGVPimwVG3WcQ7P26