### PR TITLE
fix(agent-reliability): turn holds for running subagents; verdicts must be reviewer-authored; verified store tick; single-persist follow-ups

### DIFF
--- a/app/ai/bash_safety.py
+++ b/app/ai/bash_safety.py
@@ -484,10 +484,14 @@ def _is_server_reviewed(audit_text: str) -> bool:
     return False
 
 
-def check_review_status(task_dir, subagent_ran=None) -> str | None:
+def check_review_status(
+    task_dir, subagent_ran=None, review_writers=None
+) -> str | None:
     """Deny reason if the DoD reviewer hasn't returned ``ok`` (or
     ``incomplete`` at iter ≥ 5); else ``None``. Fires for ads skills AND
     any skill declaring a ``review:`` block; no-op otherwise.
+    ``review_writers`` — per-file authorship map from the stream (see
+    ``report_reviewer.reviewer_verdict``).
     """
     if task_dir is None:
         return None
@@ -516,7 +520,9 @@ def check_review_status(task_dir, subagent_ran=None) -> str | None:
             # decides whether the task needed one (real deliverable →
             # gaps) or had nothing to verify (quick lookup → signs off
             # fast).
-            return report_reviewer.reviewer_verdict(task_dir, subagent_ran)
+            return report_reviewer.reviewer_verdict(
+                task_dir, subagent_ran, review_writers
+            )
         return None  # Nothing bound that requires review.
 
     # This path also gates the ENDING-TURN bypass (streaming result
@@ -547,7 +553,9 @@ def check_review_status(task_dir, subagent_ran=None) -> str | None:
         )
 
     # Reviewer sign-off — shared with the set_task_result path.
-    return report_reviewer.reviewer_verdict(task_dir, subagent_ran)
+    return report_reviewer.reviewer_verdict(
+        task_dir, subagent_ran, review_writers
+    )
 
 
 # ── Ad-tuning execution-review guard ───────────────────────────────
@@ -566,12 +574,15 @@ _EXEC_REVIEW_FILE_GLOB = 'EXEC_REVIEW_*_iter*.md'
 _EXEC_REVIEW_MAX_ITERS = 5
 
 
-def check_exec_review_status(task_dir) -> str | None:
+def check_exec_review_status(task_dir, review_writers=None) -> str | None:
     """Return a deny reason if the ads-execution reviewer hasn't
     returned ``ok`` (or ``incomplete`` at iter ≥ 5); otherwise None.
 
     Quiet no-op when ``EXECUTION_LOG.md`` is absent — the task is
-    not in execution mode.
+    not in execution mode. ``review_writers`` — per-file authorship
+    from the stream; an accepting verdict counts only when the
+    reviewer subagent itself wrote the file (same rule as the report
+    gate, see ``report_reviewer.reviewer_verdict``).
     """
     if task_dir is None:
         return None
@@ -649,6 +660,24 @@ def check_exec_review_status(task_dir) -> str | None:
             )
     except OSError:
         pass
+    # Authorship: an accepting exec verdict must have been WRITTEN by
+    # the reviewer subagent this turn — the same launch-and-stop /
+    # self-certification bypass as the report gate. Fail-closed when
+    # the stream signal is available (bounded by the redrive budget).
+    if (
+        review_writers is not None
+        and status in ('ok', 'incomplete')
+        and review_writers.get(latest.name) != 'subagent'
+    ):
+        return (
+            f'{latest.name} says Status: {status}, but it was not '
+            'written by the ``ads-execution-review`` subagent this '
+            'turn — a verdict the main agent writes itself does not '
+            'count. Spawn the reviewer and have IT write '
+            f'``EXEC_REVIEW_*_iter{iter_num + 1}.md`` with its own '
+            'Write tool; if it is still running, wait for its '
+            'completion notification first.'
+        )
     if status == 'ok':
         return None
     if status == 'incomplete' and iter_num >= _EXEC_REVIEW_MAX_ITERS:

--- a/app/ai/bash_safety.py
+++ b/app/ai/bash_safety.py
@@ -660,24 +660,12 @@ def check_exec_review_status(task_dir, review_writers=None) -> str | None:
             )
     except OSError:
         pass
-    # Authorship: an accepting exec verdict must have been WRITTEN by
-    # the reviewer subagent this turn — the same launch-and-stop /
-    # self-certification bypass as the report gate. Fail-closed when
-    # the stream signal is available (bounded by the redrive budget).
-    if (
-        review_writers is not None
-        and status in ('ok', 'incomplete')
-        and review_writers.get(latest.name) != 'subagent'
-    ):
-        return (
-            f'{latest.name} says Status: {status}, but it was not '
-            'written by the ``ads-execution-review`` subagent this '
-            'turn — a verdict the main agent writes itself does not '
-            'count. Spawn the reviewer and have IT write '
-            f'``EXEC_REVIEW_*_iter{iter_num + 1}.md`` with its own '
-            'Write tool; if it is still running, wait for its '
-            'completion notification first.'
-        )
+    # Authorship (shared rule, one home — see report_reviewer).
+    deny = report_reviewer.exec_authorship_deny(
+        review_writers, latest.name, status, iter_num
+    )
+    if deny:
+        return deny
     if status == 'ok':
         return None
     if status == 'incomplete' and iter_num >= _EXEC_REVIEW_MAX_ITERS:

--- a/app/ai/claude_backend.py
+++ b/app/ai/claude_backend.py
@@ -31,12 +31,12 @@ from sqlalchemy import select
 
 from app.ai.claude_backend_hooks import _HookMixin
 from app.ai.claude_backend_stream import _StreamMixin
+from app.ai.claude_backend_subagents import _SubagentMixin
 from app.ai.claude_backend_utils import (
     AGENT_DEBUG,
     AUTO_APPROVE_CALLBACK,
     DRAIN_TIMEOUT,
     INTERRUPT_TIMEOUT,
-    MAX_REPEAT_TOOL_CALLS,
     SIGNAL_TIMEOUT,
     STOP_REFLECTION_CALLBACK,
     TOOL_APPROVAL_CALLBACK,
@@ -82,7 +82,7 @@ def permission_mode_for_agent(agent_mode: str) -> str:
     return 'plan' if agent_mode == 'plan_then_execute' else 'bypassPermissions'
 
 
-class AgentSession(_HookMixin, _StreamMixin):
+class AgentSession(_HookMixin, _StreamMixin, _SubagentMixin):
     """Manages a single claude -p subprocess for a task."""
 
     def __init__(
@@ -111,13 +111,10 @@ class AgentSession(_HookMixin, _StreamMixin):
         self.auto_approve_plan = auto_approve_plan
         self.task_dir = task_dir
         self.skip_reflection = skip_reflection
-        # Whether start() should persist self.prompt as a role='user'
-        # TaskMessage. True for initial runs (the prompt exists nowhere
-        # else); False for follow-up spawns — the conversation router
+        # False for follow-up spawns/retries: the conversation router
         # already persisted the user's message, and persisting it again
-        # here duplicated every follow-up message on the fresh-session
-        # and dead-session-resume paths (observed live: identical user
-        # rows ~100ms apart).
+        # in start() duplicated every follow-up message (fresh-session
+        # and dead-session-resume paths).
         self.persist_prompt = persist_prompt
         self.resume_session_id: str | None = None
         self._proc: asyncio.subprocess.Process | None = None
@@ -192,47 +189,15 @@ class AgentSession(_HookMixin, _StreamMixin):
         # Circuit breaker: track recent tool call signatures
         self._recent_tool_calls: list[str] = []
         self._review_redrive_count: int = 0  # review-gate re-drive bound
-        # Review-gate stream signals. `_review_subagent_ran` flips when
-        # a review-ish Agent/Task spawn is seen (weak, spawn-time).
-        # `_review_file_writers` maps each REVIEW/EXEC_REVIEW file
-        # written this turn to 'subagent' or 'main' by whether the
-        # Write/Edit event carried a parent_tool_use_id — the strong
-        # authorship signal the gates trust (a verdict counts only when
-        # the reviewer subagent itself wrote it).
-        self._review_subagent_ran: bool = False
-        self._review_file_writers: dict[str, str] = {}
-        # Async-subagent lifecycle: ids of Agent/Task tool_use blocks
-        # spawned this turn, and the subset confirmed ASYNC (launch ack
-        # "Async agent launched…") that have not yet produced a
-        # <task-notification>. A turn must not end while this is
-        # non-empty — the CLI emits its `result` even with background
-        # agents still running, and closing stdin then default-denies
-        # every one of their remaining tool calls (observed live).
-        self._agent_spawn_ids: set[str] = set()
-        self._async_agents: dict[str, str] = {}
+        # Review-authorship + async-subagent stream signals — see
+        # claude_backend_subagents._init_subagent_state.
+        self._init_subagent_state()
         # PreToolUse-hook state. See app.ai.bash_safety and
         # app.ai.claude_backend_utils.check_skill_prereqs.
         self._loaded_skills: set[str] = set()
         self._catalog_read: bool = False
         # Serialize message persistence so seq + created_at stay in order
         self._emit_lock: asyncio.Lock = asyncio.Lock()
-
-    def _check_tool_loop(self, tool_name: str, tool_input: dict) -> bool:
-        """Return True if agent is stuck in a degenerate loop.
-
-        Tracks the last N tool call signatures. If all N are
-        identical, the agent is looping on garbage calls.
-        """
-        sig = f'{tool_name}:{json.dumps(tool_input, sort_keys=True)}'
-        self._recent_tool_calls.append(sig)
-        if len(self._recent_tool_calls) > MAX_REPEAT_TOOL_CALLS:
-            self._recent_tool_calls = self._recent_tool_calls[
-                -MAX_REPEAT_TOOL_CALLS:
-            ]
-        if len(self._recent_tool_calls) >= MAX_REPEAT_TOOL_CALLS:
-            if len(set(self._recent_tool_calls)) == 1:
-                return True
-        return False
 
     async def _cleanup_browser_daemons(self):
         """Kill browser-use daemons spawned for this task.

--- a/app/ai/claude_backend.py
+++ b/app/ai/claude_backend.py
@@ -98,6 +98,7 @@ class AgentSession(_HookMixin, _StreamMixin):
         auto_approve_plan: bool = False,
         task_dir: Path | None = None,
         skip_reflection: bool = False,
+        persist_prompt: bool = True,
     ):
         self.task_id = task_id
         self.prompt = prompt
@@ -110,6 +111,14 @@ class AgentSession(_HookMixin, _StreamMixin):
         self.auto_approve_plan = auto_approve_plan
         self.task_dir = task_dir
         self.skip_reflection = skip_reflection
+        # Whether start() should persist self.prompt as a role='user'
+        # TaskMessage. True for initial runs (the prompt exists nowhere
+        # else); False for follow-up spawns — the conversation router
+        # already persisted the user's message, and persisting it again
+        # here duplicated every follow-up message on the fresh-session
+        # and dead-session-resume paths (observed live: identical user
+        # rows ~100ms apart).
+        self.persist_prompt = persist_prompt
         self.resume_session_id: str | None = None
         self._proc: asyncio.subprocess.Process | None = None
         self._task: asyncio.Task | None = None
@@ -183,6 +192,24 @@ class AgentSession(_HookMixin, _StreamMixin):
         # Circuit breaker: track recent tool call signatures
         self._recent_tool_calls: list[str] = []
         self._review_redrive_count: int = 0  # review-gate re-drive bound
+        # Review-gate stream signals. `_review_subagent_ran` flips when
+        # a review-ish Agent/Task spawn is seen (weak, spawn-time).
+        # `_review_file_writers` maps each REVIEW/EXEC_REVIEW file
+        # written this turn to 'subagent' or 'main' by whether the
+        # Write/Edit event carried a parent_tool_use_id — the strong
+        # authorship signal the gates trust (a verdict counts only when
+        # the reviewer subagent itself wrote it).
+        self._review_subagent_ran: bool = False
+        self._review_file_writers: dict[str, str] = {}
+        # Async-subagent lifecycle: ids of Agent/Task tool_use blocks
+        # spawned this turn, and the subset confirmed ASYNC (launch ack
+        # "Async agent launched…") that have not yet produced a
+        # <task-notification>. A turn must not end while this is
+        # non-empty — the CLI emits its `result` even with background
+        # agents still running, and closing stdin then default-denies
+        # every one of their remaining tool calls (observed live).
+        self._agent_spawn_ids: set[str] = set()
+        self._async_agents: dict[str, str] = {}
         # PreToolUse-hook state. See app.ai.bash_safety and
         # app.ai.claude_backend_utils.check_skill_prereqs.
         self._loaded_skills: set[str] = set()
@@ -420,8 +447,12 @@ class AgentSession(_HookMixin, _StreamMixin):
         # Persist the initial user prompt so it appears in the
         # history file when sessions are reconstructed (e.g. on
         # profile switch).  Skip when replaying history — those
-        # messages are already in the DB.
-        if not self.message_history:
+        # messages are already in the DB — and skip for follow-up
+        # spawns (persist_prompt=False): the conversation router
+        # already saved the user's message, and saving it again here
+        # duplicated it (fresh-session and dead-session-resume paths
+        # both arrive with an empty message_history).
+        if self.persist_prompt and not self.message_history:
             await self._emit_message('user', self.prompt)
 
         # Build the user prompt, optionally embedding prior

--- a/app/ai/claude_backend_hooks.py
+++ b/app/ai/claude_backend_hooks.py
@@ -20,14 +20,10 @@ from app.ai.bash_safety import (
 from app.ai.claude_backend_utils import (
     AGENT_DEBUG,
     AUTO_APPROVE_CALLBACK,
-    REVIEW_REDRIVE_MAX,
     STOP_REFLECTION_CALLBACK,
     TOOL_APPROVAL_CALLBACK,
-    build_tasklist_open_reason,
-    check_exec_review_status_for_stop,
-    check_review_status_for_stop,
     check_skill_prereqs,
-    get_open_tasklist_items,
+    check_tool_loop,
     validate_fanout_plan_text,
 )
 from app.ai.skill_gate_utils import find_skill_md, skill_name_from_read
@@ -151,93 +147,6 @@ class _HookMixin:
             else:
                 await self._send_control_response(request_id, 'allow')
 
-    async def _deny_stop_if_tasklist_open(self, request_id: str) -> bool:
-        """Deny stop if TaskList has open items; return True if denied."""
-        items = get_open_tasklist_items(self.task_id)
-        if not items:
-            return False
-        logger.info('Stop denied %s — %d open', self.task_id[:8], len(items))
-        await self._send_hook_response(
-            request_id,
-            {'decision': 'block', 'reason': build_tasklist_open_reason(items)},
-        )
-        return True
-
-    async def _deny_stop_if_review_unsatisfied(self, request_id: str) -> bool:
-        """Deny stop if the ads-audit reviewer hasn't returned
-        ``Status: ok`` (or ``incomplete`` at iter 5+); return True if
-        denied.
-
-        See ``check_review_status_for_stop`` in
-        ``claude_backend_utils`` for the contract and
-        ``amazon-ads/references/reviewer-loop.md`` for the loop the
-        main agent runs to satisfy this gate. Quiet no-op for non-ads
-        tasks (no ``AD_AUDIT_*.md`` in the workspace).
-        """
-        # Past the re-drive budget the gate FAILS OPEN: the stream
-        # banner-marks the result UNVERIFIED and this hook stands down so
-        # the CLI can exit (a live deny + closed approval channel had
-        # every tool default-denied mid-recovery).
-        if self._review_redrive_count >= REVIEW_REDRIVE_MAX:
-            return False
-        deny = check_review_status_for_stop(
-            self.task_dir,
-            subagent_ran=getattr(self, '_review_subagent_ran', False),
-            review_writers=getattr(self, '_review_file_writers', None),
-        )
-        if not deny:
-            return False
-        logger.info(
-            'Stop denied %s — ads-audit reviewer unsatisfied',
-            self.task_id[:8],
-        )
-        await self._send_hook_response(
-            request_id,
-            {'decision': 'block', 'reason': deny},
-        )
-        return True
-
-    async def _deny_stop_if_exec_review_unsatisfied(self, request_id):
-        """Stop-hook variant of the exec-review gate. The primary gate
-        is in the ``set_task_result`` MCP endpoint; this is a backstop
-        for backends that do emit Stop events.
-        """
-        deny = check_exec_review_status_for_stop(
-            self.task_dir,
-            review_writers=getattr(self, '_review_file_writers', None),
-        )
-        if not deny:
-            return False
-        logger.info('Stop denied %s — exec-review', self.task_id[:8])
-        await self._send_hook_response(
-            request_id, {'decision': 'block', 'reason': deny}
-        )
-        return True
-
-    async def _deny_stop_if_async_agents_running(self, request_id) -> bool:
-        """Deny Stop while background subagents launched this turn are
-        still running; return True if denied.
-
-        Same fail-open bound as the review gates: past the re-drive
-        budget the hook stands down so a lost completion notification
-        can never wedge the turn (the result then ships banner-marked
-        by the stream path).
-        """
-        if self._review_redrive_count >= REVIEW_REDRIVE_MAX:
-            return False
-        deny = self._async_agents_pending_reason()
-        if not deny:
-            return False
-        logger.info(
-            'Stop denied %s — %d async subagent(s) still running',
-            self.task_id[:8],
-            len(self._async_agents),
-        )
-        await self._send_hook_response(
-            request_id, {'decision': 'block', 'reason': deny}
-        )
-        return True
-
     async def _handle_hook_callback(self, request_id: str, request: dict):
         """Handle a HookCallback control request."""
         callback_id = request.get('callback_id', '')
@@ -337,7 +246,9 @@ class _HookMixin:
             if read_skill:
                 self._loaded_skills.add(read_skill)
                 record_skill_load(self.task_id, read_skill)
-            if self._check_tool_loop(inner_name, inner_input):
+            if check_tool_loop(
+                self._recent_tool_calls, inner_name, inner_input
+            ):
                 logger.warning(
                     'Circuit breaker: agent %s stuck in loop (%s), stopping',
                     self.task_id[:8],
@@ -524,7 +435,7 @@ class _HookMixin:
             await self._handle_ask_user_question(request_id, tool_input)
         else:
             # Circuit breaker check
-            if self._check_tool_loop(tool_name, tool_input):
+            if check_tool_loop(self._recent_tool_calls, tool_name, tool_input):
                 logger.warning(
                     'Circuit breaker: agent %s stuck in loop (%s), stopping',
                     self.task_id[:8],

--- a/app/ai/claude_backend_hooks.py
+++ b/app/ai/claude_backend_hooks.py
@@ -183,6 +183,7 @@ class _HookMixin:
         deny = check_review_status_for_stop(
             self.task_dir,
             subagent_ran=getattr(self, '_review_subagent_ran', False),
+            review_writers=getattr(self, '_review_file_writers', None),
         )
         if not deny:
             return False
@@ -201,10 +202,37 @@ class _HookMixin:
         is in the ``set_task_result`` MCP endpoint; this is a backstop
         for backends that do emit Stop events.
         """
-        deny = check_exec_review_status_for_stop(self.task_dir)
+        deny = check_exec_review_status_for_stop(
+            self.task_dir,
+            review_writers=getattr(self, '_review_file_writers', None),
+        )
         if not deny:
             return False
         logger.info('Stop denied %s — exec-review', self.task_id[:8])
+        await self._send_hook_response(
+            request_id, {'decision': 'block', 'reason': deny}
+        )
+        return True
+
+    async def _deny_stop_if_async_agents_running(self, request_id) -> bool:
+        """Deny Stop while background subagents launched this turn are
+        still running; return True if denied.
+
+        Same fail-open bound as the review gates: past the re-drive
+        budget the hook stands down so a lost completion notification
+        can never wedge the turn (the result then ships banner-marked
+        by the stream path).
+        """
+        if self._review_redrive_count >= REVIEW_REDRIVE_MAX:
+            return False
+        deny = self._async_agents_pending_reason()
+        if not deny:
+            return False
+        logger.info(
+            'Stop denied %s — %d async subagent(s) still running',
+            self.task_id[:8],
+            len(self._async_agents),
+        )
         await self._send_hook_response(
             request_id, {'decision': 'block', 'reason': deny}
         )
@@ -399,6 +427,8 @@ class _HookMixin:
                 )
             else:
                 if await self._deny_stop_if_tasklist_open(request_id):
+                    return
+                if await self._deny_stop_if_async_agents_running(request_id):
                     return
                 if await self._deny_stop_if_review_unsatisfied(request_id):
                     return

--- a/app/ai/claude_backend_manager.py
+++ b/app/ai/claude_backend_manager.py
@@ -61,6 +61,7 @@ class ClaudeCodeBackend(AIAgentBackend):
         store_slug: str | None = None,
         on_start=None,
         skip_reflection: bool = False,
+        persist_prompt: bool = True,
     ) -> bool:
         if task_id in self._sessions and self._sessions[task_id].running:
             return False
@@ -100,6 +101,7 @@ class ClaudeCodeBackend(AIAgentBackend):
                 auto_approve_plan=auto_approve_plan,
                 task_dir=task_dir,
                 skip_reflection=skip_reflection,
+                persist_prompt=persist_prompt,
             )
             if resume:
                 async with async_session() as db:
@@ -189,6 +191,10 @@ class ClaudeCodeBackend(AIAgentBackend):
                 auto_approve_plan=prior.auto_approve_plan,
                 task_dir=prior.task_dir,
                 skip_reflection=prior.skip_reflection,
+                # The first attempt already persisted the prompt (or
+                # the router did, for follow-ups) — a retry must never
+                # write the same user message a second time.
+                persist_prompt=False,
             )
             self._sessions[task_id] = new_session
             try:

--- a/app/ai/claude_backend_stream.py
+++ b/app/ai/claude_backend_stream.py
@@ -9,6 +9,7 @@ import asyncio
 from datetime import UTC, datetime
 import json
 import logging
+import re
 
 from app.ai.claude_backend_utils import (
     AGENT_DEBUG,
@@ -19,6 +20,7 @@ from app.ai.claude_backend_utils import (
     parse_wait_condition,
 )
 from app.ai.stop_gates.report_reviewer import (
+    is_review_file_name,
     partial_banner,
     rollover_reviews,
 )
@@ -222,6 +224,94 @@ class _StreamMixin:
             # task_id.
             self.done.set()
 
+    def _async_agents_pending_reason(self) -> str | None:
+        """Deny reason while background subagents are still running.
+
+        The CLI emits its ``result`` (end-of-turn) as soon as the MAIN
+        agent stops — async subagents launched with the Agent tool keep
+        running. Ending the turn then is always wrong: closing stdin
+        default-denies every remaining tool call the subagent makes
+        (observed live — a DoD reviewer died mid-verification while the
+        shipped result claimed it was "running in the background").
+        A turn ends only when its subagents have.
+        """
+        pending = getattr(self, '_async_agents', None)
+        if not pending:
+            return None
+        ids = ', '.join(v or k for k, v in pending.items())
+        return (
+            f'{len(pending)} background subagent(s) you launched '
+            f'this turn are still running ({ids}). A turn must not '
+            'end while its subagents are running — once you stop, '
+            'their remaining tool calls are denied and their work is '
+            'lost, so any "it will report later" claim would be '
+            "false. WAIT for each one's <task-notification> "
+            'completion message and incorporate its result before '
+            'finishing. If a subagent is no longer needed, tell the '
+            'user what you launched and why you are abandoning it.'
+        )
+
+    def _track_async_agents(self, event: dict):
+        """Maintain the set of still-running ASYNC subagents.
+
+        Two signals, both on ``user`` events:
+
+        - launch ack: the tool_result for an Agent/Task spawn whose text
+          starts "Async agent launched successfully" (sync spawns return
+          the subagent's final answer instead) → the agent is running in
+          the background and the turn must not end under it.
+        - completion: the CLI injects a ``<task-notification …>`` user
+          message when a background agent finishes. Match its
+          task-id/tool-use-id/agent-id attributes against what we
+          tracked; if the notification carries none we can match,
+          clear the whole set (fail open — never wedge a turn on a
+          notification format change).
+        """
+        blocks = event.get('message', {}).get('content', [])
+        if isinstance(blocks, str):
+            blocks = [{'type': 'text', 'text': blocks}]
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            if block.get('type') == 'tool_result':
+                tid = block.get('tool_use_id')
+                if tid not in self._agent_spawn_ids:
+                    continue
+                raw = block.get('content')
+                if isinstance(raw, list):
+                    text = ' '.join(
+                        b.get('text', '')
+                        for b in raw
+                        if isinstance(b, dict) and b.get('type') == 'text'
+                    )
+                else:
+                    text = str(raw or '')
+                if 'Async agent launched' in text:
+                    m = re.search(r'agentId:\s*([A-Za-z0-9_-]+)', text)
+                    self._async_agents[tid] = m.group(1) if m else ''
+            elif block.get('type') == 'text':
+                text = block.get('text', '')
+                if '<task-notification' not in text:
+                    continue
+                ids = set(
+                    re.findall(
+                        r'(?:task-id|tool-use-id|agent-id)'
+                        r'="([^"]+)"',
+                        text,
+                    )
+                )
+                matched = [
+                    k
+                    for k, v in self._async_agents.items()
+                    if k in ids or (v and v in ids)
+                ]
+                for k in matched:
+                    del self._async_agents[k]
+                if not matched:
+                    # Unattributable notification — assume it was ours
+                    # rather than block the turn forever.
+                    self._async_agents.clear()
+
     async def _handle_event(self, event: dict):
         """Route stream-json events to SSE."""
         etype = event.get('type', '')
@@ -232,6 +322,9 @@ class _StreamMixin:
                 self.task_id[:8],
                 json.dumps(event, ensure_ascii=False)[:2000],
             )
+
+        if etype == 'user':
+            self._track_async_agents(event)
 
         if etype == 'assistant':
             # Capture error category from assistant error events
@@ -253,12 +346,24 @@ class _StreamMixin:
                     self._had_tool_use = True
                     tool_name = block.get('name', '')
                     tool_input = block.get('input', {})
+                    # Subagent-originated events carry the id of the
+                    # Agent/Task tool_use that spawned them; the main
+                    # agent's own events have it null. This is the
+                    # authorship signal for review verdicts and the
+                    # spawn-tracking key for async agents.
+                    parent_id = event.get('parent_tool_use_id')
                     # A DoD/review verdict only counts when a real reviewer
                     # SUBAGENT produced it. The main agent can't fabricate
                     # this tool_use it never made, so flag a review-ish
                     # Agent/Task spawn; the Stop gate rejects a self-written
                     # verdict when this stayed False.
                     if tool_name in ('Agent', 'Task'):
+                        if not parent_id:
+                            # Track main-agent spawns so the launch ack
+                            # (tool_result) can flag async agents.
+                            _bid = block.get('id')
+                            if _bid:
+                                self._agent_spawn_ids.add(_bid)
                         _blob = json.dumps(
                             tool_input, ensure_ascii=False
                         ).lower()
@@ -267,6 +372,17 @@ class _StreamMixin:
                             for k in ('review', 'verif', 'dod', 'audit')
                         ):
                             self._review_subagent_ran = True
+                    # Review-verdict authorship: record WHO wrote each
+                    # review-named .md this turn. A file last written by
+                    # the main agent can never satisfy the review gates
+                    # (see report_reviewer.reviewer_verdict).
+                    if tool_name in ('Write', 'Edit', 'MultiEdit'):
+                        _fp = str(tool_input.get('file_path', ''))
+                        _base = _fp.rsplit('/', 1)[-1]
+                        if is_review_file_name(_base):
+                            self._review_file_writers[_base] = (
+                                'subagent' if parent_id else 'main'
+                            )
                     if tool_name == 'TodoWrite':
                         todos = tool_input.get('todos', [])
                         await event_bus.emit(
@@ -307,10 +423,24 @@ class _StreamMixin:
             # shared gate helpers, so this covers every review gate, not
             # one task type.
             if self._executing and not is_error:
-                gate_reason = check_review_status_for_stop(
-                    self.task_dir,
-                    subagent_ran=getattr(self, '_review_subagent_ran', False),
-                ) or check_exec_review_status_for_stop(self.task_dir)
+                gate_reason = (
+                    self._async_agents_pending_reason()
+                    or check_review_status_for_stop(
+                        self.task_dir,
+                        subagent_ran=getattr(
+                            self, '_review_subagent_ran', False
+                        ),
+                        review_writers=getattr(
+                            self, '_review_file_writers', None
+                        ),
+                    )
+                    or check_exec_review_status_for_stop(
+                        self.task_dir,
+                        review_writers=getattr(
+                            self, '_review_file_writers', None
+                        ),
+                    )
+                )
                 if (
                     gate_reason
                     and self._review_redrive_count < REVIEW_REDRIVE_MAX

--- a/app/ai/claude_backend_stream.py
+++ b/app/ai/claude_backend_stream.py
@@ -9,7 +9,6 @@ import asyncio
 from datetime import UTC, datetime
 import json
 import logging
-import re
 
 from app.ai.claude_backend_utils import (
     AGENT_DEBUG,
@@ -223,94 +222,6 @@ class _StreamMixin:
             # and a retry registering a fresh session under the same
             # task_id.
             self.done.set()
-
-    def _async_agents_pending_reason(self) -> str | None:
-        """Deny reason while background subagents are still running.
-
-        The CLI emits its ``result`` (end-of-turn) as soon as the MAIN
-        agent stops — async subagents launched with the Agent tool keep
-        running. Ending the turn then is always wrong: closing stdin
-        default-denies every remaining tool call the subagent makes
-        (observed live — a DoD reviewer died mid-verification while the
-        shipped result claimed it was "running in the background").
-        A turn ends only when its subagents have.
-        """
-        pending = getattr(self, '_async_agents', None)
-        if not pending:
-            return None
-        ids = ', '.join(v or k for k, v in pending.items())
-        return (
-            f'{len(pending)} background subagent(s) you launched '
-            f'this turn are still running ({ids}). A turn must not '
-            'end while its subagents are running — once you stop, '
-            'their remaining tool calls are denied and their work is '
-            'lost, so any "it will report later" claim would be '
-            "false. WAIT for each one's <task-notification> "
-            'completion message and incorporate its result before '
-            'finishing. If a subagent is no longer needed, tell the '
-            'user what you launched and why you are abandoning it.'
-        )
-
-    def _track_async_agents(self, event: dict):
-        """Maintain the set of still-running ASYNC subagents.
-
-        Two signals, both on ``user`` events:
-
-        - launch ack: the tool_result for an Agent/Task spawn whose text
-          starts "Async agent launched successfully" (sync spawns return
-          the subagent's final answer instead) → the agent is running in
-          the background and the turn must not end under it.
-        - completion: the CLI injects a ``<task-notification …>`` user
-          message when a background agent finishes. Match its
-          task-id/tool-use-id/agent-id attributes against what we
-          tracked; if the notification carries none we can match,
-          clear the whole set (fail open — never wedge a turn on a
-          notification format change).
-        """
-        blocks = event.get('message', {}).get('content', [])
-        if isinstance(blocks, str):
-            blocks = [{'type': 'text', 'text': blocks}]
-        for block in blocks:
-            if not isinstance(block, dict):
-                continue
-            if block.get('type') == 'tool_result':
-                tid = block.get('tool_use_id')
-                if tid not in self._agent_spawn_ids:
-                    continue
-                raw = block.get('content')
-                if isinstance(raw, list):
-                    text = ' '.join(
-                        b.get('text', '')
-                        for b in raw
-                        if isinstance(b, dict) and b.get('type') == 'text'
-                    )
-                else:
-                    text = str(raw or '')
-                if 'Async agent launched' in text:
-                    m = re.search(r'agentId:\s*([A-Za-z0-9_-]+)', text)
-                    self._async_agents[tid] = m.group(1) if m else ''
-            elif block.get('type') == 'text':
-                text = block.get('text', '')
-                if '<task-notification' not in text:
-                    continue
-                ids = set(
-                    re.findall(
-                        r'(?:task-id|tool-use-id|agent-id)'
-                        r'="([^"]+)"',
-                        text,
-                    )
-                )
-                matched = [
-                    k
-                    for k, v in self._async_agents.items()
-                    if k in ids or (v and v in ids)
-                ]
-                for k in matched:
-                    del self._async_agents[k]
-                if not matched:
-                    # Unattributable notification — assume it was ours
-                    # rather than block the turn forever.
-                    self._async_agents.clear()
 
     async def _handle_event(self, event: dict):
         """Route stream-json events to SSE."""

--- a/app/ai/claude_backend_subagents.py
+++ b/app/ai/claude_backend_subagents.py
@@ -1,0 +1,224 @@
+"""Subagent lifecycle tracking + Stop-gate deny helpers for AgentSession.
+
+Mixed into AgentSession via multiple inheritance (sibling of
+``_HookMixin`` / ``_StreamMixin``). Methods here reference attributes
+initialised by ``_init_subagent_state`` (called from
+``AgentSession.__init__``) and call methods defined on the other
+mixins (``_send_hook_response``).
+
+Two structural rules live here:
+
+- **A turn cannot end under a running async subagent.** The CLI emits
+  its ``result`` as soon as the MAIN agent stops; async subagents
+  launched with the Agent tool keep running, and closing stdin then
+  default-denies every remaining tool call they make (observed live —
+  a DoD reviewer died mid-verification while the shipped result
+  claimed it was "running in the background").
+- **A review verdict counts only if the reviewer subagent wrote it.**
+  The stream attributes each review-file Write/Edit to subagent/main
+  via the event's ``parent_tool_use_id``; the gates reject an
+  accepting verdict the main agent authored itself.
+"""
+
+import logging
+import re
+
+from app.ai.claude_backend_utils import (
+    REVIEW_REDRIVE_MAX,
+    build_tasklist_open_reason,
+    check_exec_review_status_for_stop,
+    check_review_status_for_stop,
+    get_open_tasklist_items,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _SubagentMixin:
+    """Async-subagent tracking + the Stop-hook deny chain."""
+
+    def _init_subagent_state(self):
+        """Per-session stream signals; see the module docstring.
+
+        ``_review_subagent_ran`` flips when a review-ish Agent/Task
+        spawn is seen (weak, spawn-time). ``_review_file_writers`` maps
+        each review file written this turn to ``'subagent'``/``'main'``
+        (strong authorship signal). ``_agent_spawn_ids`` are the
+        Agent/Task tool_use ids spawned by the main agent;
+        ``_async_agents`` the subset confirmed ASYNC (launch ack) with
+        no ``<task-notification>`` completion yet.
+        """
+        self._review_subagent_ran: bool = False
+        self._review_file_writers: dict[str, str] = {}
+        self._agent_spawn_ids: set[str] = set()
+        self._async_agents: dict[str, str] = {}
+
+    def _async_agents_pending_reason(self) -> str | None:
+        """Deny reason while background subagents are still running."""
+        pending = getattr(self, '_async_agents', None)
+        if not pending:
+            return None
+        ids = ', '.join(v or k for k, v in pending.items())
+        return (
+            f'{len(pending)} background subagent(s) you launched '
+            f'this turn are still running ({ids}). A turn must not '
+            'end while its subagents are running — once you stop, '
+            'their remaining tool calls are denied and their work is '
+            'lost, so any "it will report later" claim would be '
+            "false. WAIT for each one's <task-notification> "
+            'completion message and incorporate its result before '
+            'finishing. If a subagent is no longer needed, tell the '
+            'user what you launched and why you are abandoning it.'
+        )
+
+    def _track_async_agents(self, event: dict):
+        """Maintain the set of still-running ASYNC subagents.
+
+        Two signals, both on ``user`` events:
+
+        - launch ack: the tool_result for an Agent/Task spawn whose text
+          starts "Async agent launched successfully" (sync spawns return
+          the subagent's final answer instead) → the agent is running in
+          the background and the turn must not end under it.
+        - completion: the CLI injects a ``<task-notification …>`` user
+          message when a background agent finishes. Match its
+          task-id/tool-use-id/agent-id attributes against what we
+          tracked; if the notification carries none we can match,
+          clear the whole set (fail open — never wedge a turn on a
+          notification format change).
+        """
+        blocks = event.get('message', {}).get('content', [])
+        if isinstance(blocks, str):
+            blocks = [{'type': 'text', 'text': blocks}]
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            if block.get('type') == 'tool_result':
+                tid = block.get('tool_use_id')
+                if tid not in self._agent_spawn_ids:
+                    continue
+                raw = block.get('content')
+                if isinstance(raw, list):
+                    text = ' '.join(
+                        b.get('text', '')
+                        for b in raw
+                        if isinstance(b, dict) and b.get('type') == 'text'
+                    )
+                else:
+                    text = str(raw or '')
+                if 'Async agent launched' in text:
+                    m = re.search(r'agentId:\s*([A-Za-z0-9_-]+)', text)
+                    self._async_agents[tid] = m.group(1) if m else ''
+            elif block.get('type') == 'text':
+                text = block.get('text', '')
+                if '<task-notification' not in text:
+                    continue
+                ids = set(
+                    re.findall(
+                        r'(?:task-id|tool-use-id|agent-id)'
+                        r'="([^"]+)"',
+                        text,
+                    )
+                )
+                matched = [
+                    k
+                    for k, v in self._async_agents.items()
+                    if k in ids or (v and v in ids)
+                ]
+                for k in matched:
+                    del self._async_agents[k]
+                if not matched:
+                    # Unattributable notification — assume it was ours
+                    # rather than block the turn forever.
+                    self._async_agents.clear()
+
+    # ── Stop-hook deny chain ────────────────────────────────────────
+    # Called in order by the STOP_REFLECTION_CALLBACK handler in
+    # claude_backend_hooks; first deny wins.
+
+    async def _deny_stop_if_tasklist_open(self, request_id: str) -> bool:
+        """Deny stop if TaskList has open items; return True if denied."""
+        items = get_open_tasklist_items(self.task_id)
+        if not items:
+            return False
+        logger.info('Stop denied %s — %d open', self.task_id[:8], len(items))
+        await self._send_hook_response(
+            request_id,
+            {'decision': 'block', 'reason': build_tasklist_open_reason(items)},
+        )
+        return True
+
+    async def _deny_stop_if_async_agents_running(self, request_id) -> bool:
+        """Deny Stop while background subagents launched this turn are
+        still running; return True if denied.
+
+        Same fail-open bound as the review gates: past the re-drive
+        budget the hook stands down so a lost completion notification
+        can never wedge the turn (the result then ships banner-marked
+        by the stream path).
+        """
+        if self._review_redrive_count >= REVIEW_REDRIVE_MAX:
+            return False
+        deny = self._async_agents_pending_reason()
+        if not deny:
+            return False
+        logger.info(
+            'Stop denied %s — %d async subagent(s) still running',
+            self.task_id[:8],
+            len(self._async_agents),
+        )
+        await self._send_hook_response(
+            request_id, {'decision': 'block', 'reason': deny}
+        )
+        return True
+
+    async def _deny_stop_if_review_unsatisfied(self, request_id: str) -> bool:
+        """Deny stop if the ads-audit reviewer hasn't returned
+        ``Status: ok`` (or ``incomplete`` at iter 5+); return True if
+        denied.
+
+        See ``check_review_status_for_stop`` in
+        ``claude_backend_utils`` for the contract and
+        ``amazon-ads/references/reviewer-loop.md`` for the loop the
+        main agent runs to satisfy this gate. Quiet no-op for non-ads
+        tasks (no ``AD_AUDIT_*.md`` in the workspace).
+        """
+        # Past the re-drive budget the gate FAILS OPEN: the stream
+        # banner-marks the result UNVERIFIED and this hook stands down so
+        # the CLI can exit (a live deny + closed approval channel had
+        # every tool default-denied mid-recovery).
+        if self._review_redrive_count >= REVIEW_REDRIVE_MAX:
+            return False
+        deny = check_review_status_for_stop(
+            self.task_dir,
+            subagent_ran=getattr(self, '_review_subagent_ran', False),
+            review_writers=getattr(self, '_review_file_writers', None),
+        )
+        if not deny:
+            return False
+        logger.info(
+            'Stop denied %s — ads-audit reviewer unsatisfied',
+            self.task_id[:8],
+        )
+        await self._send_hook_response(
+            request_id,
+            {'decision': 'block', 'reason': deny},
+        )
+        return True
+
+    async def _deny_stop_if_exec_review_unsatisfied(self, request_id):
+        """Stop-hook variant of the exec-review gate. The primary gate
+        is in the ``set_task_result`` MCP endpoint; this is a backstop
+        for backends that do emit Stop events.
+        """
+        deny = check_exec_review_status_for_stop(
+            self.task_dir,
+            review_writers=getattr(self, '_review_file_writers', None),
+        )
+        if not deny:
+            return False
+        logger.info('Stop denied %s — exec-review', self.task_id[:8])
+        await self._send_hook_response(
+            request_id, {'decision': 'block', 'reason': deny}
+        )
+        return True

--- a/app/ai/claude_backend_utils.py
+++ b/app/ai/claude_backend_utils.py
@@ -412,7 +412,7 @@ REVIEW_REDRIVE_MAX = 5
 
 
 def check_review_status_for_stop(
-    task_dir: Path | None, subagent_ran=None
+    task_dir: Path | None, subagent_ran=None, review_writers=None
 ) -> str | None:
     """Return a deny reason for Stop if the ads-audit reviewer
     hasn't run (or returned gaps); otherwise ``None``.
@@ -422,15 +422,18 @@ def check_review_status_for_stop(
     no-op for non-ads tasks (no ``AD_AUDIT_*.md`` in the workspace).
     ``subagent_ran`` (False when the stream saw no review-subagent spawn
     this turn) makes an accepting verdict get rejected as self-written.
+    ``review_writers`` (per-file authorship from the stream) makes an
+    accepting verdict count ONLY when the reviewer subagent itself
+    wrote the file — see ``report_reviewer.reviewer_verdict``.
     See ``amazon-ads/references/reviewer-loop.md`` for the contract.
     """
     if task_dir is None:
         return None
-    return check_review_status(task_dir, subagent_ran)
+    return check_review_status(task_dir, subagent_ran, review_writers)
 
 
 def check_exec_review_status_for_stop(
-    task_dir: Path | None,
+    task_dir: Path | None, review_writers=None
 ) -> str | None:
     """Return a deny reason for Stop if the ads-execution reviewer
     hasn't returned ok; otherwise ``None``.
@@ -442,4 +445,4 @@ def check_exec_review_status_for_stop(
     """
     if task_dir is None:
         return None
-    return check_exec_review_status(task_dir)
+    return check_exec_review_status(task_dir, review_writers)

--- a/app/ai/claude_backend_utils.py
+++ b/app/ai/claude_backend_utils.py
@@ -160,6 +160,25 @@ STOP_REFLECTION_CALLBACK = 'stop_reflection'
 MAX_REPEAT_TOOL_CALLS = Options.MAX_REPEAT_TOOL_CALLS.get_int()
 
 
+def check_tool_loop(
+    recent_calls: list[str], tool_name: str, tool_input: dict
+) -> bool:
+    """True if the agent is stuck in a degenerate tool loop.
+
+    Appends the call signature to *recent_calls* (the session's
+    rolling window, mutated in place) and reports whether the last
+    ``MAX_REPEAT_TOOL_CALLS`` signatures are all identical.
+    """
+    sig = f'{tool_name}:{json.dumps(tool_input, sort_keys=True)}'
+    recent_calls.append(sig)
+    if len(recent_calls) > MAX_REPEAT_TOOL_CALLS:
+        del recent_calls[:-MAX_REPEAT_TOOL_CALLS]
+    return (
+        len(recent_calls) >= MAX_REPEAT_TOOL_CALLS
+        and len(set(recent_calls)) == 1
+    )
+
+
 async def get_next_seq(db, task_id: str) -> int:
     """Get next sequence number for task messages."""
     result = await db.execute(

--- a/app/ai/stop_gates/listing_upload_gate.py
+++ b/app/ai/stop_gates/listing_upload_gate.py
@@ -1,13 +1,25 @@
 """Batch-keyed freshness gate for listing flat-file uploads.
 
+``bh_download_template`` writes an ``UPLOAD_PENDING.json`` marker when a
+template lands (an upload is now intended this turn), and
 ``bh_upload_flatfile`` records every submitted batch as an
-``UPLOAD_BATCH_<id>.json`` marker in the task workspace, and
-``listing_bulk.py parse-feedback --batch-id <id>`` writes the matching
-``BATCH_<id>_VERDICT.json`` after reading THAT batch's processing
-report. This gate closes the loop: a task that uploaded a batch cannot
-finish until the batch has a verdict, and the verdict shows no
-non-image errors (the missing-main-image deferral is the one accepted
-"done with caveat" state).
+``UPLOAD_BATCH_<id>.json`` marker. ``listing_bulk.py parse-feedback
+--batch-id <id>`` writes the matching ``BATCH_<id>_VERDICT.json`` after
+reading THAT batch's processing report. This gate closes the loop: a
+task that entered the upload flow cannot finish until the uploaded
+batch has a verdict, and the verdict shows no non-image errors (the
+missing-main-image deferral is the one accepted "done with caveat"
+state).
+
+Arming is deliberately redundant: the batch marker requires the upload
+HELPER to have succeeded, and the observed bypass was exactly a helper
+failure — the submit click missed, the agent uploaded by hand, no
+marker existed, and the gate stayed a quiet no-op. The pending marker
+(written at template download, several steps earlier) survives that
+fallback, so a manual upload is still gated: at least one batch verdict
+must exist, and the latest one must be clean. If no upload happened
+after all, the agent removes the pending marker (explicitly, visibly)
+instead of the gate silently not existing.
 
 This makes report freshness structural instead of prompted: a reviewer
 can no longer pass the turn by reading a stale report from a prior
@@ -16,8 +28,8 @@ upload actually produced this turn. Markers/verdicts are moved aside
 at turn start together with the review files (``rollover_reviews``),
 so each turn is gated only on its own uploads.
 
-No markers → quiet no-op (the gate arms itself only when the upload
-helper ran).
+No markers → quiet no-op (the gate arms itself only when the helpers
+ran).
 """
 
 from __future__ import annotations
@@ -29,41 +41,72 @@ import re
 GATE_NAME = 'listing_upload_gate'
 
 _MARKER_RE = re.compile(r'^UPLOAD_BATCH_(\w+)\.json$')
+_VERDICT_RE = re.compile(r'^BATCH_(\w+)_VERDICT\.json$')
 
 # Glob patterns for the turn-scoped artifacts this gate reads; also used
 # by ``rollover_reviews`` to move them aside at turn start.
 MARKER_GLOB = 'UPLOAD_BATCH_*.json'
 VERDICT_GLOB = 'BATCH_*_VERDICT.json'
+PENDING_GLOB = 'UPLOAD_PENDING*.json'
+
+
+def _ids(task_dir: Path, glob: str, rx: re.Pattern) -> list[str]:
+    try:
+        names = [p.name for p in Path(task_dir).glob(glob)]
+    except OSError:
+        return []
+    out = []
+    for name in names:
+        m = rx.match(name)
+        if m:
+            out.append(m.group(1))
+    return out
 
 
 def check_upload_verdicts(task_dir) -> str | None:
     """Deny reason until every batch is verdicted and the LATEST is clean.
 
-    Two rules, matching how the upload loop really converges:
-      1. EVERY marker needs a verdict — each batch's report must have
-         been read (the anti-fake-success core).
+    Rules, matching how the upload loop really converges:
+      1. EVERY batch marker needs a verdict — each batch's report must
+         have been read (the anti-fake-success core).
       2. Only the LATEST batch must be CLEAN (zero non-image errors).
          Earlier batches are immutable history: a failed intermediate
          that a later upload superseded can never be "fixed", so
-         requiring it clean would wedge the loop.
+         requiring it clean would wedge the loop. "Latest" ranges over
+         marker AND verdict-only ids, so a manually-uploaded batch
+         (helper failed → no marker) is judged too.
+      3. A pending marker (template downloaded) with NO batch activity
+         at all means the upload never got verified — or never
+         happened; the agent must parse-feedback the batch it uploaded,
+         or remove the marker if it genuinely didn't upload.
     Unreadable marker/verdict files count as unresolved (fail closed —
     the agent rewrites them by re-running the helper/parser).
     """
     if task_dir is None:
         return None
+    marker_ids = _ids(task_dir, MARKER_GLOB, _MARKER_RE)
+    verdict_ids = _ids(task_dir, VERDICT_GLOB, _VERDICT_RE)
     try:
-        markers = sorted(Path(task_dir).glob(MARKER_GLOB))
+        pending = any(Path(task_dir).glob(PENDING_GLOB))
     except OSError:
-        return None
-    latest_id = None
-    latest_non_image = None
-    for marker in markers:
-        m = _MARKER_RE.match(marker.name)
-        if not m:
-            continue
-        batch_id = m.group(1)
-        verdict_path = Path(task_dir) / f'BATCH_{batch_id}_VERDICT.json'
-        if not verdict_path.is_file():
+        pending = False
+
+    if pending and not marker_ids and not verdict_ids:
+        return (
+            'A listing template was downloaded this turn '
+            '(UPLOAD_PENDING.json) but no uploaded batch has a '
+            'parse-feedback verdict. If you uploaded a flat file '
+            '(even manually), find its batch id on the upload-status '
+            "page, fetch THAT batch's processing report "
+            '(bh_fetch_report), and run listing_bulk.py parse-feedback '
+            '<report> --batch-id <id> FROM THE TASK WORKSPACE ROOT. '
+            'If you did NOT upload anything, delete UPLOAD_PENDING.json '
+            'and say why the upload was abandoned.'
+        )
+
+    for batch_id in marker_ids:
+        if batch_id not in verdict_ids:
+            verdict_path = Path(task_dir) / f'BATCH_{batch_id}_VERDICT.json'
             return (
                 f'Upload batch {batch_id} has no parse-feedback verdict '
                 "yet. Fetch THAT batch's processing report from the SAME "
@@ -75,23 +118,26 @@ def check_upload_verdicts(task_dir) -> str | None:
                 f'{verdict_path}. The task cannot finish on an '
                 'unverified upload.'
             )
-        try:
-            verdict = json.loads(verdict_path.read_text(encoding='utf-8'))
-            non_image = int(verdict.get('non_image_errors', 0))
-        except (OSError, ValueError, TypeError):
-            return (
-                f'{verdict_path.name} is unreadable — re-run '
-                f'listing_bulk.py parse-feedback --batch-id {batch_id} '
-                "on the batch's processing report."
-            )
-        # Batch ids are monotonically increasing within an account, so
-        # the lexically greatest marker is the newest upload.
-        if latest_id is None or batch_id > latest_id:
-            latest_id = batch_id
-            latest_non_image = non_image
-    if latest_id is not None and latest_non_image:
+
+    # Batch ids are monotonically increasing within an account, so the
+    # lexically greatest id is the newest upload — across markers and
+    # verdict-only (manual-upload) batches alike.
+    latest_id = max((*marker_ids, *verdict_ids), default=None)
+    if latest_id is None:
+        return None
+    verdict_path = Path(task_dir) / f'BATCH_{latest_id}_VERDICT.json'
+    try:
+        verdict = json.loads(verdict_path.read_text(encoding='utf-8'))
+        non_image = int(verdict.get('non_image_errors', 0))
+    except (OSError, ValueError, TypeError):
         return (
-            f'Your LATEST batch {latest_id} has {latest_non_image} '
+            f'{verdict_path.name} is unreadable — re-run '
+            f'listing_bulk.py parse-feedback --batch-id {latest_id} '
+            "on the batch's processing report."
+        )
+    if non_image:
+        return (
+            f'Your LATEST batch {latest_id} has {non_image} '
             'unresolved non-image error(s) per its processing report. '
             'Fix exactly the fields the report names, re-upload, and '
             'parse-feedback the new batch. Only the missing-main-image '

--- a/app/ai/stop_gates/report_reviewer.py
+++ b/app/ai/stop_gates/report_reviewer.py
@@ -57,6 +57,17 @@ _REVIEW_ITER_RE = re.compile(r'_iter(\d+)\.md$')
 _REVIEW_NAME_RE = re.compile(r'(?:^|[^a-z])review(?:[^a-z]|$)', re.IGNORECASE)
 
 
+def is_review_file_name(name: str) -> bool:
+    """True when *name* looks like a review-verdict artifact.
+
+    Same token rule the gates use to FIND verdicts (``REVIEW_…``,
+    ``EXEC_REVIEW_…``, ``<PRODUCT>_REVIEW_…``, lowercase variants), so
+    the stream's authorship tracking and the gates agree on which
+    files are verdicts.
+    """
+    return name.endswith('.md') and bool(_REVIEW_NAME_RE.search(name))
+
+
 def rollover_reviews(task_dir) -> None:
     """Move the PRIOR turn's review verdicts aside at the start of a new
     execution turn, so this turn is reviewed on a clean slate.
@@ -84,6 +95,7 @@ def rollover_reviews(task_dir) -> None:
         # turn's batches. See stop_gates.listing_upload_gate.
         stale += list(d.glob('UPLOAD_BATCH_*.json'))
         stale += list(d.glob('BATCH_*_VERDICT.json'))
+        stale += list(d.glob('UPLOAD_PENDING*.json'))
         if not stale:
             return
         root = d / PREV_TURNS_DIR
@@ -151,7 +163,9 @@ def effective_status(content: str) -> tuple[str | None, list[str]]:
     return next(s for s in statuses if s not in known), statuses
 
 
-def reviewer_verdict(task_dir, subagent_ran=None) -> str | None:
+def reviewer_verdict(
+    task_dir, subagent_ran=None, review_writers=None
+) -> str | None:
     """Deny reason if the reviewer hasn't signed off; else ``None``.
 
     Called for EVERY ads-skill-bound task (the caller established the
@@ -161,6 +175,15 @@ def reviewer_verdict(task_dir, subagent_ran=None) -> str | None:
     cross-checks; on a task with nothing substantive to verify (a quick
     metric lookup) it signs off ``Status: ok`` fast. The server never
     pre-judges "report vs lookup"; it only requires the verdict.
+
+    ``review_writers`` (when the backend supplies it) maps each review
+    file written THIS turn to ``'subagent'`` or ``'main'`` by who made
+    the Write/Edit call. An accepting verdict is trusted only when the
+    reviewer subagent itself wrote the file: ``subagent_ran`` alone is
+    a spawn-time signal, and a main agent that self-writes ``ok`` then
+    LAUNCHES an (async) reviewer and stops satisfies it without any
+    review having happened — observed live. ``None`` = signal not
+    available (other backends) → fall back to ``subagent_ran``.
     """
     if task_dir is None:
         return None
@@ -242,12 +265,38 @@ def reviewer_verdict(task_dir, subagent_ran=None) -> str | None:
     )
 
     # A verdict is only trustworthy when an actual reviewer SUBAGENT
-    # produced it THIS turn. ``subagent_ran is False`` means the stream saw
-    # no review-subagent spawn since the last user turn, so an accepting
-    # verdict was self-written by the main agent — the exact self-
-    # certification bypass. Reject it. (``None`` = caller didn't supply the
-    # signal → keep legacy behavior; the ad floor still gates those.)
-    if subagent_ran is False and status in ('ok', 'incomplete'):
+    # produced it THIS turn.
+    #
+    # Strong signal (``review_writers`` supplied): the file itself must
+    # have been written from INSIDE a subagent (the backend attributes
+    # each Write/Edit via the event's parent_tool_use_id). This closes
+    # the launch-and-stop bypass: spawning an async reviewer flips
+    # ``subagent_ran`` at spawn time, but the accepting verdict on disk
+    # is still the main agent's own file until the reviewer WRITES its
+    # verdict. Fail-closed (bounded by the caller's redrive budget).
+    if review_writers is not None and status in ('ok', 'incomplete'):
+        if review_writers.get(latest.name) != 'subagent':
+            return (
+                f'{latest.name} says Status: {status}, but it was not '
+                'written by a DoD reviewer subagent this turn — a '
+                'verdict the main agent writes (or transcribes) itself '
+                'does not count. The reviewer subagent must write the '
+                'verdict file with ITS OWN Write tool. If your reviewer '
+                'is still running, WAIT for its completion notification '
+                'and make sure it writes '
+                f'REVIEW_<date>_iter{iter_num + 1}.md itself; if it '
+                'already finished without writing one, spawn it again '
+                '(Agent tool, subagent_type="general-purpose") and '
+                'instruct it to open the live sources and write the '
+                'verdict file before returning.'
+            )
+    # Weak signal fallback: ``subagent_ran is False`` means the stream
+    # saw no review-subagent spawn since the last user turn, so an
+    # accepting verdict was self-written by the main agent — the exact
+    # self-certification bypass. Reject it. (``None`` = caller didn't
+    # supply the signal → keep legacy behavior; the ad floor still
+    # gates those.)
+    elif subagent_ran is False and status in ('ok', 'incomplete'):
         return (
             f'{latest.name} says Status: {status}, but NO DoD reviewer '
             'subagent ran this turn — a verdict you write yourself does '

--- a/app/ai/stop_gates/report_reviewer.py
+++ b/app/ai/stop_gates/report_reviewer.py
@@ -57,6 +57,30 @@ _REVIEW_ITER_RE = re.compile(r'_iter(\d+)\.md$')
 _REVIEW_NAME_RE = re.compile(r'(?:^|[^a-z])review(?:[^a-z]|$)', re.IGNORECASE)
 
 
+def exec_authorship_deny(review_writers, name, status, iter_num):
+    """Deny reason when an accepting EXEC_REVIEW verdict was not
+    written by the reviewer subagent this turn; else ``None``.
+
+    Same authorship rule as ``reviewer_verdict`` (see there for the
+    launch-and-stop bypass this closes), phrased for the
+    execution-review loop. ``None`` writers = signal unavailable →
+    legacy behavior.
+    """
+    if review_writers is None or status not in ('ok', 'incomplete'):
+        return None
+    if review_writers.get(name) == 'subagent':
+        return None
+    return (
+        f'{name} says Status: {status}, but it was not written by '
+        'the ``ads-execution-review`` subagent this turn — a verdict '
+        'the main agent writes itself does not count. Spawn the '
+        'reviewer and have IT write '
+        f'``EXEC_REVIEW_*_iter{iter_num + 1}.md`` with its own Write '
+        'tool; if it is still running, wait for its completion '
+        'notification first.'
+    )
+
+
 def is_review_file_name(name: str) -> bool:
     """True when *name* looks like a review-verdict artifact.
 

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -718,9 +718,17 @@ async def set_task_result(
             deny.reason[:200],
         )
 
-    # Active reviewer sign-off (see apply_report_reviewer_gate).
+    # Active reviewer sign-off (see apply_report_reviewer_gate). The
+    # live session's verdict-authorship map makes an accepting verdict
+    # count only when the reviewer subagent itself wrote the file.
+    session = agent_manager.get_session(task_id)
     deny_reason, final_result = apply_report_reviewer_gate(
-        task_id, task_root, final_result
+        task_id,
+        task_root,
+        final_result,
+        review_writers=(
+            getattr(session, '_review_file_writers', None) if session else None
+        ),
     )
     if deny_reason:
         raise HTTPException(status_code=400, detail=deny_reason)

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -718,17 +718,9 @@ async def set_task_result(
             deny.reason[:200],
         )
 
-    # Active reviewer sign-off (see apply_report_reviewer_gate). The
-    # live session's verdict-authorship map makes an accepting verdict
-    # count only when the reviewer subagent itself wrote the file.
-    session = agent_manager.get_session(task_id)
+    # Active reviewer sign-off (see apply_report_reviewer_gate).
     deny_reason, final_result = apply_report_reviewer_gate(
-        task_id,
-        task_root,
-        final_result,
-        review_writers=(
-            getattr(session, '_review_file_writers', None) if session else None
-        ),
+        task_id, task_root, final_result
     )
     if deny_reason:
         raise HTTPException(status_code=400, detail=deny_reason)

--- a/app/routers/tasks_files.py
+++ b/app/routers/tasks_files.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
 from starlette.background import BackgroundTask
 
+from app.ai.claude_backend_manager import agent_manager
 from app.ai.skill_review import skills_requiring_review
 from app.ai.stop_gates import (
     record_attempt,
@@ -33,15 +34,13 @@ logger = logging.getLogger(__name__)
 _TASKS_DIR = VIBE_SELLER_DIR / 'tasks'
 
 
-def apply_report_reviewer_gate(
-    task_id, task_root, final_result, review_writers=None
-):
+def apply_report_reviewer_gate(task_id, task_root, final_result):
     """Reviewer sign-off for review-declaring skills at ``set_task_result``.
 
-    ``review_writers`` — the live session's per-file verdict-authorship
-    map (who wrote each review file this turn), supplied by the caller
-    from ``agent_manager``; an accepting verdict then counts only when
-    the reviewer subagent itself wrote the file.
+    The live session's per-file verdict-authorship map (who wrote each
+    review file this turn) is read from ``agent_manager``; an accepting
+    verdict then counts only when the reviewer subagent itself wrote
+    the file.
 
     The active reviewer is enforced here (not only in the Stop hook) so a
     backend that finishes via this endpoint can't complete with the
@@ -62,8 +61,10 @@ def apply_report_reviewer_gate(
     )
     if not needs_review:
         return None, final_result
+    session = agent_manager.get_session(task_id)
     deny = report_reviewer.reviewer_verdict(
-        task_root, review_writers=review_writers
+        task_root,
+        review_writers=getattr(session, '_review_file_writers', None),
     )
     if not deny:
         return None, final_result

--- a/app/routers/tasks_files.py
+++ b/app/routers/tasks_files.py
@@ -33,8 +33,15 @@ logger = logging.getLogger(__name__)
 _TASKS_DIR = VIBE_SELLER_DIR / 'tasks'
 
 
-def apply_report_reviewer_gate(task_id, task_root, final_result):
+def apply_report_reviewer_gate(
+    task_id, task_root, final_result, review_writers=None
+):
     """Reviewer sign-off for review-declaring skills at ``set_task_result``.
+
+    ``review_writers`` — the live session's per-file verdict-authorship
+    map (who wrote each review file this turn), supplied by the caller
+    from ``agent_manager``; an accepting verdict then counts only when
+    the reviewer subagent itself wrote the file.
 
     The active reviewer is enforced here (not only in the Stop hook) so a
     backend that finishes via this endpoint can't complete with the
@@ -55,7 +62,9 @@ def apply_report_reviewer_gate(task_id, task_root, final_result):
     )
     if not needs_review:
         return None, final_result
-    deny = report_reviewer.reviewer_verdict(task_root)
+    deny = report_reviewer.reviewer_verdict(
+        task_root, review_writers=review_writers
+    )
     if not deny:
         return None, final_result
     attempt = record_attempt(task_id, 'ads_report_reviewer')

--- a/app/skills_v2/amazon-listing/SKILL.md
+++ b/app/skills_v2/amazon-listing/SKILL.md
@@ -386,14 +386,27 @@ S=.claude/skills/amazon-listing/scripts
 DL=~/.vibe-seller/downloads/<slug>
 
 # 1. Generate + download ONE marketplace's template (region-stamped by
-#    the ticked store — this does the ticking for you):
+#    the ticked store — this does the ticking for you AND verifies it
+#    took: kat-checkbox ignores JS clicks, so the states are read back
+#    and returned as "stores"; ok=false means the target never got
+#    ticked — do NOT generate/fill from that state). Writes
+#    UPLOAD_PENDING.json to MARKER_DIR: from here the task cannot
+#    finish until an uploaded batch has a parse-feedback verdict (or
+#    you delete the marker because no upload happened after all):
 SC_HOST=sellercentral.amazon.<tld> PRODUCT_TYPE=<keyword> \
-STORE_LABEL=Amazon.<tld> DOWNLOADS_DIR=$DL \
+STORE_LABEL=Amazon.<tld> DOWNLOADS_DIR=$DL MARKER_DIR="$PWD" \
 browser-use < $S/bh_download_template.py
+# Then confirm the stamp before filling: `listing_bulk.py inspect`
+# prints "marketplaces:" — your target MUST be listed, and `fill`
+# requires --marketplace <CC> and hard-fails on a wrong-region
+# template instead of listing on the wrong storefront.
 
 # 2. Stage + submit the filled .txt (file-chooser intercept + Submit +
 #    batch id). Writes UPLOAD_BATCH_<id>.json to MARKER_DIR — the task
-#    CANNOT finish until that batch has a clean parse-feedback verdict:
+#    CANNOT finish until that batch has a clean parse-feedback verdict.
+#    If this reports ok=false and you complete the upload BY HAND, the
+#    gate still applies (UPLOAD_PENDING arms it): find the batch id on
+#    the status page and parse-feedback it like any other batch:
 UPLOAD_FILE=$DL/out.txt SC_HOST=sellercentral.amazon.<tld> \
 MARKER_DIR="$PWD" browser-use < $S/bh_upload_flatfile.py
 

--- a/app/skills_v2/amazon-listing/scripts/bh_download_template.py
+++ b/app/skills_v2/amazon-listing/scripts/bh_download_template.py
@@ -8,10 +8,27 @@ unticked. Run through the STORE WRAPPER:
 
   SC_HOST=sellercentral.amazon.ae PRODUCT_TYPE=socks \
   STORE_LABEL=Amazon.ae DOWNLOADS_DIR=~/.vibe-seller/downloads/<slug> \
+  MARKER_DIR="$PWD" \
   browser-use < .claude/skills/amazon-listing/scripts/bh_download_template.py
 
 Prints exactly one ``RESULT {json}`` line:
-  ok / template (downloaded path) / picked (product type) / reason
+  ok / template (downloaded path) / picked (product type) /
+  stores (label -> ticked, read back AFTER ticking) / reason
+
+The store tick is VERIFIED, never assumed: kat-checkbox often ignores a
+JS ``.click()`` (shadow DOM), and a template generated WITHOUT the
+target store ticked is region-stamped for the wrong marketplace — the
+whole upload then succeeds on the wrong storefront. After ticking, the
+checkbox states are read back; an unticked target is retried with a
+trusted coordinate click; if the target STILL isn't ticked, the result
+is ``ok: false`` with the observed states. Other leaves left ticked are
+fine — a bundled multi-marketplace template works (``fill`` routes the
+offer by marketplace), so we never fight the other checkboxes.
+
+On success it also writes ``UPLOAD_PENDING.json`` into MARKER_DIR (pass
+your task workspace): the completion gate then refuses to end the turn
+until the batch you upload has a parse-feedback verdict (or you remove
+the marker because no upload happened).
 
 On any miss it screenshots and reports the step that failed — explore
 from the screenshot rather than blind-retrying.
@@ -26,12 +43,50 @@ HOST = os.environ['SC_HOST']
 PTYPE = os.environ['PRODUCT_TYPE']
 STORE = os.environ['STORE_LABEL']
 DL = os.path.expanduser(os.environ['DOWNLOADS_DIR'])
-out = {'ok': False, 'template': None, 'picked': None}
+MARKER_DIR = os.environ.get('MARKER_DIR', '.')
+out = {'ok': False, 'template': None, 'picked': None, 'stores': None}
 
 _WALK = (
     'function* w(r){for(const e of r.querySelectorAll("*")){yield e;'
     'if(e.shadowRoot) yield* w(e.shadowRoot);}}'
 )
+
+
+def _store_states():
+    """Read back every Amazon.* leaf checkbox: label, state, coords.
+
+    State comes from the component property OR the attribute —
+    whichever the kat build maintains — so a stale attribute can't
+    report a click that never took effect.
+    """
+    raw = js(
+        _WALK + 'const res=[];'
+        'for(const e of w(document)){'
+        'if((e.tagName||"").toLowerCase()!=="kat-checkbox") continue;'
+        'const lbl=(e.getAttribute("label")||e.textContent||"").trim();'
+        'if(!/^Amazon\\./i.test(lbl)) continue;'
+        'const on=(e.checked===true)||(e.hasAttribute("checked")&&'
+        'e.getAttribute("checked")!=="false");'
+        'const r=e.getBoundingClientRect();'
+        'res.push({label:lbl,on:on,x:Math.round(r.x+r.width/2),'
+        'y:Math.round(r.y+r.height/2)});}'
+        'return JSON.stringify(res);'
+    )
+    return json.loads(raw) if raw else []
+
+
+def _target_unticked():
+    """States list + the target entry when it still needs a tick.
+
+    Only the TARGET's tick is load-bearing: an unticked target stamps
+    the template for the wrong region. Extra ticked leaves are fine (a
+    bundled template routes by marketplace at fill time), so they are
+    reported but never fought.
+    """
+    states = _store_states()
+    tgt = next((s for s in states if s['label'].lower() == STORE.lower()), None)
+    needs_click = tgt if (tgt is not None and not tgt['on']) else None
+    return states, tgt, needs_click
 
 
 def _click_text(pattern):
@@ -115,25 +170,10 @@ else:
             out['picked'] = info.get('label')
             click_at_xy(info['box']['x'], info['box']['y'])
             time.sleep(4)
-            # Store checkboxes: tick the TARGET leaf, untick other
-            # Amazon.* leaves (never touch region parents like Europe —
-            # unticking a parent clears all its children).
-            js(
-                _WALK + 'for(const e of w(document)){'
-                'if((e.tagName||"").toLowerCase()!=="kat-checkbox")'
-                'continue;'
-                'const lbl=(e.getAttribute("label")||e.textContent||"")'
-                '.trim();'
-                'if(!/^Amazon\\./i.test(lbl)) continue;'
-                'const on=e.hasAttribute("checked")&&'
-                'e.getAttribute("checked")!=="false";'
-                f'const want=(lbl.toLowerCase()==="{STORE.lower()}");'
-                'if(want!==on) e.click();}'
-                'return "stores set";'
-            )
-            time.sleep(2)
-            # Generate sits low in the modal — extend the viewport so
-            # the trusted click lands.
+            # Extend the viewport BEFORE ticking: the store checkboxes
+            # and the Generate button sit low in the modal, and both the
+            # coordinate readback and the trusted clicks need on-screen
+            # coordinates.
             cdp(
                 'Emulation.setDeviceMetricsOverride',
                 width=1920,
@@ -142,7 +182,60 @@ else:
                 mobile=False,
             )
             time.sleep(1)
-            if not _click_text('^generate spreadsheet$'):
+            # Store checkboxes: make sure the TARGET leaf is ticked
+            # (never touch region parents like Europe — unticking a
+            # parent clears all its children; extra ticked leaves are
+            # fine, `fill` routes by marketplace). Fast path is a JS
+            # click; kat-checkbox often IGNORES it (shadow DOM), so the
+            # target's state is read back and retried with a trusted
+            # coordinate click. Never proceed on an unverified target
+            # tick — the template is region-stamped by these boxes.
+            js(
+                _WALK + 'for(const e of w(document)){'
+                'if((e.tagName||"").toLowerCase()!=="kat-checkbox")'
+                'continue;'
+                'const lbl=(e.getAttribute("label")||e.textContent||"")'
+                '.trim();'
+                f'if(lbl.toLowerCase()!=="{STORE.lower()}") continue;'
+                'const on=(e.checked===true)||(e.hasAttribute("checked")&&'
+                'e.getAttribute("checked")!=="false");'
+                'if(!on) e.click();}'
+                'return "stores set";'
+            )
+            time.sleep(2)
+            states, tgt, needs_click = _target_unticked()
+            for _attempt in range(2):
+                if not needs_click:
+                    break
+                click_at_xy(needs_click['x'], needs_click['y'])
+                time.sleep(1.5)
+                states, tgt, needs_click = _target_unticked()
+            out['stores'] = {s['label']: bool(s['on']) for s in states}
+            if not states:
+                _fail(
+                    'no Amazon.* store checkboxes found in the generator '
+                    'modal — the page layout changed; explore from the '
+                    'screenshot'
+                )
+            elif tgt is None:
+                _fail(
+                    f'target store {STORE!r} is not among the Amazon.* '
+                    'checkboxes (see "stores") — wrong STORE_LABEL '
+                    'spelling, or this account has no such storefront. '
+                    'Do NOT generate: the template would be '
+                    'region-stamped for a different marketplace.'
+                )
+            elif needs_click:
+                _fail(
+                    f'store tick UNVERIFIED: {STORE!r} is still NOT '
+                    'ticked after JS + trusted-click retries (see '
+                    '"stores" for the observed states). Do NOT generate '
+                    'from this state — the template would be '
+                    'region-stamped for the wrong marketplace. Tick it '
+                    'by hand (trusted click on the checkbox coords), '
+                    'verify, then re-run.'
+                )
+            elif not _click_text('^generate spreadsheet$'):
                 _fail('Generate Spreadsheet button not found')
             else:
                 template = None
@@ -163,4 +256,20 @@ else:
                         'Generate clicked but no new .xlsm landed in ' + DL
                     )
                     capture_screenshot()
+                else:
+                    # Arm the upload gate: a downloaded template means an
+                    # upload is intended this turn; the turn can't end
+                    # until the uploaded batch has a verdict (or the
+                    # agent removes this marker because no upload
+                    # happened). See stop_gates/listing_upload_gate.
+                    marker = os.path.join(MARKER_DIR, 'UPLOAD_PENDING.json')
+                    with open(marker, 'w') as fh:
+                        json.dump(
+                            {
+                                'template': template,
+                                'store': STORE,
+                                'host': HOST,
+                            },
+                            fh,
+                        )
                 print('RESULT ' + json.dumps(out))

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -115,11 +115,19 @@ from listing_schema import (  # noqa: E402, F401
     valid_value_case as _valid_value_case,
 )
 from marketplace_ids import (  # noqa: E402,F401
+    COUNTRY_BY_ID as _COUNTRY_BY_ID,
     MARKETPLACE_IDS,  # re-exported for callers/tests
     fulfillment_index as _fulfillment_index_for_marketplace,
     ids_in_template as _marketplace_ids_in_template,
     resolve as _resolve_marketplace_id,
 )
+
+
+def _mkt_label(mkt_id):
+    """'A2VIGQ35RCS4UG (AE)'-style label for messages."""
+    cc = _COUNTRY_BY_ID.get(mkt_id)
+    return f'{mkt_id} ({cc})' if cc else str(mkt_id)
+
 
 # Item Highlight (`title_differentiation`) is an OPTIONAL field Amazon only
 # accepts when the Item Name is <= 75 chars; a longer title makes Amazon
@@ -230,6 +238,15 @@ def cmd_inspect(args):
     data_row = _data_start_row(ws, header_row)
     print(f'template : {tt[:80]}')
     print(f'dialect  : {schema.dialect}')
+    mkts = _marketplace_ids_in_template(cols)
+    if mkts:
+        print(
+            'marketplaces: '
+            + ', '.join(_mkt_label(m) for m in mkts)
+            + '   <- the template is REGION-STAMPED for these; verify '
+            'this is the marketplace you intend to list on BEFORE '
+            'filling'
+        )
     print(f'sheets   : {wb.sheetnames}')
     print(f'header at Excel row {header_row}; data starts row {data_row}')
     print(f'total fields: {len(cols)}   required fields: {len(required)}')
@@ -361,10 +378,35 @@ def cmd_fill(args):
     # The offer price is per-marketplace; resolve the target once (CLI
     # --marketplace wins, else spec's top-level "marketplace", else the
     # template itself if it names exactly one marketplace).
-    mkt_id = _resolve_marketplace_id(
-        getattr(args, 'marketplace', None) or spec.get('marketplace'),
-        _marketplace_ids_in_template(cols),
-    )
+    template_ids = _marketplace_ids_in_template(cols)
+    requested = getattr(args, 'marketplace', None) or spec.get('marketplace')
+    mkt_id = _resolve_marketplace_id(requested, template_ids)
+    # Region-stamp guard. A template generated with the wrong store
+    # ticked is stamped for the wrong marketplace, and every later step
+    # then faithfully "succeeds" on the wrong storefront (observed
+    # live). Declaring the target makes that a hard error here; not
+    # declaring it on a single-stamped template auto-adopts the stamp,
+    # so say LOUDLY which marketplace is about to receive the listing.
+    if template_ids and requested and mkt_id not in template_ids:
+        raise SystemExit(
+            f'error: you are filling for {_mkt_label(mkt_id)} but this '
+            'template is region-stamped for '
+            + ', '.join(_mkt_label(m) for m in template_ids)
+            + ' — it has no offer columns for your target. The template '
+            'was generated with the wrong store ticked. Do NOT fill or '
+            'upload it; regenerate with the target store ticked '
+            '(bh_download_template verifies the tick) and fill that one.'
+        )
+    if template_ids and not requested and mkt_id:
+        print(
+            f'warning: no marketplace declared — auto-adopting the '
+            f"template's own stamp {_mkt_label(mkt_id)}. The listing "
+            'will land on THAT storefront; if that is not the intended '
+            'target, STOP and regenerate the template. Declare '
+            '--marketplace <CC> (or spec "marketplace") to make a '
+            'mismatch fail instead.',
+            file=sys.stderr,
+        )
 
     unknown_fields = set()
     warnings = []

--- a/app/skills_v2/amazon-listing/scripts/listing_bulk.py
+++ b/app/skills_v2/amazon-listing/scripts/listing_bulk.py
@@ -115,19 +115,13 @@ from listing_schema import (  # noqa: E402, F401
     valid_value_case as _valid_value_case,
 )
 from marketplace_ids import (  # noqa: E402,F401
-    COUNTRY_BY_ID as _COUNTRY_BY_ID,
     MARKETPLACE_IDS,  # re-exported for callers/tests
     fulfillment_index as _fulfillment_index_for_marketplace,
     ids_in_template as _marketplace_ids_in_template,
+    label as _mkt_label,
     resolve as _resolve_marketplace_id,
+    stamp_guard as _stamp_guard,
 )
-
-
-def _mkt_label(mkt_id):
-    """'A2VIGQ35RCS4UG (AE)'-style label for messages."""
-    cc = _COUNTRY_BY_ID.get(mkt_id)
-    return f'{mkt_id} ({cc})' if cc else str(mkt_id)
-
 
 # Item Highlight (`title_differentiation`) is an OPTIONAL field Amazon only
 # accepts when the Item Name is <= 75 chars; a longer title makes Amazon
@@ -240,13 +234,9 @@ def cmd_inspect(args):
     print(f'dialect  : {schema.dialect}')
     mkts = _marketplace_ids_in_template(cols)
     if mkts:
-        print(
-            'marketplaces: '
-            + ', '.join(_mkt_label(m) for m in mkts)
-            + '   <- the template is REGION-STAMPED for these; verify '
-            'this is the marketplace you intend to list on BEFORE '
-            'filling'
-        )
+        # The template is REGION-STAMPED for these — verify the target
+        # marketplace is among them BEFORE filling.
+        print('marketplaces: ' + ', '.join(_mkt_label(m) for m in mkts))
     print(f'sheets   : {wb.sheetnames}')
     print(f'header at Excel row {header_row}; data starts row {data_row}')
     print(f'total fields: {len(cols)}   required fields: {len(required)}')
@@ -381,32 +371,13 @@ def cmd_fill(args):
     template_ids = _marketplace_ids_in_template(cols)
     requested = getattr(args, 'marketplace', None) or spec.get('marketplace')
     mkt_id = _resolve_marketplace_id(requested, template_ids)
-    # Region-stamp guard. A template generated with the wrong store
-    # ticked is stamped for the wrong marketplace, and every later step
-    # then faithfully "succeeds" on the wrong storefront (observed
-    # live). Declaring the target makes that a hard error here; not
-    # declaring it on a single-stamped template auto-adopts the stamp,
-    # so say LOUDLY which marketplace is about to receive the listing.
-    if template_ids and requested and mkt_id not in template_ids:
-        raise SystemExit(
-            f'error: you are filling for {_mkt_label(mkt_id)} but this '
-            'template is region-stamped for '
-            + ', '.join(_mkt_label(m) for m in template_ids)
-            + ' — it has no offer columns for your target. The template '
-            'was generated with the wrong store ticked. Do NOT fill or '
-            'upload it; regenerate with the target store ticked '
-            '(bh_download_template verifies the tick) and fill that one.'
-        )
-    if template_ids and not requested and mkt_id:
-        print(
-            f'warning: no marketplace declared — auto-adopting the '
-            f"template's own stamp {_mkt_label(mkt_id)}. The listing "
-            'will land on THAT storefront; if that is not the intended '
-            'target, STOP and regenerate the template. Declare '
-            '--marketplace <CC> (or spec "marketplace") to make a '
-            'mismatch fail instead.',
-            file=sys.stderr,
-        )
+    # Region-stamp guard: hard-fail a declared-target mismatch; shout
+    # when auto-adopting a single stamp. See marketplace_ids.stamp_guard.
+    fatal, warn = _stamp_guard(requested, mkt_id, template_ids)
+    if fatal:
+        raise SystemExit(fatal)
+    if warn:
+        print(warn, file=sys.stderr)
 
     unknown_fields = set()
     warnings = []

--- a/app/skills_v2/amazon-listing/scripts/marketplace_ids.py
+++ b/app/skills_v2/amazon-listing/scripts/marketplace_ids.py
@@ -101,6 +101,48 @@ def ids_in_template(cols):
     return ids
 
 
+def label(mkt_id):
+    """'A2VIGQ35RCS4UG (AE)'-style label for messages."""
+    cc = COUNTRY_BY_ID.get(mkt_id)
+    return f'{mkt_id} ({cc})' if cc else str(mkt_id)
+
+
+def stamp_guard(requested, mkt_id, template_ids):
+    """Region-stamp guard for ``fill`` → ``(fatal, warning)`` strings.
+
+    A template generated with the wrong store ticked is stamped for the
+    wrong marketplace, and every later step then faithfully "succeeds"
+    on the wrong storefront (observed live). Declaring the target makes
+    that a hard error (*fatal*); not declaring it on a single-stamped
+    template auto-adopts the stamp, so *warning* says LOUDLY which
+    marketplace is about to receive the listing.
+    """
+    if not template_ids:
+        return None, None
+    stamped = ', '.join(label(m) for m in template_ids)
+    if requested and mkt_id not in template_ids:
+        return (
+            f'error: you are filling for {label(mkt_id)} but this '
+            f'template is region-stamped for {stamped} — it has no '
+            'offer columns for your target. The template was generated '
+            'with the wrong store ticked. Do NOT fill or upload it; '
+            'regenerate with the target store ticked '
+            '(bh_download_template verifies the tick) and fill that '
+            'one.',
+            None,
+        )
+    if not requested and mkt_id:
+        return None, (
+            'warning: no marketplace declared — auto-adopting the '
+            f"template's own stamp {label(mkt_id)}. The listing will "
+            'land on THAT storefront; if that is not the intended '
+            'target, STOP and regenerate the template. Declare '
+            '--marketplace <CC> (or spec "marketplace") to make a '
+            'mismatch fail instead.'
+        )
+    return None, None
+
+
 def resolve(marketplace, template_ids=None):
     """Country code ('SA') / raw id / template auto-detect -> marketplace id.
 

--- a/app/skills_v2/amazon-reports/SKILL.md
+++ b/app/skills_v2/amazon-reports/SKILL.md
@@ -1173,11 +1173,15 @@ into each country's folder yourself:
 
 ```python
 import pandas as pd
+
 df = pd.read_csv('unified_advertised_product.csv')
 col = [c for c in df.columns if '站点' in c or 'marketplace' in c.lower()][0]
-for mkt, sub in df.groupby(col):        # AMAZON_SA / AMAZON_AE / AMAZON_AU
-    cc = mkt.split('_')[-1].lower()      # sa / ae / au
-    sub.to_csv(f'reports_{{MM}}_{cc}_{{slug}}/Sponsored_Products_Advertised_product_report_{{Mon}}.csv', index=False)
+for mkt, sub in df.groupby(col):  # AMAZON_SA / AMAZON_AE / AMAZON_AU
+    cc = mkt.split('_')[-1].lower()  # sa / ae / au
+    sub.to_csv(
+        f'reports_{{MM}}_{cc}_{{slug}}/Sponsored_Products_Advertised_product_report_{{Mon}}.csv',
+        index=False,
+    )
 ```
 
 **Verify content, not just that a file exists:** after splitting, confirm

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -88,7 +88,7 @@ wait_for_load()  # wait for navigation/network to settle
 ensure_real_tab()  # switch off a stale/internal (chrome://) tab
 js('<javascript>')  # run JS; returns the SERIALIZABLE result only
 cdp('Domain.method', **params)  # raw CDP — params are KEYWORDS, not a dict
-                                # e.g. cdp('Page.navigate', url='...')
+# e.g. cdp('Page.navigate', url='...')
 ```
 
 - **`js()` returns serializable values only.** `js("document.title")` and

--- a/app/task_runner_followup.py
+++ b/app/task_runner_followup.py
@@ -107,6 +107,12 @@ async def spawn_followup_agent(
                 # captured any learnings; conversational turns have
                 # nothing new to learn from.
                 skip_reflection=True,
+                # The conversation router already persisted the user's
+                # message before spawning us — persisting the prompt
+                # again in AgentSession.start() duplicated every
+                # follow-up message (fresh-session and dead-session
+                # resume paths both start with empty message_history).
+                persist_prompt=False,
             )
     except Exception:
         logger.exception(

--- a/docs/skill-review-mechanism.md
+++ b/docs/skill-review-mechanism.md
@@ -77,14 +77,23 @@ for anything structurally verifiable:
   compaction-clobber regression). *This is what an LLM judge cannot
   reproduce and must not replace.*
 - `listing_submitted` — **implemented as the batch-marker gate**
-  (`stop_gates/listing_upload_gate.py`): the upload helper
+  (`stop_gates/listing_upload_gate.py`): the download helper
+  (`amazon-listing/scripts/bh_download_template.py`) writes an
+  `UPLOAD_PENDING.json` marker when a template lands (an upload is now
+  intended this turn), the upload helper
   (`amazon-listing/scripts/bh_upload_flatfile.py`) records every
   submitted batch as an `UPLOAD_BATCH_<id>.json` marker in the task
   workspace, and `listing_bulk.py parse-feedback --batch-id <id>` writes
   the matching `BATCH_<id>_VERDICT.json` after reading THAT batch's
   processing report. Completion is denied until every marker has a
   verdict and the **latest** batch has zero non-image errors (earlier
-  batches are immutable history a later upload supersedes). Freshness is
+  batches are immutable history a later upload supersedes); "latest"
+  ranges over marker AND verdict-only ids, so a batch uploaded BY HAND
+  (the upload helper failed, the agent fell back to manual clicking —
+  no batch marker exists) is judged too, and the pending marker keeps
+  the gate armed for exactly that fallback: pending with no batch
+  activity at all denies until the agent verdicts the batch it uploaded
+  or deletes the marker because no upload happened. Freshness is
   keyed to the batch id the upload actually produced — a reviewer can't
   pass the turn on a stale report. Markers/verdicts roll over with the
   review files at each new turn (`rollover_reviews`). ("Uploaded?"
@@ -105,12 +114,25 @@ against reality**, then loops until the bar is met. "Did the ads get
 fully drilled?" / "Did the listing actually get created and succeed?" are
 answered by **going and looking**, not by reading the writer's prose.
 
-- **Verdict authorship is enforced, not assumed.** The stream marks the
-  session when it observes a review/verify `Agent`/`Task` subagent spawn
-  (a tool_use the main agent cannot fabricate); `reviewer_verdict`
-  rejects an accepting `Status: ok`/terminal-`incomplete` verdict when
-  no reviewer subagent ran this turn — a verdict the writer wrote itself
-  does not count (`subagent_ran` in `stop_gates/report_reviewer.py`).
+- **Verdict authorship is enforced, not assumed.** The stream attributes
+  every review-file `Write`/`Edit` to `subagent` or `main` via the
+  event's `parent_tool_use_id` (a signal the main agent cannot
+  fabricate); `reviewer_verdict` rejects an accepting `Status:
+  ok`/terminal-`incomplete` verdict unless the reviewer subagent itself
+  wrote the file (`review_writers` in `stop_gates/report_reviewer.py`;
+  the spawn-time `subagent_ran` flag remains as the fallback signal for
+  backends without stream attribution). Spawn-time alone was bypassed
+  live: the main agent self-wrote `ok`, was denied, LAUNCHED an async
+  reviewer — flipping the spawn flag — and stopped before the reviewer
+  wrote anything.
+- **A turn cannot end under a running subagent.** The CLI emits its
+  `result` as soon as the MAIN agent stops; async subagents keep
+  running, and closing stdin then default-denies their remaining tool
+  calls. The stream tracks async-agent launches (`Async agent launched`
+  ack) and completions (`<task-notification>`), and both the Stop hook
+  and the result path re-drive the agent while any launched subagent is
+  still running — bounded by the same redrive budget, failing open with
+  the UNVERIFIED banner so a lost notification can't wedge the turn.
 - **Agent-spawned reviewer subagent with browser + tool access.** It runs
   in the task context (so it can drive the store's Ziniao `browser-use`
   wrapper and MCP tools) but in a **separate, adversarial context** whose

--- a/tests/unit/test_agent_loop.py
+++ b/tests/unit/test_agent_loop.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-import app.ai.claude_backend as _mod
-from app.ai.claude_backend import AgentSession
+import app.ai.claude_backend_utils as _mod
+from app.ai.claude_backend_utils import check_tool_loop
 
 pytestmark = pytest.mark.unit
 
@@ -17,59 +17,56 @@ def _pin_threshold(monkeypatch):
 
 
 class TestCheckToolLoop:
-    def _make_session(self):
-        return AgentSession(
-            task_id='test-task',
-            prompt='test',
-            mode='execute',
-        )
+    """check_tool_loop mutates the session's rolling window in place —
+    each test uses its own list, mirroring
+    ``AgentSession._recent_tool_calls``."""
 
     def test_no_loop_below_threshold(self):
         """5 identical calls (below 6) → no loop."""
-        s = self._make_session()
+        recent = []
         for _ in range(THRESHOLD - 1):
-            assert s._check_tool_loop('Bash', {'command': ':0'}) is False
+            assert check_tool_loop(recent, 'Bash', {'command': ':0'}) is False
 
     def test_loop_at_threshold(self):
         """6 identical calls → loop detected."""
-        s = self._make_session()
+        recent = []
         for _ in range(THRESHOLD - 1):
-            s._check_tool_loop('Bash', {'command': ':0'})
-        assert s._check_tool_loop('Bash', {'command': ':0'}) is True
+            check_tool_loop(recent, 'Bash', {'command': ':0'})
+        assert check_tool_loop(recent, 'Bash', {'command': ':0'}) is True
 
     def test_different_call_resets(self):
         """5 identical + 1 different → no loop."""
-        s = self._make_session()
+        recent = []
         for _ in range(THRESHOLD - 1):
-            s._check_tool_loop('Bash', {'command': ':0'})
+            check_tool_loop(recent, 'Bash', {'command': ':0'})
         # Different call breaks the streak
-        assert s._check_tool_loop('Read', {'file': 'x'}) is False
+        assert check_tool_loop(recent, 'Read', {'file': 'x'}) is False
 
     def test_loop_after_different_calls(self):
         """Different calls then 6 identical → loop."""
-        s = self._make_session()
-        s._check_tool_loop('Read', {'file': 'a'})
-        s._check_tool_loop('Write', {'file': 'b'})
+        recent = []
+        check_tool_loop(recent, 'Read', {'file': 'a'})
+        check_tool_loop(recent, 'Write', {'file': 'b'})
         for _ in range(THRESHOLD - 1):
-            s._check_tool_loop('Bash', {'command': ':0'})
-        assert s._check_tool_loop('Bash', {'command': ':0'}) is True
+            check_tool_loop(recent, 'Bash', {'command': ':0'})
+        assert check_tool_loop(recent, 'Bash', {'command': ':0'}) is True
 
     def test_different_inputs_no_loop(self):
         """Same tool, different inputs → no loop."""
-        s = self._make_session()
+        recent = []
         for i in range(10):
-            result = s._check_tool_loop('Bash', {'command': f'cmd{i}'})
+            result = check_tool_loop(recent, 'Bash', {'command': f'cmd{i}'})
             assert result is False
 
     def test_window_slides(self):
         """After a streak is broken by a different call,
         need a full new streak to trigger again."""
-        s = self._make_session()
+        recent = []
         # Build up streak but break it with a different call
         for _ in range(THRESHOLD - 1):
-            s._check_tool_loop('Bash', {'command': ':0'})
-        s._check_tool_loop('Read', {'file': 'x'})  # breaks streak
+            check_tool_loop(recent, 'Bash', {'command': ':0'})
+        check_tool_loop(recent, 'Read', {'file': 'x'})  # breaks streak
         # Now need a full new streak of Write calls
         for _ in range(THRESHOLD - 1):
-            assert s._check_tool_loop('Write', {'f': '0'}) is False
-        assert s._check_tool_loop('Write', {'f': '0'}) is True
+            assert check_tool_loop(recent, 'Write', {'f': '0'}) is False
+        assert check_tool_loop(recent, 'Write', {'f': '0'}) is True

--- a/tests/unit/test_amazon_listing_bulk_skill.py
+++ b/tests/unit/test_amazon_listing_bulk_skill.py
@@ -1358,3 +1358,99 @@ class TestReviewContractTargetMarketplace:
         # A listing on the wrong marketplace / only a batch id must not pass.
         assert 'gap' in text
         assert 'wrong marketplace' in text or 'different marketplace' in text
+
+
+# --- region-stamp guard (wrong-marketplace template must not fill) ---
+
+
+def test_fill_hard_fails_on_wrong_region_template(mkt_template, tmp_path):
+    # The live incident: the store tick silently failed, the template
+    # came back stamped for a different marketplace, and the upload
+    # then "succeeded" on the wrong storefront. Declaring the target
+    # must make that a hard error at fill time.
+    spec = _spec(
+        tmp_path,
+        {
+            'marketplace': 'EG',  # not stamped in this SA+AE template
+            'product_type': 'socks',
+            'rows': [
+                {
+                    'sku': 'K-WHT',
+                    'parentage': 'Child',
+                    'fields': {
+                        'item_name': 'x',
+                        'feed_product_type': 'socks',
+                    },
+                }
+            ],
+        },
+    )
+    out = str(tmp_path / 'out.xlsx')
+    with pytest.raises(SystemExit) as e:
+        _run(['fill', mkt_template, '--spec', spec, '--out', out])
+    msg = str(e.value)
+    assert 'region-stamped' in msg and 'regenerate' in msg
+
+
+def test_fill_cli_marketplace_flag_also_guarded(mkt_template, tmp_path):
+    spec = _spec(
+        tmp_path,
+        {
+            'product_type': 'socks',
+            'rows': [
+                {
+                    'sku': 'K-WHT',
+                    'parentage': 'Child',
+                    'fields': {
+                        'item_name': 'x',
+                        'feed_product_type': 'socks',
+                    },
+                }
+            ],
+        },
+    )
+    out = str(tmp_path / 'out.xlsx')
+    with pytest.raises(SystemExit) as e:
+        _run([
+            'fill',
+            mkt_template,
+            '--spec',
+            spec,
+            '--out',
+            out,
+            '--marketplace',
+            'EG',
+        ])
+    assert 'region-stamped' in str(e.value)
+
+
+def test_fill_auto_adopt_single_stamp_warns_loudly(template, tmp_path, capsys):
+    # No declared marketplace + single-stamped template: auto-adopt is
+    # kept (legacy flows), but the adopted storefront must be shouted.
+    spec = _spec(
+        tmp_path,
+        {
+            'product_type': 'socks',
+            'brand': 'acme',
+            'rows': [
+                {
+                    'sku': 'K-WHT',
+                    'fields': {
+                        'item_name': 'x',
+                        'feed_product_type': 'socks',
+                    },
+                }
+            ],
+        },
+    )
+    out = str(tmp_path / 'out.xlsx')
+    _run(['fill', template, '--spec', spec, '--out', out])
+    err = capsys.readouterr().err
+    assert 'auto-adopting' in err and 'MKTSA' in err
+
+
+def test_inspect_prints_region_stamp(mkt_template, capsys):
+    _run(['inspect', mkt_template])
+    out = capsys.readouterr().out
+    assert 'marketplaces:' in out
+    assert 'A17E79C6D8DWNP (SA)' in out and 'A2VIGQ35RCS4UG (AE)' in out

--- a/tests/unit/test_followup_persist_prompt.py
+++ b/tests/unit/test_followup_persist_prompt.py
@@ -1,0 +1,69 @@
+"""Follow-up user messages must be persisted exactly once.
+
+The conversation router saves the user's message before spawning the
+agent; ``AgentSession.start()`` ALSO persisted ``self.prompt`` whenever
+``message_history`` was empty — which is exactly the state on the
+fresh-session and dead-session-resume follow-up paths, so every
+follow-up message landed in ``task_messages`` twice (observed live:
+identical user rows ~100ms apart). Ownership is now explicit:
+``persist_prompt=False`` on every spawn whose prompt is already in the
+DB (follow-ups, retries); True only for initial runs.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.ai.claude_backend import AgentSession
+import app.task_runner_followup as followup_mod
+from app.task_states import TaskStatus
+
+pytestmark = pytest.mark.unit
+
+
+class _CaptureManager:
+    def __init__(self):
+        self.calls = []
+
+    async def run(self, task_id, prompt, **kwargs):
+        self.calls.append((task_id, prompt, kwargs))
+        return True
+
+
+async def _noop_finalize(*_a, **_k):
+    return None
+
+
+async def test_spawn_followup_agent_does_not_repersist_prompt():
+    mgr = _CaptureManager()
+    with (
+        patch.object(followup_mod, 'agent_manager', mgr),
+        patch.object(
+            followup_mod, 'assert_profile_compatible', lambda _pid: None
+        ),
+        patch.object(followup_mod, 'finalize_followup_session', _noop_finalize),
+    ):
+        await followup_mod.spawn_followup_agent(
+            'task-1',
+            None,
+            prompt='please also do the other thing',
+            system_extra='',
+            mode='auto',
+            profile_id='default',
+            auto_approve_plan=False,
+            revert_status=TaskStatus.COMPLETED,
+            resume=False,
+        )
+    assert len(mgr.calls) == 1
+    _tid, _prompt, kwargs = mgr.calls[0]
+    assert kwargs.get('persist_prompt') is False
+
+
+def test_agent_session_persist_prompt_default_true():
+    s = AgentSession('t', 'p')
+    assert s.persist_prompt is True
+
+
+def test_agent_session_persist_prompt_stored():
+    s = AgentSession('t', 'p', persist_prompt=False)
+    assert s.persist_prompt is False

--- a/tests/unit/test_handle_event_result.py
+++ b/tests/unit/test_handle_event_result.py
@@ -494,3 +494,303 @@ class TestHandleEventReflectionGuard:
         assert session._result_text == ''
         # Always cleared so a later turn does not adopt stale state.
         assert session._pre_reflection_result is None
+
+
+class TestAsyncAgentTurnHold:
+    """A `result` while async subagents launched this turn are still
+    running must NOT end the turn — the CLI emits its result as soon as
+    the MAIN agent stops, and closing stdin then default-denies every
+    remaining subagent tool call (observed live: a DoD reviewer died
+    mid-verification while the shipped result claimed it was 'running
+    in the background')."""
+
+    def _spawn_async_agent(self, session, agent_id='agent-abc123'):
+        """Feed the spawn tool_use + async launch ack into the stream."""
+        return [
+            {
+                'type': 'assistant',
+                'parent_tool_use_id': None,
+                'message': {
+                    'content': [
+                        {
+                            'type': 'tool_use',
+                            'id': 'toolu_spawn1',
+                            'name': 'Agent',
+                            'input': {'prompt': 'DoD review the upload'},
+                        }
+                    ]
+                },
+            },
+            {
+                'type': 'user',
+                'parent_tool_use_id': None,
+                'message': {
+                    'content': [
+                        {
+                            'type': 'tool_result',
+                            'tool_use_id': 'toolu_spawn1',
+                            'content': (
+                                'Async agent launched successfully. '
+                                '(internal metadata)\n'
+                                f'agentId: {agent_id}'
+                            ),
+                        }
+                    ]
+                },
+            },
+        ]
+
+    async def test_result_with_running_async_agent_redrives(self):
+        session = _make_session('auto')
+        session.task_dir = '/tmp/fake-task'
+        emitted, sent = [], []
+
+        async def _mock_emit(role, content):
+            emitted.append((role, content))
+
+        async def _mock_send(msg):
+            sent.append(msg)
+
+        with (
+            patch.object(session, '_emit_message', _mock_emit),
+            patch.object(session, 'send_user_message', _mock_send),
+            patch(
+                'app.ai.claude_backend_stream.check_review_status_for_stop',
+                return_value=None,
+            ),
+            patch(
+                'app.ai.claude_backend_stream'
+                '.check_exec_review_status_for_stop',
+                return_value=None,
+            ),
+        ):
+            for ev in self._spawn_async_agent(session):
+                await session._handle_event(ev)
+            await session._handle_event({
+                'type': 'result',
+                'result': 'reviewer is running in the background',
+            })
+
+        assert session._first_result_emitted is False
+        assert len(sent) == 1 and 'still running' in sent[0]
+        assert session._review_redrive_count == 1
+
+    async def test_sync_spawn_does_not_hold_turn(self):
+        # A sync Task tool blocks the main agent; its tool_result is the
+        # subagent's ANSWER, not a launch ack — no turn hold.
+        session = _make_session('auto')
+        session.task_dir = '/tmp/fake-task'
+
+        async def _noop(*a, **k):
+            pass
+
+        with (
+            patch.object(session, '_emit_message', _noop),
+            patch(
+                'app.ai.claude_backend_stream.check_review_status_for_stop',
+                return_value=None,
+            ),
+            patch(
+                'app.ai.claude_backend_stream'
+                '.check_exec_review_status_for_stop',
+                return_value=None,
+            ),
+        ):
+            events = self._spawn_async_agent(session)
+            events[1]['message']['content'][0]['content'] = (
+                'Review complete: Status ok, verdict written.'
+            )
+            for ev in events:
+                await session._handle_event(ev)
+            await session._handle_event({
+                'type': 'result',
+                'result': 'done',
+            })
+
+        assert session._async_agents == {}
+        assert session._first_result_emitted is True
+
+    async def test_task_notification_releases_turn(self):
+        session = _make_session('auto')
+        session.task_dir = '/tmp/fake-task'
+
+        async def _noop(*a, **k):
+            pass
+
+        with (
+            patch.object(session, '_emit_message', _noop),
+            patch(
+                'app.ai.claude_backend_stream.check_review_status_for_stop',
+                return_value=None,
+            ),
+            patch(
+                'app.ai.claude_backend_stream'
+                '.check_exec_review_status_for_stop',
+                return_value=None,
+            ),
+        ):
+            for ev in self._spawn_async_agent(session):
+                await session._handle_event(ev)
+            assert session._async_agents
+            await session._handle_event({
+                'type': 'user',
+                'message': {
+                    'content': [
+                        {
+                            'type': 'text',
+                            'text': (
+                                '<task-notification tool-use-id='
+                                '"toolu_spawn1" status="completed">'
+                                'done</task-notification>'
+                            ),
+                        }
+                    ]
+                },
+            })
+            assert session._async_agents == {}
+            await session._handle_event({
+                'type': 'result',
+                'result': 'final answer',
+            })
+
+        assert session._first_result_emitted is True
+
+    async def test_unattributable_notification_fails_open(self):
+        # A notification whose ids we can't match must clear the set —
+        # a format change may never wedge the turn forever.
+        session = _make_session('auto')
+
+        async def _noop(*a, **k):
+            pass
+
+        with patch.object(session, '_emit_message', _noop):
+            for ev in self._spawn_async_agent(session):
+                await session._handle_event(ev)
+            assert session._async_agents
+            await session._handle_event({
+                'type': 'user',
+                'message': {
+                    'content': [
+                        {
+                            'type': 'text',
+                            'text': '<task-notification>done</task-notification>',
+                        }
+                    ]
+                },
+            })
+        assert session._async_agents == {}
+
+    async def test_notification_by_agent_id_matches(self):
+        session = _make_session('auto')
+
+        async def _noop(*a, **k):
+            pass
+
+        with patch.object(session, '_emit_message', _noop):
+            for ev in self._spawn_async_agent(session, agent_id='ag-77'):
+                await session._handle_event(ev)
+            await session._handle_event({
+                'type': 'user',
+                'message': {
+                    'content': [
+                        {
+                            'type': 'text',
+                            'text': (
+                                '<task-notification agent-id="ag-77">'
+                                'finished</task-notification>'
+                            ),
+                        }
+                    ]
+                },
+            })
+        assert session._async_agents == {}
+
+
+class TestReviewFileAuthorshipTracking:
+    """The stream attributes each review-file Write/Edit to 'subagent'
+    or 'main' via the event's parent_tool_use_id — the signal the gates
+    use to reject a self-written accepting verdict."""
+
+    def _write_event(self, parent, path='REVIEW_2026-07-20_iter1.md'):
+        return {
+            'type': 'assistant',
+            'parent_tool_use_id': parent,
+            'message': {
+                'content': [
+                    {
+                        'type': 'tool_use',
+                        'id': 'toolu_w1',
+                        'name': 'Write',
+                        'input': {'file_path': f'/ws/{path}'},
+                    }
+                ]
+            },
+        }
+
+    async def test_main_write_recorded_as_main(self):
+        session = _make_session('auto')
+
+        async def _noop(*a, **k):
+            pass
+
+        with patch.object(session, '_emit_message', _noop):
+            await session._handle_event(self._write_event(None))
+        assert session._review_file_writers == {
+            'REVIEW_2026-07-20_iter1.md': 'main'
+        }
+
+    async def test_subagent_write_recorded_as_subagent(self):
+        session = _make_session('auto')
+
+        async def _noop(*a, **k):
+            pass
+
+        with patch.object(session, '_emit_message', _noop):
+            await session._handle_event(self._write_event('toolu_parent9'))
+        assert session._review_file_writers == {
+            'REVIEW_2026-07-20_iter1.md': 'subagent'
+        }
+
+    async def test_main_overwrite_after_subagent_downgrades(self):
+        # Last writer wins: a main-agent rewrite of the reviewer's file
+        # must not keep the 'subagent' attribution.
+        session = _make_session('auto')
+
+        async def _noop(*a, **k):
+            pass
+
+        with patch.object(session, '_emit_message', _noop):
+            await session._handle_event(self._write_event('toolu_parent9'))
+            await session._handle_event(self._write_event(None))
+        assert session._review_file_writers == {
+            'REVIEW_2026-07-20_iter1.md': 'main'
+        }
+
+    async def test_non_review_files_not_tracked(self):
+        session = _make_session('auto')
+
+        async def _noop(*a, **k):
+            pass
+
+        with patch.object(session, '_emit_message', _noop):
+            await session._handle_event(
+                self._write_event(None, path='PREVIEW.md')
+            )
+            await session._handle_event(
+                self._write_event(None, path='notes.txt')
+            )
+        assert session._review_file_writers == {}
+
+    async def test_exec_review_tracked_too(self):
+        session = _make_session('auto')
+
+        async def _noop(*a, **k):
+            pass
+
+        with patch.object(session, '_emit_message', _noop):
+            await session._handle_event(
+                self._write_event(None, path='EXEC_REVIEW_2026-07-20_iter1.md')
+            )
+        assert session._review_file_writers == {
+            'EXEC_REVIEW_2026-07-20_iter1.md': 'main'
+        }

--- a/tests/unit/test_listing_upload_gate.py
+++ b/tests/unit/test_listing_upload_gate.py
@@ -91,3 +91,60 @@ class TestUploadVerdictGate:
         assert not list(tmp_path.glob('UPLOAD_BATCH_*.json'))
         moved = list(tmp_path.glob('.prev_turns/turn_*/UPLOAD_BATCH_*'))
         assert moved
+
+
+def _pending(d):
+    (d / 'UPLOAD_PENDING.json').write_text(
+        json.dumps({'template': 'WIDGETS.xlsm', 'store': 'Amazon.sa'}),
+        encoding='utf-8',
+    )
+
+
+class TestPendingMarkerArming:
+    """The template-download marker arms the gate even when the upload
+    helper failed and the agent submitted by hand (no batch marker) —
+    the observed bypass that let an unverified manual upload finish."""
+
+    def test_pending_without_any_batch_denies(self, tmp_path):
+        _pending(tmp_path)
+        deny = check_upload_verdicts(tmp_path)
+        assert deny is not None
+        assert 'parse-feedback' in deny and 'UPLOAD_PENDING' in deny
+
+    def test_pending_with_clean_verdict_only_passes(self, tmp_path):
+        # Manual upload: no UPLOAD_BATCH marker, but the agent fetched
+        # the report and verdicted the batch — satisfied.
+        _pending(tmp_path)
+        _verdict(tmp_path, '100000000001', non_image=0)
+        assert check_upload_verdicts(tmp_path) is None
+
+    def test_pending_with_failed_verdict_only_denies(self, tmp_path):
+        # Manual upload whose report shows errors must still block —
+        # "latest batch clean" ranges over verdict-only ids too.
+        _pending(tmp_path)
+        _verdict(tmp_path, '100000000001', non_image=4)
+        deny = check_upload_verdicts(tmp_path)
+        assert deny is not None and '4 unresolved' in deny
+
+    def test_verdict_only_latest_judged_without_pending(self, tmp_path):
+        # Even with no pending marker, a verdict-only batch (manual
+        # upload, manually verdicted) is judged for cleanliness.
+        _verdict(tmp_path, '100000000002', non_image=1)
+        deny = check_upload_verdicts(tmp_path)
+        assert deny is not None and '100000000002' in deny
+
+    def test_pending_removed_disarms(self, tmp_path):
+        # The sanctioned no-upload exit: delete the marker.
+        _pending(tmp_path)
+        (tmp_path / 'UPLOAD_PENDING.json').unlink()
+        assert check_upload_verdicts(tmp_path) is None
+
+    def test_rollover_moves_pending(self, tmp_path):
+        # A next-turn follow-up must not inherit this turn's pending
+        # marker (it would demand a verdict for an upload that turn
+        # never made).
+        _pending(tmp_path)
+        rollover_reviews(tmp_path)
+        assert check_upload_verdicts(tmp_path) is None
+        assert not list(tmp_path.glob('UPLOAD_PENDING*.json'))
+        assert list(tmp_path.glob('.prev_turns/turn_*/UPLOAD_PENDING*'))

--- a/tests/unit/test_review_stop_gate.py
+++ b/tests/unit/test_review_stop_gate.py
@@ -163,6 +163,65 @@ class TestReviewStopGate:
         assert check_review_status(tmp_path) is None
         assert check_review_status(tmp_path, subagent_ran=None) is None
 
+    def test_launch_and_stop_bypass_denied_by_authorship(
+        self, tmp_path, monkeypatch
+    ):
+        # The observed live bypass: the main agent self-writes an ok
+        # verdict, gets denied (subagent_ran=False), LAUNCHES an async
+        # reviewer — which flips subagent_ran=True at spawn time — and
+        # stops before the reviewer writes anything. With the authorship
+        # map supplied, the on-disk verdict is attributed to 'main' and
+        # must still be rejected even though a subagent "ran".
+        self._ok_review_task(tmp_path, monkeypatch)
+        deny = check_review_status(
+            tmp_path,
+            subagent_ran=True,
+            review_writers={'REVIEW_2026-07-09_iter1.md': 'main'},
+        )
+        assert deny is not None and 'not' in deny and 'subagent' in deny
+
+    def test_subagent_written_verdict_accepted(self, tmp_path, monkeypatch):
+        # Same on-disk verdict, but the stream attributed the Write to a
+        # subagent (parent_tool_use_id was set) → accept.
+        self._ok_review_task(tmp_path, monkeypatch)
+        assert (
+            check_review_status(
+                tmp_path,
+                subagent_ran=True,
+                review_writers={'REVIEW_2026-07-09_iter1.md': 'subagent'},
+            )
+            is None
+        )
+
+    def test_unattributed_verdict_denied_when_writers_supplied(
+        self, tmp_path, monkeypatch
+    ):
+        # Writers map supplied but the file isn't in it (e.g. written
+        # via a bash heredoc to dodge Write tracking) → fail closed;
+        # the deny tells the agent the reviewer must write it itself.
+        self._ok_review_task(tmp_path, monkeypatch)
+        deny = check_review_status(
+            tmp_path, subagent_ran=True, review_writers={}
+        )
+        assert deny is not None and 'subagent' in deny
+
+    def test_gaps_verdict_authorship_irrelevant(self, tmp_path, monkeypatch):
+        # Authorship only guards ACCEPTING verdicts — a main-written
+        # 'gaps' still denies on its own content, not on authorship.
+        monkeypatch.setattr(
+            'app.ai.bash_safety.recorded_skills',
+            lambda _tid: {'amazon-ads'},
+        )
+        (tmp_path / 'REVIEW_2026-07-09_iter1.md').write_text(
+            '# Review\nStatus: gaps\n', encoding='utf-8'
+        )
+        deny = check_review_status(
+            tmp_path,
+            subagent_ran=True,
+            review_writers={'REVIEW_2026-07-09_iter1.md': 'main'},
+        )
+        assert deny is not None and 'gaps' in deny
+
     def test_review_file_nonstandard_name_accepted(self, tmp_path, monkeypatch):
         # A weak model may name the review file <PRODUCT>_REVIEW_<date>.md
         # instead of REVIEW_<date>_iter<N>.md. As long as it has a Status

--- a/tests/workflow/conftest.py
+++ b/tests/workflow/conftest.py
@@ -148,6 +148,7 @@ def install_fake_agent(fake_agent, monkeypatch):
         'app.ai.claude_backend_manager.agent_backend', fake_agent
     )
     monkeypatch.setattr('app.routers.tasks.agent_manager', fake_agent)
+    monkeypatch.setattr('app.routers.tasks_files.agent_manager', fake_agent)
     monkeypatch.setattr(
         'app.routers.tasks_conversation.agent_manager', fake_agent
     )

--- a/tests/workflow/fake_agent.py
+++ b/tests/workflow/fake_agent.py
@@ -203,6 +203,7 @@ class FakeAgent(AIAgentBackend):
         store_slug: str | None = None,
         on_start=None,
         skip_reflection: bool = False,
+        persist_prompt: bool = True,
     ) -> bool:
         if self._running.get(task_id):
             return False


### PR DESCRIPTION
## Root cause (live incident)

A follow-up turn ended at 16:54 with the result *"the DoD review
subagent is running in the background — I'll report when it finishes"*
while (a) the reviewer was still mid-verification and every one of its
remaining tool calls got default-denied the moment stdin closed, and
(b) the listing had actually landed on the **wrong marketplace**
because the template generator's store tick silently failed. The
gates from #77–#80 all fired — and were routed around through four
residual holes. This PR closes them at the design level (vibe-kanban's
executor was used as the reference: it never closes the control
channel at the first result event; the turn ends only when the process
— including its subagents — is done).

## Fixes

1. **Reviewer-spawn ≠ reviewer-verdict.** `_review_subagent_ran`
   flipped at *spawn* time, so *self-write `Status: ok` → get denied →
   launch an async reviewer → stop* passed the gate on the self-written
   file. The stream now attributes every review-file Write/Edit to
   `subagent`/`main` via the event's `parent_tool_use_id`; all three
   completion paths (Stop hook, result re-drive, `set_task_result`)
   accept an accepting verdict only when the reviewer subagent itself
   wrote the file. Spawn-time flag stays as fallback for backends
   without stream attribution.

2. **A turn cannot end under a running async subagent.** The CLI emits
   its `result` when the *main* agent stops; background agents keep
   running. The stream tracks `Async agent launched` acks and
   `<task-notification>` completions; Stop hook + result path re-drive
   while any launched subagent is still running — bounded by the
   existing redrive budget, failing open with the UNVERIFIED banner so
   a lost notification can never wedge a turn.

3. **Verified store tick + region-stamp hard-fail.**
   `bh_download_template` read nothing back after its JS clicks
   (kat-checkbox routinely ignores them) and reported `ok: true` on an
   untick — producing a template stamped for the account's home
   marketplace. It now reads the checkbox states back, retries the
   target with a trusted coordinate click, returns the observed
   `stores` map, and refuses to generate when the target isn't ticked.
   `listing_bulk.py inspect` prints the region stamp; `fill` hard-fails
   when the declared marketplace has no offer columns in the template,
   and warns loudly when auto-adopting a single stamp. The upload gate
   additionally arms at template download (`UPLOAD_PENDING.json`), so
   a *manual* upload after a helper failure can no longer finish
   unverified; latest-batch-clean now ranges over verdict-only
   (manual) batches too.

4. **Follow-up user messages persisted exactly once.** The router
   persists the message; `AgentSession.start()` persisted the prompt
   again whenever `message_history` was empty — exactly the
   fresh-session (#80) and dead-session-resume states, duplicating
   every follow-up row. Ownership is now explicit (`persist_prompt`),
   False for follow-up spawns and retries.

## Tests

- `test_review_stop_gate.py`: launch-and-stop bypass denied by
  authorship; subagent-written verdict accepted; unattributed verdict
  fails closed; authorship irrelevant for `gaps`.
- `test_handle_event_result.py`: result under a running async agent
  re-drives; sync spawns don't hold the turn; `<task-notification>`
  (by tool-use-id and agent-id) releases; unattributable notification
  fails open; review-file authorship tracking incl. main-overwrite
  downgrade.
- `test_listing_upload_gate.py`: pending-marker arming, verdict-only
  (manual upload) batches judged, sanctioned disarm, rollover.
- `test_amazon_listing_bulk_skill.py`: wrong-region fill hard-fails
  (spec + CLI flag), single-stamp auto-adopt warns, inspect prints the
  stamp.
- `test_followup_persist_prompt.py`: follow-up spawn passes
  `persist_prompt=False`; session default stays True.

`pytest -m "unit or workflow"`: 1841 unit + 543 workflow passing (one
pre-existing environmental failure in `test_platform.py` — `lsof`
blocked in the sandbox — fails identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg5csnfP39iFPAEqcEnqwK