### PR TITLE
feat(turn-lifecycle): activate quiescence-watchdog defaults, turn-scoped task verdict, turn-lifecycle e2e (PR B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,8 @@ jobs:
           E2E_BASE_URL: http://127.0.0.1:7777
           MOCK_CLI: tests/e2e/mock_cli.py
         run: >
-          uv run pytest tests/e2e/test_conversation_ui.py --e2e -v
+          uv run pytest tests/e2e/test_conversation_ui.py
+          tests/e2e/test_turn_lifecycle_mock.py --e2e -v
           --log-cli-level=INFO
 
       - name: Stop mock CLI server

--- a/app/env_options.py
+++ b/app/env_options.py
@@ -48,12 +48,14 @@ class Options(enum.Enum):
     # after its turn's result before stdin is closed to end it.
     # 0 = close at the result event (legacy behavior). The async
     # tier applies when background subagents were launched this
-    # process; the quiet tier otherwise. HARD_IDLE closes a process
-    # that emits NO stream events at all for that long, regardless
-    # of gates (0 = disabled). See app/ai/claude_backend_turns.py.
-    TURN_LINGER_S = ('VIBE_TURN_LINGER_S', '0')
-    TURN_LINGER_QUIET_S = ('VIBE_TURN_LINGER_QUIET_S', '0')
-    TURN_HARD_IDLE_S = ('VIBE_TURN_HARD_IDLE_S', '0')
+    # process (late notifications and NESTED spawns are invisible
+    # to tracking and need the grace); the quiet tier otherwise.
+    # HARD_IDLE closes a process that emits NO stream events at all
+    # for that long, regardless of gates (0 = disabled). See
+    # app/ai/claude_backend_turns.py.
+    TURN_LINGER_S = ('VIBE_TURN_LINGER_S', '60')
+    TURN_LINGER_QUIET_S = ('VIBE_TURN_LINGER_QUIET_S', '5')
+    TURN_HARD_IDLE_S = ('VIBE_TURN_HARD_IDLE_S', '600')
 
     # Sync
     KNOWLEDGE_REPO_URL = ('KNOWLEDGE_REPO_URL', '')

--- a/app/routers/tasks_conversation.py
+++ b/app/routers/tasks_conversation.py
@@ -184,6 +184,29 @@ async def send_task_message(
             # through to the resume/fresh-session spawn below instead
             # of being silently dropped into a dying pipe.
             if await agent_manager.send_message(task_id, content):
+                # The task-level verdict is TURN-SCOPED: a delivered
+                # follow-up opens a new turn, so the prior turn's
+                # result/error must not survive it (the finished-task
+                # spawn path below clears the same fields). Without
+                # this, a turn-1 ``set_task_result``/``set_task_error``
+                # sticks: ``_save_result``'s preserve-existing rule
+                # then refuses the new turn's streamed result and the
+                # UI shows the stale verdict next to the new turn's
+                # answer. Gate redrives do NOT pass through here, so
+                # a converging turn keeps its accepted result.
+                task.result = None
+                task.error = None
+                task.error_category = None
+                task.updated_at = datetime.now(UTC).isoformat()
+                await db.commit()
+                await event_bus.emit(
+                    'task_update',
+                    {
+                        'task_id': task_id,
+                        'status': task.status,
+                        'error': None,
+                    },
+                )
                 return {
                     'ok': True,
                     'task_id': task_id,

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -258,9 +258,9 @@ silently dropped.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `VIBE_TURN_LINGER_S` | `0` | Soft-linger window (s) when async subagents were launched this process. `0` = close at the result event (legacy behavior) |
-| `VIBE_TURN_LINGER_QUIET_S` | `0` | Soft-linger window (s) for processes with no async subagents |
-| `VIBE_TURN_HARD_IDLE_S` | `0` | Close after this much total stream silence regardless of holds. `0` = disabled |
+| `VIBE_TURN_LINGER_S` | `60` | Soft-linger window (s) when async subagents were launched this process. `0` = close at the result event (legacy behavior) |
+| `VIBE_TURN_LINGER_QUIET_S` | `5` | Soft-linger window (s) for processes with no async subagents |
+| `VIBE_TURN_HARD_IDLE_S` | `600` | Close after this much total stream silence regardless of holds. `0` = disabled |
 
 ## Configuration
 

--- a/tests/e2e/mock_cli.py
+++ b/tests/e2e/mock_cli.py
@@ -132,6 +132,181 @@ ASK_MARKER = '[[MOCK_ASK_FREE_TEXT]]'
 # tag in sync with MANUAL_ANSWER_TAG there.
 ASK_QUESTION = 'Which marketplaces should I audit? (free-text-e2e)'
 
+# Turn-lifecycle markers (process-per-turn model, PR #87):
+# - ASYNC: a well-behaved run — spawn an async subagent, WAIT for its
+#   task-notification, then emit the final result and exit.
+# - PREMATURE: the backstop path — emit a result while the subagent is
+#   still running; the backend must redrive instead of ending the
+#   turn; the mock then finishes properly.
+# - LINGER: emit the result and then stay alive reading stdin until
+#   the backend's quiescence watchdog closes it (EOF) — proving the
+#   watchdog, not the mock, terminates the turn.
+ASYNC_MARKER = '[[MOCK_ASYNC_SUBAGENT]]'
+PREMATURE_MARKER = '[[MOCK_PREMATURE_RESULT]]'
+LINGER_MARKER = '[[MOCK_LINGER_WAIT]]'
+
+_SPAWN_ID = 'toolu_mock_spawn_1'
+
+
+def emit_async_spawn():
+    """Main-agent Agent tool_use + the async launch ack."""
+    emit({
+        'type': 'assistant',
+        'message': {
+            'role': 'assistant',
+            'content': [
+                {
+                    'type': 'tool_use',
+                    'id': _SPAWN_ID,
+                    'name': 'Agent',
+                    'input': {
+                        'description': 'Review the deliverable',
+                        'prompt': 'Independently review the output file.',
+                    },
+                }
+            ],
+        },
+    })
+    emit({
+        'type': 'user',
+        'message': {
+            'role': 'user',
+            'content': [
+                {
+                    'type': 'tool_result',
+                    'tool_use_id': _SPAWN_ID,
+                    'content': (
+                        'Async agent launched successfully. (internal '
+                        'metadata)\nagentId: mock-reviewer-1'
+                    ),
+                }
+            ],
+        },
+    })
+
+
+def emit_subagent_activity_and_notification():
+    """Subagent events (parent_tool_use_id set) then the completion
+    notification the CLI injects into the parent."""
+    emit({
+        'type': 'assistant',
+        'parent_tool_use_id': _SPAWN_ID,
+        'message': {
+            'role': 'assistant',
+            'content': [
+                {'type': 'text', 'text': 'Reviewing the deliverable...'}
+            ],
+        },
+    })
+    time.sleep(DELAY)
+    emit({
+        'type': 'assistant',
+        'parent_tool_use_id': _SPAWN_ID,
+        'message': {
+            'role': 'assistant',
+            'content': [
+                {'type': 'text', 'text': 'Review passed: no gaps found.'}
+            ],
+        },
+    })
+    time.sleep(DELAY)
+    emit({
+        'type': 'user',
+        'message': {
+            'role': 'user',
+            'content': [
+                {
+                    'type': 'text',
+                    'text': (
+                        '<task-notification tool-use-id="'
+                        + _SPAWN_ID
+                        + '" status="completed">reviewer finished'
+                        '</task-notification>'
+                    ),
+                }
+            ],
+        },
+    })
+
+
+def wait_for_user_message(timeout: float = 30.0) -> str:
+    """Read the next stream-json ``user`` message from stdin (e.g. a
+    review-gate redrive) and return its text; '' on timeout."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if select.select([sys.stdin], [], [], 0.1)[0]:
+            line = sys.stdin.readline()
+            if not line:
+                return ''
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if msg.get('type') == 'user':
+                content = msg.get('message', {}).get('content', '')
+                if isinstance(content, list):
+                    content = ' '.join(
+                        b.get('text', '')
+                        for b in content
+                        if isinstance(b, dict)
+                    )
+                return content or ''
+    return ''
+
+
+def run_async_subagent():
+    """Well-behaved async flow: wait for the reviewer's notification
+    BEFORE the final result — no redrive should fire."""
+    emit_system()
+    time.sleep(DELAY)
+    emit_thinking('Producing the deliverable, then a background review.')
+    emit_async_spawn()
+    time.sleep(DELAY)
+    emit_subagent_activity_and_notification()
+    time.sleep(DELAY)
+    final = f'{RESULT} (reviewer confirmed: no gaps)'
+    emit_text(final)
+    emit_result(final)
+
+
+def run_premature_result():
+    """Backstop flow: result emitted while the subagent still runs.
+    The backend must REDRIVE (not end the turn); on the redrive
+    message the mock completes the review and finishes properly."""
+    emit_system()
+    time.sleep(DELAY)
+    emit_async_spawn()
+    time.sleep(DELAY)
+    emit_result('premature: reviewer still running in the background')
+    # The backend's redrive arrives as a user message on stdin.
+    redrive = wait_for_user_message(timeout=60.0)
+    if 'subagent' not in redrive:
+        emit_text(f'ERROR: expected a redrive, got: {redrive[:120]!r}')
+        emit_result('mock error: no redrive received')
+        return
+    emit_subagent_activity_and_notification()
+    time.sleep(DELAY)
+    final = f'{RESULT} (finished after the redrive + review)'
+    emit_text(final)
+    emit_result(final)
+
+
+def run_linger_wait():
+    """Emit the result then STAY ALIVE until the backend's quiescence
+    watchdog closes stdin (readline returns EOF) — the mock never
+    exits on its own, exactly like the real CLI."""
+    emit_system()
+    time.sleep(DELAY)
+    emit_text(RESULT)
+    emit_result(RESULT)
+    while True:
+        line = sys.stdin.readline()
+        if not line:  # EOF — the watchdog closed the pipe
+            break
+
 
 def read_initial_prompt(max_lines: int = 10) -> str:
     """Read the first stream-json ``user`` message from stdin and
@@ -333,6 +508,12 @@ if __name__ == '__main__':
     prompt = read_initial_prompt()
     if ASK_MARKER in prompt:
         run_ask_question()
+    elif ASYNC_MARKER in prompt:
+        run_async_subagent()
+    elif PREMATURE_MARKER in prompt:
+        run_premature_result()
+    elif LINGER_MARKER in prompt:
+        run_linger_wait()
     elif mode == 'plan_then_execute':
         run_plan_then_execute()
     else:

--- a/tests/e2e/test_turn_lifecycle_mock.py
+++ b/tests/e2e/test_turn_lifecycle_mock.py
@@ -1,0 +1,172 @@
+"""Turn-lifecycle e2e against the mock CLI (process-per-turn model).
+
+Runs in the e2e-mock-cli CI job (server started with
+``MOCK_CLI=tests/e2e/mock_cli.py``). Three flows, selected by markers
+in the task description (see mock_cli.py):
+
+- ``[[MOCK_ASYNC_SUBAGENT]]`` — a well-behaved run: async subagent
+  spawned, its events stream through the parent, the mock WAITS for
+  the ``<task-notification>`` before its final result. Must complete
+  with NO ``review_gate_redrive`` — the notification loop, not the
+  redrive backstop, carries it.
+- ``[[MOCK_PREMATURE_RESULT]]`` — the backstop: a result emitted while
+  the subagent still runs must be intercepted (redrive), then the
+  completed review + final result finish the task; the final text is
+  the deliverable (last-wins).
+- ``[[MOCK_LINGER_WAIT]]`` — the mock emits its result and stays alive
+  until stdin EOF, exactly like the real CLI: the quiescence watchdog
+  must close the turn (``turn_idle_close`` event) and the task must
+  complete.
+"""
+
+import logging
+import os
+
+import httpx
+import pytest
+
+from tests.e2e.e2e_helpers import (
+    create_store,
+    create_task,
+    get_messages,
+    login,
+    poll_task_status,
+)
+
+logger = logging.getLogger(__name__)
+
+MOCK_CLI = os.environ.get('MOCK_CLI', '')
+if not MOCK_CLI:
+    pytest.skip(
+        'MOCK_CLI not set — skipping turn-lifecycle mock tests. '
+        'Run with: MOCK_CLI=tests/e2e/mock_cli.py ./start.sh 7777',
+        allow_module_level=True,
+    )
+
+pytestmark = [pytest.mark.e2e]
+
+# Generous per-test budget: the linger flow deliberately waits out the
+# quiet tier (default 5s) plus watchdog tick granularity.
+TASK_TIMEOUT = 180
+
+
+@pytest.fixture(scope='module')
+def api() -> httpx.Client:
+    client = httpx.Client(timeout=30)
+    login(client)
+    return client
+
+
+@pytest.fixture(scope='module')
+def store_id(api) -> str:
+    return create_store(api, 'Turn Lifecycle Mock Store')['id']
+
+
+def _events(msgs: list[dict], needle: str) -> list[dict]:
+    return [
+        m
+        for m in msgs
+        if m.get('role') == 'agent_event' and needle in str(m.get('content'))
+    ]
+
+
+class TestAsyncSubagentFlow:
+    def test_notification_loop_completes_without_redrive(
+        self, api, store_id
+    ):
+        task = create_task(
+            api,
+            'async subagent turn test',
+            store_id=store_id,
+            description=(
+                '[[MOCK_ASYNC_SUBAGENT]] produce the deliverable and have '
+                'a background reviewer verify it.'
+            ),
+            skip_reflection=True,
+        )
+        data = poll_task_status(
+            api,
+            task['id'],
+            {'completed'},
+            fail_statuses={'failed'},
+            timeout=TASK_TIMEOUT,
+        )
+        assert data['status'] == 'completed'
+        assert 'reviewer confirmed' in (data.get('result') or '')
+
+        msgs = get_messages(api, task['id'])
+        # The subagent's activity streamed through the parent (its
+        # assistant events are re-emitted as normal messages)...
+        assert any(
+            m.get('role') == 'assistant'
+            and 'Review passed: no gaps' in str(m.get('content'))
+            for m in msgs
+        )
+        # ...the notification arrived...
+        assert _events(msgs, 'task-notification')
+        # ...and the redrive backstop was NEVER needed.
+        assert not _events(msgs, 'review_gate_redrive')
+        results = [m for m in msgs if m.get('role') == 'result']
+        assert len(results) == 1
+        assert 'reviewer confirmed' in results[0]['content']
+
+
+class TestPrematureResultBackstop:
+    def test_result_under_running_subagent_is_redriven(self, api, store_id):
+        task = create_task(
+            api,
+            'premature result turn test',
+            store_id=store_id,
+            description=(
+                '[[MOCK_PREMATURE_RESULT]] stop early while the reviewer '
+                'is still running.'
+            ),
+            skip_reflection=True,
+        )
+        data = poll_task_status(
+            api,
+            task['id'],
+            {'completed'},
+            fail_statuses={'failed'},
+            timeout=TASK_TIMEOUT,
+        )
+        assert data['status'] == 'completed'
+
+        msgs = get_messages(api, task['id'])
+        # The premature result was intercepted by the redrive...
+        assert _events(msgs, 'review_gate_redrive')
+        # ...so it never became a result card; only the post-review
+        # final result did (last-wins deliverable).
+        results = [m for m in msgs if m.get('role') == 'result']
+        assert len(results) == 1
+        assert 'finished after the redrive' in results[0]['content']
+        assert 'finished after the redrive' in (data.get('result') or '')
+
+
+class TestLingerWatchdogTerminatesTurn:
+    def test_watchdog_closes_idle_turn(self, api, store_id):
+        task = create_task(
+            api,
+            'linger watchdog turn test',
+            store_id=store_id,
+            description=(
+                '[[MOCK_LINGER_WAIT]] finish the work and then idle like '
+                'a real CLI until the platform ends the turn.'
+            ),
+            skip_reflection=True,
+        )
+        data = poll_task_status(
+            api,
+            task['id'],
+            {'completed'},
+            fail_statuses={'failed'},
+            timeout=TASK_TIMEOUT,
+        )
+        assert data['status'] == 'completed'
+
+        msgs = get_messages(api, task['id'])
+        # The mock never exits on its own — the ONLY way this task
+        # completed is the quiescence watchdog closing stdin.
+        closes = _events(msgs, 'turn_idle_close')
+        assert closes, 'expected a turn_idle_close agent_event'
+        assert 'quiescent' in closes[0]['content']

--- a/tests/e2e/test_turn_lifecycle_mock.py
+++ b/tests/e2e/test_turn_lifecycle_mock.py
@@ -71,9 +71,7 @@ def _events(msgs: list[dict], needle: str) -> list[dict]:
 
 
 class TestAsyncSubagentFlow:
-    def test_notification_loop_completes_without_redrive(
-        self, api, store_id
-    ):
+    def test_notification_loop_completes_without_redrive(self, api, store_id):
         task = create_task(
             api,
             'async subagent turn test',

--- a/tests/unit/test_handle_event_result.py
+++ b/tests/unit/test_handle_event_result.py
@@ -293,10 +293,12 @@ class TestHandleEventResultTurns:
         assert emitted[1] == ('result', 'Extra ack')
         assert session._result_text == 'Extra ack'
 
-    async def test_legacy_linger_zero_closes_at_result(self):
-        """With linger=0 (the rollout default) the turn terminator
+    async def test_legacy_linger_zero_closes_at_result(self, monkeypatch):
+        """With linger=0 (the escape hatch) the turn terminator
         still fires inline at the accepted result — byte-identical to
         the pre-migration close-at-result behavior."""
+        monkeypatch.setenv('VIBE_TURN_LINGER_S', '0')
+        monkeypatch.setenv('VIBE_TURN_LINGER_QUIET_S', '0')
         session = _make_session('execute')
 
         async def _noop(*a, **k):
@@ -483,9 +485,14 @@ class TestReviewGateRedrive:
         assert session._input_closed is False
         session._proc.stdin.close.assert_not_called()
 
-    async def test_satisfied_gate_closes_control_channel(self):
-        """Gate satisfied → stdin DOES close so the CLI exits (the fix
-        must not regress normal end-of-turn)."""
+    async def test_satisfied_gate_closes_control_channel(self, monkeypatch):
+        """Gate satisfied + linger=0 (escape hatch) → stdin DOES close
+        so the CLI exits — the legacy end-of-turn must not regress.
+        (Under the active default tiers the quiescence watchdog owns
+        the close instead; see test_linger_configured_keeps_channel_
+        open.)"""
+        monkeypatch.setenv('VIBE_TURN_LINGER_S', '0')
+        monkeypatch.setenv('VIBE_TURN_LINGER_QUIET_S', '0')
         session = _make_session('auto')
         session.task_dir = '/tmp/fake-task'
         session._proc = Mock()

--- a/tests/unit/test_turn_linger.py
+++ b/tests/unit/test_turn_linger.py
@@ -46,10 +46,15 @@ class TestTierSelection:
         s._had_async_spawns = True
         assert s._turn_linger_seconds() == 60.0
 
-    def test_defaults_are_legacy_zero(self):
-        # Rollout stage 1: no env vars set → close at the result event.
+    def test_defaults_are_active_tiers(self, monkeypatch):
+        # Rollout stage 2 (the flip): with no env overrides the linger
+        # is ACTIVE — 5s quiet tier, 60s async tier.
+        monkeypatch.delenv(Options.TURN_LINGER_S.env_var, raising=False)
+        monkeypatch.delenv(Options.TURN_LINGER_QUIET_S.env_var, raising=False)
         s = _session()
-        assert s._turn_linger_seconds() == 0.0
+        assert s._turn_linger_seconds() == 5.0
+        s._had_async_spawns = True
+        assert s._turn_linger_seconds() == 60.0
 
 
 class TestCloseGuards:

--- a/tests/workflow/test_wf_turn_lifecycle.py
+++ b/tests/workflow/test_wf_turn_lifecycle.py
@@ -14,6 +14,7 @@ import asyncio
 
 import pytest
 
+from app.models.task import Task
 from tests.workflow.conftest import wait_for_task
 from tests.workflow.fake_agent import FakeAgentScenario
 
@@ -143,8 +144,6 @@ class TestTurnScopedVerdict:
     async def test_injected_followup_clears_prior_result_and_error(
         self, admin_client, install_fake_agent, override_async_session
     ):
-        from app.models.task import Task
-
         store_id = await _create_store(admin_client, 'Verdict Scope Store')
         install_fake_agent.default_scenario = FakeAgentScenario(
             result='turn one verdict',

--- a/tests/workflow/test_wf_turn_lifecycle.py
+++ b/tests/workflow/test_wf_turn_lifecycle.py
@@ -131,3 +131,55 @@ class TestPostResultWindow:
         ]
         assert len(user_msgs) == 1
         await wait_for_task(admin_client, task_id)
+
+
+class TestTurnScopedVerdict:
+    """A delivered follow-up opens a new turn — the prior turn's
+    task-level verdict (result/error) must not survive it. Without the
+    clear, ``_save_result``'s preserve-existing rule refuses the new
+    turn's streamed result and the UI shows a stale verdict next to
+    the new turn's answer."""
+
+    async def test_injected_followup_clears_prior_result_and_error(
+        self, admin_client, install_fake_agent, override_async_session
+    ):
+        from app.models.task import Task
+
+        store_id = await _create_store(admin_client, 'Verdict Scope Store')
+        install_fake_agent.default_scenario = FakeAgentScenario(
+            result='turn one verdict',
+            exit_delay=2.0,
+        )
+        r = await admin_client.post(
+            '/api/tasks',
+            json={'title': 'Turn-scoped verdict', 'store_id': store_id},
+        )
+        task_id = r.json()['id']
+
+        # Wait for turn 1's verdict to land while the process lives on.
+        for _ in range(200):
+            data = (await admin_client.get(f'/api/tasks/{task_id}')).json()
+            if data.get('result'):
+                break
+            await asyncio.sleep(0.02)
+        assert data['result'] == 'turn one verdict'
+        assert install_fake_agent.is_running(task_id)
+
+        # A prior error too (e.g. turn 1 called set_task_error).
+        async with override_async_session() as db:
+            task = await db.get(Task, task_id)
+            task.error = 'turn one error'
+            task.error_category = 'agent_reported'
+            await db.commit()
+
+        r2 = await admin_client.post(
+            f'/api/tasks/{task_id}/messages',
+            json={'content': 'please continue with the next part'},
+        )
+        assert r2.status_code == 200 and r2.json()['ok'] is True
+
+        data = (await admin_client.get(f'/api/tasks/{task_id}')).json()
+        assert not data.get('result')
+        assert not data.get('error')
+
+        await wait_for_task(admin_client, task_id)


### PR DESCRIPTION
## What (PR B of the process-per-turn migration — #87 was PR A)

Activates the turn-lifecycle model shipped in #87, makes the
task-level verdict turn-scoped, and proves the whole model end to end
in CI.

### 1. Default flip — the watchdog is now the active turn terminator
| Variable | Was | Now |
|---|---|---|
| `VIBE_TURN_LINGER_S` (async tier) | `0` (legacy close-at-result) | `60` |
| `VIBE_TURN_LINGER_QUIET_S` | `0` | `5` |
| `VIBE_TURN_HARD_IDLE_S` | `0` (disabled) | `600` |

All three measure **stream silence** — any CLI event or stdin write
resets them, so a long-running subagent review never times out (its
activity streams through the parent). The hard-idle bound only ends
10 minutes of *total* silence (dead work; 2× the worst healthy
silence ever observed). `0` remains the escape hatch reproducing the
legacy close-at-result behavior; the unit tests pinning that path now
set it explicitly.

### 2. Task-level verdict is turn-scoped (stale result/error fix)
A follow-up delivered into a live process opens a new turn, but the
prior turn's `task.result` / `task.error` survived it — and
`_save_result`'s preserve-existing rule then refused the new turn's
streamed result, so the UI kept showing the stale verdict (or a stale
red error banner) next to the new turn's answer. The finished-task
spawn path already cleared these fields; the **injection path now
does the same** the moment delivery is confirmed, and emits a
`task_update` so the frontend drops the stale verdict immediately.
Gate redrives don't pass through this branch, so a converging turn
keeps its accepted result. Pinned by
`test_wf_turn_lifecycle.py::TestTurnScopedVerdict` (result + error set
by turn 1 are gone at delivery; the task still finalizes cleanly).

### 3. New e2e — `tests/e2e/test_turn_lifecycle_mock.py` (e2e-mock-cli job)
Three mock-CLI flows emitting the exact event shapes the real CLI
produces (verified against a live CLI spike: Agent spawn + `Async
agent launched` ack, `parent_tool_use_id` subagent events,
`<task-notification>`):

1. **Notification loop, no redrive** — async subagent spawned, its
   activity streams through the parent, the agent waits for the
   notification before its final result → task completes with **zero
   `review_gate_redrive`** markers: the watchdog carries the turn, the
   #85 redrive is now the backstop.
2. **Premature result → redrive backstop** — a result emitted while
   the subagent still runs is intercepted; after the redrive the
   completed review's final result is the deliverable (last-wins,
   single result card).
3. **Watchdog terminates an idle CLI** — the mock idles after its
   result exactly like the real CLI (which never exits with stdin
   open); the only way the task completes is the quiescence watchdog's
   `turn_idle_close (quiescent_5s)` — asserted.

### Verification
- Full `pytest -m "unit or workflow"`: 1911 passed (one pre-existing
  environmental `lsof` failure, fails on main identically).
- All three new e2e green against a local mock-CLI server with the
  flipped defaults (~18s total including the real 5s linger).
- Live dev-server validation of the same defaults was done in #87's
  cycle (async reviewer + `quiescent_60s` + delivery-race fallback +
  `quiescent_5s`, COMPLETED with last-wins result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg5csnfP39iFPAEqcEnqwK