### PR TITLE
fix(lifecycle): defer exec RUNNING past the semaphore; error channel can't fail a task with a valid result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ review-*.png
 
 # Build artifacts (wheel/sdist staging)
 build/
+
+# local investigation handoff notes (contain live-account data)
+refactor.md

--- a/app/ai/claude_backend_stream.py
+++ b/app/ai/claude_backend_stream.py
@@ -396,7 +396,13 @@ class _StreamMixin:
                     await self.send_user_message(
                         'You cannot finish yet — a required review gate '
                         'is not satisfied. Do NOT just re-answer; act on '
-                        'this and then finish:\n\n' + gate_reason
+                        'this and then finish. If you genuinely cannot '
+                        'satisfy it, finish normally and state the '
+                        'remaining caveats IN YOUR RESULT — never call '
+                        'vibe_seller_set_task_error for caveats or '
+                        'partial work (that channel marks the whole task '
+                        'FAILED and is only for a task with no usable '
+                        'deliverable):\n\n' + gate_reason
                     )
                     return
                 if gate_reason:

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -543,54 +543,6 @@ async def stop_agent(
     return {'ok': True, 'task_id': task_id, 'status': 'agent_stopped'}
 
 
-class SetTaskErrorRequest(BaseModel):
-    error: str
-
-
-@router.post('/{task_id}/error')
-async def set_task_error(
-    task_id: str,
-    body: SetTaskErrorRequest,
-    db: AsyncSession = Depends(get_db),
-    _user: User = Depends(get_current_user),
-):
-    """Record an unrecoverable error for a task.
-
-    Called by the agent via the `vibe_seller_set_task_error`
-    MCP tool. Saves `task.error` and `task.error_category`
-    but does NOT transition status — status transitions are
-    owned by `auto_run_task` cleanup after the agent session
-    exits. It detects a non-empty `task.error` and marks the
-    task FAILED at the same cleanup step where successful
-    tasks become COMPLETED. This keeps post-task knowledge
-    commit + metadata sync running even on failure.
-    """
-    task = await db.get(Task, task_id)
-    if not task:
-        raise HTTPException(status_code=404, detail='Task not found')
-    if task.status not in {TaskStatus.RUNNING, TaskStatus.DESIGNING}:
-        raise HTTPException(
-            status_code=400,
-            detail=(f'Cannot set error on task in status {task.status}'),
-        )
-    task.error = body.error
-    task.error_category = task.error_category or 'agent_reported'
-    task.updated_at = datetime.now(UTC).isoformat()
-    await db.commit()
-    # Emit status=task.status (not FAILED) so the UI doesn't
-    # flip the badge prematurely. The FAILED transition lands
-    # later via auto_run_task cleanup and re-emits task_update.
-    await event_bus.emit(
-        'task_update',
-        {
-            'task_id': task_id,
-            'status': task.status,
-            'error': task.error,
-        },
-    )
-    return {'ok': True, 'task_id': task_id, 'status': task.status}
-
-
 class SetTaskResultRequest(BaseModel):
     result: str
 
@@ -726,6 +678,12 @@ async def set_task_result(
         raise HTTPException(status_code=400, detail=deny_reason)
 
     task.result = final_result
+    # Recovery: a valid result supersedes an earlier agent-reported
+    # error this turn (error → recovered → result must not ship as
+    # FAILED). Infra-detected errors are not cleared.
+    if task.error and task.error_category == 'agent_reported':
+        task.error = None
+        task.error_category = None
     task.updated_at = datetime.now(UTC).isoformat()
     await db.commit()
 

--- a/app/routers/tasks_files.py
+++ b/app/routers/tasks_files.py
@@ -13,6 +13,8 @@ import zipfile
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from fastapi.responses import FileResponse
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.background import BackgroundTask
 
 from app.ai.claude_backend_manager import agent_manager
@@ -25,8 +27,12 @@ from app.ai.stop_gates import (
 from app.ai.stop_gates.ad_rules import resolve_rules
 from app.auth import get_current_user
 from app.browser.manager import store_slug
+from app.database import get_db
+from app.events.bus import event_bus
 from app.models.store import Store
+from app.models.task import Task
 from app.models.user import User
+from app.task_states import TaskStatus
 from app.workspace.manager import VIBE_SELLER_DIR
 
 router = APIRouter(prefix='/api/tasks', tags=['tasks'])
@@ -393,3 +399,93 @@ async def upload_task_file(
         'abs_path': str(out_path),
         'url': f'/api/tasks/{task_id}/files/{rel_path}',
     }
+
+
+def record_agent_error(task, error_text: str) -> dict | None:
+    """Apply the set_task_error contract to *task* (mutates, no commit).
+
+    ``set_task_error`` means UNRECOVERABLE failure. A task that already
+    produced a valid result this turn is not that — under gate pressure
+    agents were observed using the error channel as an "explain my
+    remaining caveats so I may end" escape hatch, and a non-empty
+    ``task.error`` deterministically flips the task FAILED at cleanup,
+    hiding a complete deliverable behind a failure badge.
+
+    With a non-empty ``task.result``: the text is appended to the
+    result as a caveat block, ``task.error`` stays untouched, and a
+    payload is returned for the endpoint to send back so the agent
+    knows not to retry the error channel. Without a result: classic
+    behavior (``task.error`` set, returns None).
+    """
+    if task.result and task.result.strip():
+        caveat = error_text.strip()
+        task.result = (
+            f'{task.result}\n\n> ⚠️ **Agent-reported caveats**\n> '
+            + caveat.replace('\n', '\n> ')
+        )
+        return {
+            'status': task.status,
+            'recorded_as': 'caveat',
+            'note': (
+                'A valid result already exists for this turn, so this '
+                'was appended to it as a caveat — the task will NOT be '
+                'marked failed. set_task_error is only for tasks with '
+                'no usable deliverable.'
+            ),
+        }
+    task.error = error_text
+    task.error_category = task.error_category or 'agent_reported'
+    return None
+
+
+class SetTaskErrorRequest(BaseModel):
+    error: str
+
+
+@router.post('/{task_id}/error')
+async def set_task_error(
+    task_id: str,
+    body: SetTaskErrorRequest,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(get_current_user),
+):
+    """Record an unrecoverable error (`vibe_seller_set_task_error`).
+
+    Saves `task.error` (+category) without transitioning status —
+    cleanup marks the task FAILED on a non-empty error. When a valid
+    result already exists this turn, the text is recorded as a CAVEAT
+    on the result instead (see ``record_agent_error``) and the task
+    completes normally.
+    """
+    task = await db.get(Task, task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail='Task not found')
+    if task.status not in {TaskStatus.RUNNING, TaskStatus.DESIGNING}:
+        raise HTTPException(
+            status_code=400,
+            detail=(f'Cannot set error on task in status {task.status}'),
+        )
+    # Caveat-vs-error contract lives in ``record_agent_error`` (see
+    # tasks_files): with a valid result already on the task, the text
+    # becomes a caveat on the result and the task will NOT fail.
+    payload = record_agent_error(task, body.error)
+    task.updated_at = datetime.now(UTC).isoformat()
+    await db.commit()
+    if payload is not None:
+        await event_bus.emit(
+            'task_update',
+            {'task_id': task_id, 'status': task.status, 'error': None},
+        )
+        return {'ok': True, 'task_id': task_id, **payload}
+    # Emit status=task.status (not FAILED) so the UI doesn't
+    # flip the badge prematurely. The FAILED transition lands
+    # later via auto_run_task cleanup and re-emits task_update.
+    await event_bus.emit(
+        'task_update',
+        {
+            'task_id': task_id,
+            'status': task.status,
+            'error': task.error,
+        },
+    )
+    return {'ok': True, 'task_id': task_id, 'status': task.status}

--- a/app/task_runner_exec.py
+++ b/app/task_runner_exec.py
@@ -31,6 +31,7 @@ from app.task_runner import (
 )
 from app.task_session_lifecycle import (
     _wait_for_session_end,
+    make_exec_on_start as _make_exec_on_start,
     wait_for_session_with_retry,
 )
 from app.task_states import (
@@ -200,20 +201,6 @@ async def execute_planned_task(task_id: str, store: Store | None):
                         )
                         return
 
-                if task.status != TaskStatus.RUNNING:
-                    assert_transition(task.status, TaskStatus.RUNNING)
-                    task.status = TaskStatus.RUNNING
-                    task.started_at = datetime.now(UTC).isoformat()
-                    task.updated_at = datetime.now(UTC).isoformat()
-                    await db.commit()
-                    await event_bus.emit(
-                        'task_update',
-                        {
-                            'task_id': task_id,
-                            'status': TaskStatus.RUNNING,
-                        },
-                    )
-
             bundle = await build_system_extra(
                 task,
                 store,
@@ -241,6 +228,16 @@ async def execute_planned_task(task_id: str, store: Store | None):
                     _store_slug(store.name, store.id) if store else None
                 ),
                 skip_reflection=task.skip_reflection,
+                # RUNNING is committed only AFTER the concurrency
+                # semaphore is acquired (mirrors auto_run_task's
+                # _on_start). Setting it before run() left fan-out
+                # tasks RUNNING-and-silent while queued for a slot:
+                # updated_at never moved, the stall reaper failed them
+                # as "stalled" (they were queued, not stalled), and
+                # the queued run then started the agent anyway on the
+                # already-FAILED task. on_start returning False makes
+                # run() release the slot and skip the spawn entirely.
+                on_start=_make_exec_on_start(task_id),
             )
 
             # Event-driven wait on the freshly-registered session.
@@ -556,21 +553,14 @@ async def execute_woken_task(task_id: str, store: Store | None):
                     )
                     return
 
-            # Transition to running — preserve wait_condition
-            assert_transition(task.status, TaskStatus.RUNNING)
-            task.status = TaskStatus.RUNNING
-            task.started_at = datetime.now(UTC).isoformat()
-            task.updated_at = datetime.now(UTC).isoformat()
+            # Preserve wait_condition bookkeeping now; the RUNNING
+            # transition itself is deferred to on_start so a wake that
+            # queues behind the agent semaphore isn't reaped as
+            # "stalled" while it waits.
             condition['resumed'] = True
             task.wait_condition = json.dumps(condition)
+            task.updated_at = datetime.now(UTC).isoformat()
             await db.commit()
-            await event_bus.emit(
-                'task_update',
-                {
-                    'task_id': task_id,
-                    'status': TaskStatus.RUNNING,
-                },
-            )
 
         # Build system prompt (MCP config only — no browser start)
         store_emails: list[str] = []
@@ -600,6 +590,9 @@ async def execute_woken_task(task_id: str, store: Store | None):
             profile_id=(task.ai_profile_id or DEFAULT_PROFILE_ID),
             message_history=history,
             resume=True,
+            # RUNNING deferred to post-semaphore, same contract as
+            # execute_planned_task above.
+            on_start=_make_exec_on_start(task_id),
             store_slug=(_store_slug(store.name, store.id) if store else None),
             skip_reflection=task.skip_reflection,
         )

--- a/app/task_session_lifecycle.py
+++ b/app/task_session_lifecycle.py
@@ -19,7 +19,9 @@ import logging
 
 from app.ai.claude_backend_manager import agent_manager
 from app.database import async_session
+from app.events.bus import event_bus
 from app.models.task import Task
+from app.task_states import TaskStatus, assert_transition
 
 logger = logging.getLogger(__name__)
 
@@ -220,3 +222,44 @@ async def wait_for_session_with_retry(task_id: str, session):
     if not await _wait_for_session_end(task_id, retry):
         return None
     return retry
+
+
+def make_exec_on_start(task_id: str):
+    """RUNNING transition deferred until the concurrency slot is held.
+
+    Mirrors ``auto_run_task``'s ``_on_start``: a task waiting for the
+    agent semaphore keeps its pre-run status (PLANNED/QUEUED) so the
+    stall reaper never mistakes a queued fan-out task for a stalled
+    one (it reaped tasks whose ``updated_at`` was still the creation
+    instant), and a task that left the expected state while queued
+    (reaper-failed, user stop, retry) ABORTS the spawn instead of
+    running a full agent session against a dead task.
+    """
+
+    async def _on_start() -> bool:
+        async with async_session() as db:
+            t = await db.get(Task, task_id)
+            if not t or t.status not in (
+                TaskStatus.PLANNED,
+                TaskStatus.QUEUED,
+                TaskStatus.RUNNING,  # approve-path already transitioned
+            ):
+                logger.warning(
+                    'Exec on_start: task %s in status %s — aborting spawn',
+                    task_id[:8],
+                    getattr(t, 'status', 'missing'),
+                )
+                return False
+            if t.status != TaskStatus.RUNNING:
+                assert_transition(t.status, TaskStatus.RUNNING)
+                t.status = TaskStatus.RUNNING
+                t.started_at = t.started_at or datetime.now(UTC).isoformat()
+            t.updated_at = datetime.now(UTC).isoformat()
+            await db.commit()
+        await event_bus.emit(
+            'task_update',
+            {'task_id': task_id, 'status': TaskStatus.RUNNING},
+        )
+        return True
+
+    return _on_start

--- a/tests/workflow/fake_agent.py
+++ b/tests/workflow/fake_agent.py
@@ -260,6 +260,15 @@ class FakeAgent(AIAgentBackend):
         self._tasks[task_id] = t
         return True
 
+    def loaded_skills_and_workspace(self, task_id: str):
+        """Mirror ClaudeCodeBackend: (loaded_skills, task_dir).
+
+        The fake binds no skills and has no workspace, so the
+        set_task_result endpoint's skill-declared exit gates resolve
+        to a no-op — matching a real task that loaded no skills.
+        """
+        return set(), None
+
     def get_session(self, task_id: str) -> _FakeSession | None:
         """Return the fake session for a task, if any."""
         return self._sessions.get(task_id)

--- a/tests/workflow/test_wf_error_result_contract.py
+++ b/tests/workflow/test_wf_error_result_contract.py
@@ -1,0 +1,136 @@
+"""The set_task_error / set_task_result verdict contract.
+
+``set_task_error`` means UNRECOVERABLE failure. Observed live: an
+agent under review-gate pressure produced a complete deliverable, then
+called ``set_task_error`` with a "remaining caveats" note to be
+allowed to end — and the non-empty ``task.error`` flipped a task with
+a valid 100KB-class result to FAILED, hiding the deliverable behind a
+failure badge. Two contract rules pin the fix:
+
+- error-after-result → recorded as a CAVEAT appended to the result;
+  ``task.error`` untouched; the task completes.
+- result-after-error → the valid result supersedes the earlier
+  agent-reported error (recovery); infra-detected errors are never
+  cleared this way.
+"""
+
+import asyncio
+
+import pytest
+
+from tests.workflow.conftest import wait_for_task
+from tests.workflow.fake_agent import FakeAgentScenario
+
+pytestmark = pytest.mark.workflow
+
+
+async def _create_store(client, name):
+    r = await client.post('/api/stores', json={'name': name})
+    return r.json()['id']
+
+
+async def _running_task(admin_client, install_fake_agent, store_name):
+    """A task whose fake agent stays alive (gate) so the MCP endpoints
+    see status=RUNNING, plus its release gate."""
+    gate = asyncio.Event()
+    install_fake_agent.default_scenario = FakeAgentScenario(
+        result='deliverable from the agent',
+        gate=gate,
+    )
+    store_id = await _create_store(admin_client, store_name)
+    r = await admin_client.post(
+        '/api/tasks',
+        json={'title': 'contract test', 'store_id': store_id},
+    )
+    task_id = r.json()['id']
+    for _ in range(200):
+        data = (await admin_client.get(f'/api/tasks/{task_id}')).json()
+        if data['status'] == 'running':
+            break
+        await asyncio.sleep(0.02)
+    assert data['status'] == 'running'
+    return task_id, gate
+
+
+class TestErrorAfterResultIsCaveat:
+    async def test_error_with_existing_result_becomes_caveat(
+        self, admin_client, install_fake_agent
+    ):
+        task_id, gate = await _running_task(
+            admin_client, install_fake_agent, 'Caveat Contract Store'
+        )
+        r = await admin_client.post(
+            f'/api/tasks/{task_id}/result',
+            json={'result': 'Full audit report: 10/10 items covered.'},
+        )
+        assert r.status_code == 200
+
+        r2 = await admin_client.post(
+            f'/api/tasks/{task_id}/error',
+            json={'error': '2 minor rows deferred to the next run.'},
+        )
+        assert r2.status_code == 200
+        body = r2.json()
+        assert body['recorded_as'] == 'caveat'
+
+        data = (await admin_client.get(f'/api/tasks/{task_id}')).json()
+        assert not data.get('error')
+        assert 'Full audit report' in data['result']
+        assert 'Agent-reported caveats' in data['result']
+        assert '2 minor rows deferred' in data['result']
+
+        gate.set()
+        final = await wait_for_task(admin_client, task_id)
+        assert final['status'] == 'completed'
+        assert not final.get('error')
+
+    async def test_error_without_result_still_fails_task(
+        self, admin_client, install_fake_agent
+    ):
+        # The classic contract is untouched: no deliverable + error
+        # → FAILED at cleanup.
+        task_id, gate = await _running_task(
+            admin_client, install_fake_agent, 'Hard Error Store'
+        )
+        r = await admin_client.post(
+            f'/api/tasks/{task_id}/error',
+            json={'error': 'service unreachable, no data collected'},
+        )
+        assert r.status_code == 200 and 'recorded_as' not in r.json()
+
+        data = (await admin_client.get(f'/api/tasks/{task_id}')).json()
+        assert 'service unreachable' in (data.get('error') or '')
+
+        gate.set()
+        final = await wait_for_task(
+            admin_client, task_id, target='failed'
+        )
+        assert final['status'] == 'failed'
+
+
+class TestResultAfterErrorRecovers:
+    async def test_result_clears_agent_reported_error(
+        self, admin_client, install_fake_agent
+    ):
+        task_id, gate = await _running_task(
+            admin_client, install_fake_agent, 'Recovery Contract Store'
+        )
+        r = await admin_client.post(
+            f'/api/tasks/{task_id}/error',
+            json={'error': 'first attempt hit a login wall'},
+        )
+        assert r.status_code == 200
+
+        r2 = await admin_client.post(
+            f'/api/tasks/{task_id}/result',
+            json={'result': 'Recovered on retry: report complete.'},
+        )
+        assert r2.status_code == 200
+
+        data = (await admin_client.get(f'/api/tasks/{task_id}')).json()
+        assert not data.get('error')
+        assert 'Recovered on retry' in data['result']
+
+        gate.set()
+        final = await wait_for_task(admin_client, task_id)
+        assert final['status'] == 'completed'

--- a/tests/workflow/test_wf_error_result_contract.py
+++ b/tests/workflow/test_wf_error_result_contract.py
@@ -102,9 +102,7 @@ class TestErrorAfterResultIsCaveat:
         assert 'service unreachable' in (data.get('error') or '')
 
         gate.set()
-        final = await wait_for_task(
-            admin_client, task_id, target='failed'
-        )
+        final = await wait_for_task(admin_client, task_id, target='failed')
         assert final['status'] == 'failed'
 
 

--- a/tests/workflow/test_wf_exec_queue_race.py
+++ b/tests/workflow/test_wf_exec_queue_race.py
@@ -85,9 +85,7 @@ class TestQueuedExecKeepsPreRunStatus:
                 break
             await asyncio.sleep(0.02)
         assert install_fake_agent.is_running(holder_id)
-        install_fake_agent.default_scenario = FakeAgentScenario(
-            result='B done'
-        )
+        install_fake_agent.default_scenario = FakeAgentScenario(result='B done')
 
         pre = (await admin_client.get(f'/api/tasks/{b_id}')).json()
         r2 = await admin_client.post(f'/api/tasks/{b_id}/execute-plan')

--- a/tests/workflow/test_wf_exec_queue_race.py
+++ b/tests/workflow/test_wf_exec_queue_race.py
@@ -1,0 +1,162 @@
+"""Exec-path RUNNING is committed only after the concurrency slot.
+
+Observed live: an all-stores schedule fanned out more tasks than
+``max_concurrent``; ``execute_planned_task`` set RUNNING *before*
+``agent_manager.run()`` blocked on the semaphore, so the queued tasks
+sat RUNNING-and-silent with ``updated_at`` frozen at creation — the
+stall reaper failed them as "stalled" within 3 minutes, and when a
+slot finally freed the queued run started a full agent session against
+the already-FAILED task (burning a complete audit into a dead task).
+
+Contract (mirrors ``auto_run_task._on_start``):
+- a task queued for the semaphore keeps its pre-run status;
+- the RUNNING transition (+ ``updated_at`` bump) happens only after
+  the slot is acquired;
+- a task that left the expected state while queued aborts the spawn.
+"""
+
+import asyncio
+
+import pytest
+
+from app.models.task import Task
+from tests.workflow.conftest import wait_for_task
+from tests.workflow.fake_agent import FakeAgentScenario
+
+pytestmark = pytest.mark.workflow
+
+
+async def _create_store(client, name):
+    r = await client.post('/api/stores', json={'name': name})
+    return r.json()['id']
+
+
+async def _planned_task_with_dead_session(
+    admin_client, install_fake_agent, store_id, title
+):
+    """A PLANNED task whose planning session is gone — the
+    execute-plan path must spawn a fresh session (the branch that
+    queues on the semaphore)."""
+    r = await admin_client.post(
+        '/api/tasks',
+        json={'title': title, 'store_id': store_id, 'plan_mode': True},
+    )
+    task_id = r.json()['id']
+    await wait_for_task(admin_client, task_id, target='planned')
+    # Simulate the planning session having died (server restart /
+    # reaped CLI): stop() cancels the fake session AND releases its
+    # concurrency slot, so approve_plan() returns False and
+    # execute-plan takes the fresh-spawn branch.
+    await install_fake_agent.stop(task_id)
+    return task_id
+
+
+class TestQueuedExecKeepsPreRunStatus:
+    async def test_queued_task_stays_planned_then_completes(
+        self, admin_client, install_fake_agent
+    ):
+        install_fake_agent.set_max_concurrent(1)
+        store_id = await _create_store(admin_client, 'Queue Race Store')
+
+        # Task B first (the semaphore also gates planning sessions):
+        # planned, then its planning session dies → execute-plan must
+        # spawn fresh.
+        install_fake_agent.default_scenario = FakeAgentScenario(
+            plan='## Plan\n1. do the thing', result='B done'
+        )
+        b_id = await _planned_task_with_dead_session(
+            admin_client, install_fake_agent, store_id, 'queued executee'
+        )
+
+        # Task A occupies the single slot until we release its gate.
+        # (The scenario is read when run() starts, so set the gated
+        # default BEFORE creating A, then restore B's scenario.)
+        gate = asyncio.Event()
+        install_fake_agent.default_scenario = FakeAgentScenario(
+            result='holder done', gate=gate
+        )
+        r = await admin_client.post(
+            '/api/tasks',
+            json={'title': 'slot holder', 'store_id': store_id},
+        )
+        holder_id = r.json()['id']
+        for _ in range(200):
+            if install_fake_agent.is_running(holder_id):
+                break
+            await asyncio.sleep(0.02)
+        assert install_fake_agent.is_running(holder_id)
+        install_fake_agent.default_scenario = FakeAgentScenario(
+            result='B done'
+        )
+
+        pre = (await admin_client.get(f'/api/tasks/{b_id}')).json()
+        r2 = await admin_client.post(f'/api/tasks/{b_id}/execute-plan')
+        assert r2.status_code == 200, (r2.text, pre['status'], pre.get('plan'))
+
+        # While queued for the semaphore, B must NOT be RUNNING — the
+        # exact state the stall reaper used to kill.
+        await asyncio.sleep(0.3)
+        data = (await admin_client.get(f'/api/tasks/{b_id}')).json()
+        assert data['status'] in ('planned', 'queued')
+
+        # Release the slot: B transitions RUNNING only now, executes,
+        # completes.
+        gate.set()
+        final = await wait_for_task(admin_client, b_id)
+        assert final['status'] == 'completed'
+        assert final['result'] == 'B done'
+
+    async def test_task_failed_while_queued_aborts_spawn(
+        self, admin_client, install_fake_agent, override_async_session
+    ):
+        install_fake_agent.set_max_concurrent(1)
+        store_id = await _create_store(admin_client, 'Queue Abort Store')
+
+        install_fake_agent.default_scenario = FakeAgentScenario(
+            plan='## Plan\n1. do the thing', result='must never appear'
+        )
+        b_id = await _planned_task_with_dead_session(
+            admin_client, install_fake_agent, store_id, 'doomed executee'
+        )
+
+        gate = asyncio.Event()
+        install_fake_agent.default_scenario = FakeAgentScenario(
+            result='holder done', gate=gate
+        )
+        r = await admin_client.post(
+            '/api/tasks',
+            json={'title': 'slot holder 2', 'store_id': store_id},
+        )
+        holder_id = r.json()['id']
+        for _ in range(200):
+            if install_fake_agent.is_running(holder_id):
+                break
+            await asyncio.sleep(0.02)
+        assert install_fake_agent.is_running(holder_id)
+        install_fake_agent.default_scenario = FakeAgentScenario(
+            result='must never appear'
+        )
+
+        r2 = await admin_client.post(f'/api/tasks/{b_id}/execute-plan')
+        assert r2.status_code == 200
+        await asyncio.sleep(0.2)
+
+        # Reaper/user kills the task while it waits for a slot.
+        async with override_async_session() as db:
+            t = await db.get(Task, b_id)
+            t.status = 'failed'
+            t.error = 'force-failed while queued'
+            await db.commit()
+
+        gate.set()
+        # The queued spawn must ABORT (on_start sees FAILED): no agent
+        # run, no result, status untouched.
+        await asyncio.sleep(0.5)
+        data = (await admin_client.get(f'/api/tasks/{b_id}')).json()
+        assert data['status'] == 'failed'
+        assert not data.get('result')
+        runs = install_fake_agent.get_calls(task_id=b_id, action='run')
+        # Only the original planning run — the queued EXECUTE spawn
+        # was aborted by on_start.
+        assert len(runs) == 1
+        assert runs[0].mode == 'plan_then_execute'


### PR DESCRIPTION
## Context

A scheduled all-stores fan-out surfaced three defects at once: two
fan-out tasks were force-failed by the stall reaper **before their
agents ever started**, then ran complete audits into the dead tasks
("Cannot set result on task in status failed"); a third task produced
a complete deliverable but shipped as FAILED because the agent —
coerced by an unsatisfiable completeness gate through 5 redrives —
called `set_task_error` with a "remaining caveats" note.

## Fixes (design-level)

### 1. Exec paths defer RUNNING until the concurrency slot is held
`execute_planned_task` / `execute_woken_task` committed RUNNING
*before* `agent_manager.run()` blocked on the semaphore. Tasks fanned
out beyond `max_concurrent` sat RUNNING-and-silent with `updated_at`
frozen at creation → the stall reaper's 3-minute rule failed them
(they were **queued, not stalled** — the "provider dropped the SSE
stream" error text was a mis-diagnosis), and the still-queued spawn
later started a full session against the FAILED task.

Both paths now pass `on_start` (new `make_exec_on_start` in
`task_session_lifecycle`, mirroring `auto_run_task._on_start`, which
fixed this same bug on the auto path long ago): queued tasks keep
their pre-run status invisible to the reaper, and a task that left the
expected state while queued **aborts the spawn**.

### 2. `set_task_error` + valid result ⇒ caveat, never 失败
The error channel means *unrecoverable failure*. With a non-empty
result already on the task, the text is now appended to the result as
an "Agent-reported caveats" block, `task.error` stays untouched, and
the endpoint's response tells the agent the task will NOT fail (so it
doesn't retry the channel). Symmetric recovery: `set_task_result`
clears an earlier `agent_reported` error. Error with no deliverable
keeps the classic FAILED contract. (`record_agent_error` in
`tasks_files`; the endpoint moved there for the 800-line cap.)

### 3. Redrive message stops pointing at the loaded gun
The review-gate redrive text now explicitly says: if the gate cannot
be satisfied, finish normally and put the caveats IN THE RESULT —
never `set_task_error` for partial work.

## Tests
- `test_wf_exec_queue_race.py`: queued execute-plan task stays
  PLANNED/QUEUED behind a saturated semaphore and completes when a
  slot frees; a task failed while queued aborts the spawn (no second
  agent run, no result).
- `test_wf_error_result_contract.py`: error-after-result → caveat in
  result, COMPLETED; error-without-result → FAILED (classic);
  result-after-error → error cleared, COMPLETED.
- FakeAgent gains `loaded_skills_and_workspace` so workflow tests
  drive the real `set_task_result` endpoint.
- Full `pytest -m "unit or workflow"`: 1916 passed (one pre-existing
  environmental failure, identical on main).

Also adds the local investigation notes file to `.gitignore` so it can
never be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg5csnfP39iFPAEqcEnqwK