### PR TITLE
fix(amazon-ads): defeat persisted campaign-list search/status filter in enumeration

### DIFF
--- a/app/skills_v2/amazon-ads/SKILL.md
+++ b/app/skills_v2/amazon-ads/SKILL.md
@@ -36,6 +36,36 @@ back to the user ("please do X manually"). Work the problem:
   itself. If you catch yourself scrolling a grid and re-reading, stop —
   export instead.
 
+- **A persisted search/status filter silently hides campaigns — clear
+  it FIRST, and trust the grid's own total, not a scraped row count.**
+  The Campaign Manager's campaign-search box keeps whatever term was last
+  typed (stored in the browser profile, not the URL), so it stays applied
+  when you open the list and can show a small fraction of a much larger
+  account. **Before enumerating, if the campaign-search input has a
+  non-empty value, campaigns are hidden — clear it.** Three traps make
+  this the most common under-count cause, all verified live:
+    - **The list-level "clear filters" / "remove all" control does NOT
+      clear it** — that only drops the status/type filter *chips*; the
+      search term survives.
+    - **Setting the input `.value` does NOT clear it** — the field is
+      React-controlled: it re-applies the old filter, and a `value===''`
+      check then *falsely* passes ("false-cleared").
+    - **A synthetic `dispatchEvent` click on the ✕ does nothing** — the
+      widget only honors a *trusted* pointer event.
+  **What works: a REAL coordinate click (`click_at_xy`) on the search
+  box's own clear ✕** — locate it by the aria-label `Clear search terms`
+  (aria-labels stay English even on a localized UI; the visible
+  placeholder/footer text does not, so never key on that). Then read the
+  grid's **`aria-rowcount`** (language-neutral; the full filtered total,
+  not the ~13 virtualized DOM rows) — a real clear makes it jump. **A
+  suspiciously low total = a filter still applied; do not report it.**
+  Also clear the default status filter so paused/archived campaigns
+  count. Amazon ships more than one console layout — the exact selectors
+  are the common ag-grid case, but the invariant holds on all of them:
+  trust the grid's own total over any DOM scrape. Snippet + fallbacks:
+  [`mechanics.md`](references/mechanics.md) §2a (**load it before your
+  first campaign-list read**).
+
 - **Data is scoped to whatever marketplace the console is showing — so a
   country's absence is never proof it's empty.** Amazon's ad console comes
   in more than one shape, and you must not assume which you're on:

--- a/app/skills_v2/amazon-ads/references/audit-quickref.md
+++ b/app/skills_v2/amazon-ads/references/audit-quickref.md
@@ -51,9 +51,17 @@ Completeness is the #1 thing the reviewer checks. Get the FULL active
 set before drilling.
 
 - **Amazon**: open Campaign Manager via the in-page menu (not a typed
-  URL). **Clear the "Find a campaign" search box** (a stale term hides
-  most campaigns) and set the date to 30 days. The grid virtualizes —
-  do NOT count DOM rows; use **Bulk Operations**. On that page, **reuse
+  URL). **Clear the campaign-search box with a real `click_at_xy` on its
+  ✕ (`aria-label="Clear search terms"`) — NOT by setting the input value
+  and NOT via the list-level "clear filters" control** (a persisted term
+  hides most campaigns; the native-setter clear is a false-CLEARED trap —
+  see `mechanics.md` §2a). **Verify by the grid's `aria-rowcount`**
+  (language-neutral), never by the input going blank: a real clear makes
+  it jump to the whole-account count, and that number is your
+  completeness target. Also clear the default status filter so
+  paused/archived campaigns count too. Then set the date
+  to 30 days. The grid virtualizes — do NOT count DOM rows; use **Bulk
+  Operations**. On that page, **reuse
   the newest existing export first** — walk shadow roots for the
   `<a download …/bulk-operations/download/…xlsx>` links and, if the
   newest one's filename date range covers your window, just click it

--- a/app/skills_v2/amazon-ads/references/mechanics.md
+++ b/app/skills_v2/amazon-ads/references/mechanics.md
@@ -127,48 +127,78 @@ jump straight to the campaigns you want.
 > store that actually has 145 — the agent read the filtered list as if
 > it were the whole account.
 >
-> **Phase 1 (Discover) must enumerate the WHOLE account, so before you
-> read the list you must clear the search and confirm it's empty:**
+> **Phase 1 (Discover) must enumerate the WHOLE account. A persisted
+> search term silently hides most campaigns, and clearing it correctly is
+> harder than it looks — three dead ends bite here (all verified live).
+> Match by language-STABLE anchors: the UI text is localized, but
+> `aria-label`s stay English and `aria-rowcount` is numeric — key on
+> those, never on visible label text.**
 >
-> ```js
-> // pass this to js("""…""") — clears any persisted "Find a campaign" term
-> (function(){
->   var inp=[...document.querySelectorAll('input')]
->     .find(function(i){return /Find a campaign|查找广告活动/
->       .test(i.getAttribute('placeholder')||'');});
->   if(!inp) return 'NO_SEARCH_INPUT';
->   var set=Object.getOwnPropertyDescriptor(
->     window.HTMLInputElement.prototype,'value').set;
->   set.call(inp,'');
->   inp.dispatchEvent(new Event('input',{bubbles:true}));
->   inp.dispatchEvent(new KeyboardEvent('keydown',{bubbles:true,key:'Enter'}));
->   return 'CLEARED';
-> })()
+> 1. ⚠️ **The native-setter clear is a FALSE-CLEARED trap.** The search is
+>    a React-controlled input; `value` setter + `input`/`Enter` zeroes the
+>    DOM `.value` **without resetting the applied filter**. The grid keeps
+>    showing the filtered subset, yet a follow-up `input.value === ''`
+>    check now *passes* — so you "confirm cleared" and read a filtered list
+>    as the whole account.
+> 2. ⚠️ **The list-level "clear filters" / "remove all" control does NOT
+>    clear the search box.** It removes the *status/type filter chips*
+>    only; the search term is a separate control and survives it. (An
+>    audit that used only that control reported a tiny total for an account
+>    with an order of magnitude more campaigns.)
+> 3. ⚠️ **A synthetic `dispatchEvent(new MouseEvent('click'))` on the ✕
+>    does nothing** — the widget only reacts to a *trusted* pointer event.
+>    You must issue a **real coordinate click**.
+>
+> **The one method that works: real `click_at_xy` on the search box's own
+> clear ✕**, located by the English `aria-label` `Clear search terms`.
+> There can be two such ✕ on the page (a metrics search + the campaign
+> search); the campaign one sits just above the campaign grid, so pick the
+> closest ✕ above the grid — no dependence on placeholder language:
+>
+> ```python
+> xy = js(r'''
+>   var grid=document.querySelector("[role=grid],[role=treegrid]");
+>   var gtop=grid?grid.getBoundingClientRect().top:1e9;
+>   var cands=[...document.querySelectorAll('button[aria-label]')]
+>     .filter(function(b){return /clear search/i.test(b.getAttribute("aria-label")||"");})
+>     .map(function(b){return {b:b,r:b.getBoundingClientRect()};})
+>     .filter(function(o){return o.r.width>0 && o.r.top<gtop;});   // ✕ above the grid
+>   if(!cands.length) return "null";                                // no ✕ => already empty
+>   cands.sort(function(a,z){return z.r.top-a.r.top;});             // closest above grid
+>   var e=cands[0].b; e.scrollIntoView({block:"center"});
+>   var r=e.getBoundingClientRect();
+>   return JSON.stringify({x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)});
+> ''')
+> import json
+> if xy!="null":
+>     c=json.loads(xy); click_at_xy(c["x"], c["y"])   # REAL click — dispatchEvent is ignored
 > ```
 >
-> Then **verify the true total** before trusting any row count — the
-> grid's `aria-rowcount` (minus the header row) is authoritative and
-> reflects the full filtered set, not just the rendered rows:
+> Then **verify by the grid's own total, never by the input value** —
+> `aria-rowcount` (minus the header row) is language-neutral and covers the
+> full filtered set. A real clear makes it jump to the whole-account count:
 >
-> ```js
-> (function(){
->   var g=document.querySelector('[role=grid],[role=treegrid]');
->   var inp=[...document.querySelectorAll('input')]
->     .find(function(i){return /Find a campaign|查找广告活动/
->       .test(i.getAttribute('placeholder')||'');});
->   return JSON.stringify({searchVal:inp?inp.value:null,
->     totalRows:(+g.getAttribute('aria-rowcount'))-1});
-> })()
+> ```python
+> print(js('var g=document.querySelector("[role=grid],[role=treegrid]"); return g?(+g.getAttribute("aria-rowcount"))-1:null;'))
 > ```
 >
-> If `searchVal` is non-empty, you did not clear it — stop and clear
-> before reading. The grid **virtualizes** (≈13 DOM rows regardless of
-> total), so `querySelectorAll('.ag-center-cols-container [role=row]')`
-> NEVER gives you the full list once the account has >~15 campaigns. For
-> the full enumeration use **bulk download** (§2d) — it is the only
-> reliable way to capture every campaign's name/id/status/type/spend in
-> one shot. Treat any DOM-scrape of the campaign list as a spot-check,
-> never as the manifest.
+> **That number is your completeness target.** If it did NOT rise after the
+> clear, the search is still applied — re-run the ✕ click; do not proceed
+> on a total that looks small for the account. Also clear the default
+> status filter (its own chip ×) so paused/archived campaigns count. The
+> grid **virtualizes** (only ~a dozen DOM rows exist regardless of total),
+> so scraping `[role=row]` NEVER yields the full list once the account has
+> more than ~15 campaigns. For the full enumeration use **bulk download**
+> (§2d); if that is unavailable (see the 404 note in §2d), the
+> grid-with-`aria-rowcount` path above is the backstop — paginate the
+> `Next Page` control until you have collected that many ids.
+>
+> **Amazon ships more than one console layout** (grid vs card, different
+> class names, LTR/RTL). The selectors above are the common ag-grid case;
+> if `[role=grid]`/the ✕ aren't found, the *invariant* still holds — a
+> persisted search/status filter hides rows, so find the list's own
+> total-count element and its search-clear affordance for whatever layout
+> you're on, and trust that total over any DOM row scrape.
 
 The default status filter is "Active : Enabled" (a removable chip
 near the table). The "Remove all" link near the top *doesn't* clear
@@ -228,6 +258,18 @@ keyword and category and auto-target groups.
 The "Total: N" cell in the table footer is the authoritative count.
 
 ### 2d. Bulk download (cross-campaign capture)
+
+> ⚠️ **If the bulk-operations page 404s / has no export UI, do NOT fall
+> back to a raw grid scrape — you will silently under-count.** Some
+> accounts (observed on a multi-country consolidated ad account) return
+> 404 on `…/campaign-manager/bulk-operations?entityId=…` and expose no
+> Bulk Operations nav link. When that happens, enumerate from the grid
+> the SAFE way (§2a): clear the "Find a campaign" search via its ✕,
+> remove the "Active: Enabled" status chip, read the authoritative
+> `Total: N` / `aria-rowcount`, and **paginate `Next Page` until you have
+> collected all N ids**. The grid path is only reliable once the search
+> and status filters are provably cleared (verified by the total), which
+> is exactly the step a 404-driven fallback tends to skip.
 
 **FIRST, reuse the newest existing export — do NOT generate a fresh job
 by default.** For a read-only audit you need a recent snapshot, not a


### PR DESCRIPTION
## Why

A stale term left in the Campaign Manager's **campaign-search box** (stored in the browser profile, not the URL) stays *applied* when the console opens, silently hiding most campaigns. An audit read the filtered list as the whole account and reported a total an order of magnitude too low.

**Verified live:** a store whose console showed a "3-campaign" total under a leftover search term actually had **59 campaigns**. The skill already told the agent to "clear the search," but the documented method didn't work and the guidance lived only in reference files a lightweight task never loads.

## The three clearing traps (all verified live) + the one method that works

- **List-level "clear filters / remove all"** drops only the status/type filter *chips* — the search term survives it.
- **Setting the React-controlled input's `.value`** zeroes the DOM value **without** resetting the filter, so a `value===''` check *falsely* passes ("false-cleared").
- **A synthetic `dispatchEvent` click on the ✕** is ignored (untrusted event).
- ✅ **What works:** a **real `click_at_xy`** on the search box's own clear ✕, located by the language-stable `aria-label="Clear search terms"` (the campaign ✕ is the closest one above the grid), then verify the grid's **`aria-rowcount`** jumped — never trust the input going blank.

## Design

- **Moved the invariant into the always-loaded `SKILL.md` preconditions.** A non-audit task never opens `mechanics.md`/`audit-quickref.md`, so the guidance buried there was skipped and the bug reproduced. (Confirmed: the failing run never `Read` those files.)
- **Language-neutral:** keys on English `aria-label`s + numeric `aria-rowcount`, not localized visible text (UI text is localized; aria-labels are not). No hardcoded country.
- **Layout-general:** states the invariant for Amazon's multiple console layouts, with the ag-grid selectors as the common case + an explicit fallback.
- **Bulk-Operations-404 fallback** (`mechanics.md` §2d): when the bulk export page 404s, enumerate from the grid the *safe* way (clear search + status, read `aria-rowcount`, paginate) instead of a raw scrape.

## Verification

Reproduced the stuck filter on a real store, restarted (`--dev`) to sync the skill, and ran a live task through the normal task flow:
- **Before the fix:** agent reported the filtered total (wrong).
- **After the fix:** agent cleared the residual search + status filters, read `aria-rowcount`, and reported the **true total (59)**; independent reviewer re-verified (Status: ok).

## Scope

Only `app/skills_v2/amazon-ads/` (active tree). All examples use placeholders — no project id, entity, SKU, brand, or store name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)