### PR TITLE
fix(routing): keep store selected when opening a store's task

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -244,10 +244,10 @@ export default function App() {
   // The URL is the source of truth for what's open. Each effect loads
   // the rich object when its route param appears and clears it when the
   // param is gone (Back / navigating away). Guards prevent reload loops.
-  // List scope from the route alone: a store, or the all-stores list on
-  // the tasks view (the open task is orthogonal — /tasks and /tasks/$id
-  // share the 'all' scope). loadedScopeRef loads it once per scope
-  // change, incl. the initial landing.
+  // List scope from the route alone: a store (either /stores/$id or a task
+  // open under it, /stores/$id/tasks/$tid), or the all-stores list on the
+  // tasks view (/tasks and the flat /tasks/$id for no-store tasks).
+  // loadedScopeRef loads it once per scope change, incl. initial landing.
   const listScopeKey = routeStoreId
     ? `store:${routeStoreId}`
     : appView === 'tasks' && taskSubTab === 'onetime'
@@ -422,7 +422,16 @@ export default function App() {
   // (selectScope / loadTaskById) so URL is the single source of truth.
   const selectStore = (store: Store) => navigate({ to: '/stores/$storeId', params: { storeId: store.id } })
   const selectAllTasks = () => navigate({ to: '/tasks' })
-  const selectTask = (task: Task) => navigate({ to: '/tasks/$taskId', params: { taskId: task.id } })
+  // A store task opens under its store (/stores/$storeId/tasks/$taskId) so
+  // the URL keeps the store scope — otherwise the flat route drops it and
+  // the sidebar snaps back to All Stores. No-store tasks use the flat form.
+  const selectTask = (task: Task) =>
+    task.store_id
+      ? navigate({
+          to: '/stores/$storeId/tasks/$taskId',
+          params: { storeId: task.store_id, taskId: task.id },
+        })
+      : navigate({ to: '/tasks/$taskId', params: { taskId: task.id } })
 
   const loadTaskById = async (taskId: string) => {
     let fullTask: Task

--- a/frontend/src/__tests__/route.test.ts
+++ b/frontend/src/__tests__/route.test.ts
@@ -38,8 +38,16 @@ describe('parseNav — selection params', () => {
     expect(n.storeId).toBeNull()
     expect(n.scheduleId).toBeNull()
   })
-  it('a task path does not set a store id (flat scheme)', () => {
+  it('a flat task path (no-store task) sets no store id', () => {
     expect(parseNav('/tasks/t1').storeId).toBeNull()
+    expect(parseNav('/tasks/t1').taskId).toBe('t1')
+  })
+  it('a store-scoped task path sets both store and task id', () => {
+    const n = parseNav('/stores/s1/tasks/t1')
+    expect(n.storeId).toBe('s1')
+    expect(n.taskId).toBe('t1')
+    expect(n.appView).toBe('tasks')
+    expect(n.taskSubTab).toBe('onetime')
   })
 })
 

--- a/frontend/src/lib/route.ts
+++ b/frontend/src/lib/route.ts
@@ -40,7 +40,11 @@ export function parseNav(pathname: string): NavState {
   return {
     appView,
     settingsTab: slugToSettingsTab(tabSlug),
-    taskId: pathname.match(/^\/tasks\/([^/]+)/)?.[1] ?? null,
+    // A task path is either flat (/tasks/$id, no-store tasks) or nested
+    // under its store (/stores/$storeId/tasks/$id) — the nested form keeps
+    // the store selected while the task is open. Match both; the store id
+    // comes from the /stores/ prefix, present only in the nested form.
+    taskId: pathname.match(/^\/(?:stores\/[^/]+\/)?tasks\/([^/]+)/)?.[1] ?? null,
     storeId: pathname.match(/^\/stores\/([^/]+)/)?.[1] ?? null,
     scheduleId: pathname.match(/^\/schedules\/([^/]+)/)?.[1] ?? null,
     taskSubTab: pathname.startsWith('/schedules') ? 'scheduled' : 'onetime',

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -8,9 +8,11 @@
  * (type-safe `navigate`, no notFound on deep-links); their rendering is
  * still done by `App`, so they carry no component.
  *
- * Paths: /tasks · /tasks/$taskId · /stores/$storeId · /schedules ·
- * /schedules/$scheduleId · /workspace · /settings/$tab. `/` and
- * `/settings` redirect to sensible defaults.
+ * Paths: /tasks · /tasks/$taskId · /stores/$storeId ·
+ * /stores/$storeId/tasks/$taskId · /schedules · /schedules/$scheduleId ·
+ * /workspace · /settings/$tab. `/` and `/settings` redirect to sensible
+ * defaults. A store-scoped task lives under its store so opening it keeps
+ * the store selected (the flat /tasks/$taskId form is for no-store tasks).
  *
  * Routes are declared inline (not via a helper) so TanStack can infer
  * each literal path into the type-safe `navigate`/`redirect` surface.
@@ -47,6 +49,11 @@ const storeRoute = createRoute({
   path: 'stores/$storeId',
   component: () => null,
 })
+const storeTaskRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'stores/$storeId/tasks/$taskId',
+  component: () => null,
+})
 const schedulesRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: 'schedules',
@@ -80,6 +87,7 @@ const routeTree = rootRoute.addChildren([
   tasksRoute,
   taskRoute,
   storeRoute,
+  storeTaskRoute,
   schedulesRoute,
   scheduleRoute,
   workspaceRoute,


### PR DESCRIPTION
## Problem

On the Tasks page, selecting a store in the left sidebar and then clicking one of its tasks loaded the task detail correctly, but the sidebar highlight **and** the middle-column list title snapped back to **All Stores**. The user lost the store context just by opening a task inside it.

## Root cause

Since #94 (`refactor(routing): URL-based navigation with TanStack Router`), the list scope is derived **entirely from the URL**. The task route was flat — `/tasks/$taskId` — carrying no store id. So:

1. `selectTask` navigated to the flat route, dropping the store from the URL.
2. The scope-reconciliation effect recomputed the scope to `all` (no `routeStoreId`) and reset the selected store to All Stores.

The design surface that made this possible: a store-scoped task had no URL that expressed "this task, open within its store."

## Fix (design, not symptom)

A store-scoped task now lives under its store:

```
/stores/$storeId/tasks/$taskId
```

so the URL — the single source of truth for scope — always carries the store while its task is open. No-store (orchestrator) tasks keep the flat `/tasks/$taskId` form.

- `router.tsx` — new nested `stores/$storeId/tasks/$taskId` route.
- `lib/route.ts` — `parseNav` extracts the task id from **both** the flat and store-scoped forms; the store id comes from the `/stores/` prefix.
- `App.tsx` — `selectTask` picks the route by `task.store_id`.
- `route.test.ts` — pins the nested-scheme contract.

## Verification

- All 367 frontend unit tests pass; `tsc --noEmit` clean; ESLint clean (0 errors).
- Verified live in a browser against a running dev server: clicking a store's task now navigates to the nested URL, the sidebar keeps the store highlighted, and the middle-column title stays on the store. Confirmed both the in-app click path and a cold deep-link reload of the nested URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)