### PR TITLE
fix(chat): stage attachments until Send instead of writing to agent cwd

### DIFF
--- a/app/routers/tasks_conversation.py
+++ b/app/routers/tasks_conversation.py
@@ -28,6 +28,7 @@ from app.models.user import User
 from app.plan_states import PlanStatus
 from app.routers.dida365_oauth import refresh_token_if_needed
 from app.routers.tasks import schedule_or_run
+from app.routers.tasks_files import promote_staged_attachments
 from app.scheduler.task_queue import task_queue_scheduler
 from app.task_runner import (
     TaskHeader,
@@ -100,7 +101,10 @@ async def send_task_message(
     restarted with the new profile environment and full chat history.
     """
     content = body.get('content', '').strip()
-    if not content:
+    attachment_ids = body.get('attachment_ids') or []
+    if not isinstance(attachment_ids, list):
+        attachment_ids = []
+    if not content and not attachment_ids:
         raise HTTPException(status_code=400, detail='content is required')
 
     task = await db.get(Task, task_id)
@@ -113,12 +117,39 @@ async def send_task_message(
     current_profile_id = task.ai_profile_id or DEFAULT_PROFILE_ID
     is_profile_switch = requested_profile_id != current_profile_id
 
-    # Save the user message
+    # Promote staged chat attachments into the task workspace. This is the
+    # ONE moment an attachment becomes visible to the agent: staging kept
+    # it outside the agent's cwd until the user pressed Send. From here we
+    # keep TWO content strings:
+    #   display_content — stored + shown in the transcript; images become
+    #                     markdown so the user sees a thumbnail, not a path.
+    #   agent_content   — delivered to the agent; absolute paths it Reads
+    #                     directly (images are vision input).
+    attachments = (
+        promote_staged_attachments(task_id, attachment_ids)
+        if attachment_ids
+        else []
+    )
+    display_content = content
+    agent_content = content
+    if attachments:
+        img_md = '\n'.join(
+            f'![{a["filename"]}]({a["url"]})' for a in attachments
+        )
+        file_lines = '\n'.join(
+            f'Attached file: {a["abs_path"]}' for a in attachments
+        )
+        display_content = f'{content}\n{img_md}'.strip() if content else img_md
+        agent_content = (
+            f'{content}\n{file_lines}'.strip() if content else file_lines
+        )
+
+    # Save the user message (transcript-facing content)
     seq = await get_next_seq(db, task_id)
     user_message = TaskMessage(
         task_id=task_id,
         role='user',
-        content=content,
+        content=display_content,
         seq=seq,
         profile_id=requested_profile_id if is_profile_switch else None,
     )
@@ -133,15 +164,30 @@ async def send_task_message(
 
     await db.commit()
 
-    # Emit user message to SSE so other clients see it
+    # Emit user message to SSE so other clients see it (transcript view)
     await event_bus.emit(
         'task_message',
         {
             'task_id': task_id,
             'role': 'user',
-            'content': content,
+            'content': display_content,
         },
     )
+
+    # Everything below delivers to the AGENT — use the path-bearing
+    # content so promoted attachments reach it (send_message stdin, wake
+    # trigger_data, resume/fresh-session prompt all read ``content``).
+    content = agent_content
+
+    # Canonical "message accepted" fields every return path echoes, so the
+    # client can render the exact stored bubble (thumbnails, not paths).
+    accepted = {
+        'ok': True,
+        'task_id': task_id,
+        'profile_id': requested_profile_id,
+        'content': display_content,
+        'attachments': attachments,
+    }
 
     # Handle waiting tasks: treat message as wake action
     if task.status in WAKEABLE:
@@ -163,9 +209,7 @@ async def send_task_message(
             await task_queue_scheduler.submit(task_id, task.store_id)
 
         return {
-            'ok': True,
-            'task_id': task_id,
-            'profile_id': requested_profile_id,
+            **accepted,
             'profile_switched': is_profile_switch,
             'woken': True,
         }
@@ -207,12 +251,7 @@ async def send_task_message(
                         'error': None,
                     },
                 )
-                return {
-                    'ok': True,
-                    'task_id': task_id,
-                    'profile_id': requested_profile_id,
-                    'profile_switched': False,
-                }
+                return {**accepted, 'profile_switched': False}
 
     # Determine if we can resume a CLI session (has full context)
     is_plan_feedback = task.status == TaskStatus.PLANNED
@@ -393,12 +432,7 @@ async def send_task_message(
             feedback=content,
         )
         if rejected:
-            return {
-                'ok': True,
-                'task_id': task_id,
-                'profile_id': requested_profile_id,
-                'profile_switched': is_profile_switch,
-            }
+            return {**accepted, 'profile_switched': is_profile_switch}
 
         # Session died — start fresh plan_then_execute. Spawn off
         # the request path so a saturated agent semaphore doesn't
@@ -417,12 +451,7 @@ async def send_task_message(
                 revert_status=TaskStatus.PLANNED,
             )
         )
-        return {
-            'ok': True,
-            'task_id': task_id,
-            'profile_id': requested_profile_id,
-            'profile_switched': is_profile_switch,
-        }
+        return {**accepted, 'profile_switched': is_profile_switch}
     elif task.status in (TaskStatus.COMPLETED, TaskStatus.FAILED):
         # Follow-up on a finished task: clear stale data and
         # restart.  Auto mode → RUNNING; plan mode → DESIGNING.
@@ -482,12 +511,7 @@ async def send_task_message(
                 revert_error_category=prev_error_category,
             )
         )
-        return {
-            'ok': True,
-            'task_id': task_id,
-            'profile_id': requested_profile_id,
-            'profile_switched': is_profile_switch,
-        }
+        return {**accepted, 'profile_switched': is_profile_switch}
     else:
         await refresh_token_if_needed()
         # Mode selection for follow-ups on tasks NOT in WAITING /
@@ -528,12 +552,7 @@ async def send_task_message(
             )
         )
 
-    return {
-        'ok': True,
-        'task_id': task_id,
-        'profile_id': requested_profile_id,
-        'profile_switched': is_profile_switch,
-    }
+    return {**accepted, 'profile_switched': is_profile_switch}
 
 
 @router.get('/{task_id}/questions/pending')

--- a/app/routers/tasks_files.py
+++ b/app/routers/tasks_files.py
@@ -7,6 +7,7 @@ import mimetypes
 import os
 from pathlib import Path
 import re
+import shutil
 import tempfile
 import uuid
 import zipfile
@@ -351,25 +352,127 @@ _UPLOAD_ALLOWED_TYPES = {
     'application/pdf',
 }
 _UPLOAD_MAX_SIZE = 15 * 1024 * 1024  # 15MB
+_UPLOAD_ALLOWED_EXTS = ('.png', '.jpg', '.jpeg', '.gif', '.webp', '.pdf')
+
+# Chat attachments stage OUTSIDE the task workspace so the agent's cwd
+# (``tasks/<id>/``) never sees them via ``ls``/``find`` before Send. The
+# invariant: a user attachment becomes agent-visible ONLY when the user
+# sends the message that carries it. ``promote_staged_attachments`` (call
+# it from the /messages endpoint) is the single moment that happens.
+_CHAT_STAGING_DIR = VIBE_SELLER_DIR / 'chat_staging'
+_STAGING_ID_RE = re.compile(r'^[0-9a-f]{32}$')
+# Staged-but-never-sent files are swept on the next upload for the task.
+_STAGING_TTL_SECONDS = 24 * 3600
 
 
-@router.post('/{task_id}/files/upload')
-async def upload_task_file(
-    task_id: str,
-    file: UploadFile,
-    _user: User = Depends(get_current_user),
-):
-    """Save a user-supplied file into the task workspace ``uploads/``.
+class StagedAttachment(BaseModel):
+    """A chat file uploaded to staging, not yet visible to the agent."""
 
-    This is how chat attachments reach the AGENT: the file lands inside
-    the task workspace (the agent's cwd), and the returned ``abs_path``
-    is inserted into the user's message text, so the agent can Read it
-    directly (images included — the model reads them as vision input).
-    Unlike ``/api/attachments`` (DB-tracked blobs under the data dir,
-    invisible to the agent), this path is agent-first by design.
+    id: str
+    filename: str
+    content_type: str
+    # Preview URL for the send-bar chip / transcript thumbnail. NOT an
+    # absolute path — the path is withheld from the client by design.
+    url: str
+
+
+def _normalized_upload_name(file: UploadFile) -> str:
+    """ASCII-safe, cross-platform filename for a stored upload.
+
+    Strips everything outside ``[A-Za-z0-9._-]`` — which also removes
+    every character Windows forbids in a filename (``<>:"/\\|?*`` and
+    control chars) and non-ASCII (e.g. Chinese) names that break the
+    serve URL and browser-use path handling. So a Chinese-named upload
+    still lands as a valid ASCII path on macOS, Linux, and Windows.
+    """
+    raw = Path(file.filename or 'upload').name
+    stem = re.sub(r'[^A-Za-z0-9._-]', '_', Path(raw).stem) or 'upload'
+    ext = Path(raw).suffix.lower()
+    if ext not in _UPLOAD_ALLOWED_EXTS:
+        ext = mimetypes.guess_extension(file.content_type or '') or '.bin'
+    return f'{stem}{ext}'
+
+
+def _staging_task_dir(task_id: str) -> Path:
+    """Resolve a task's staging dir, guarding traversal via task_id."""
+    base = _CHAT_STAGING_DIR.resolve()
+    d = (_CHAT_STAGING_DIR / task_id).resolve()
+    if not d.is_relative_to(base):
+        raise HTTPException(status_code=400, detail='Invalid task id')
+    return d
+
+
+def _staging_item_dir(task_id: str, staged_id: str) -> Path:
+    """Resolve one staged item's dir; reject ids that aren't hex uuids."""
+    if not _STAGING_ID_RE.match(staged_id):
+        raise HTTPException(status_code=400, detail='Invalid attachment id')
+    base = _staging_task_dir(task_id)
+    d = (base / staged_id).resolve()
+    if not d.is_relative_to(base):
+        raise HTTPException(status_code=400, detail='Invalid attachment id')
+    return d
+
+
+def _sweep_stale_staging(task_staging: Path) -> None:
+    """Best-effort removal of staged items older than the TTL."""
+    if not task_staging.is_dir():
+        return
+    cutoff = datetime.now(UTC).timestamp() - _STAGING_TTL_SECONDS
+    for child in task_staging.iterdir():
+        try:
+            if child.is_dir() and child.stat().st_mtime < cutoff:
+                shutil.rmtree(child, ignore_errors=True)
+        except OSError:
+            pass
+
+
+def _staged_file(item_dir: Path) -> Path | None:
+    """The single stored file inside a staged item dir, if present."""
+    if not item_dir.is_dir():
+        return None
+    files = [p for p in item_dir.iterdir() if p.is_file()]
+    return files[0] if files else None
+
+
+def promote_staged_attachments(
+    task_id: str, staged_ids: list[str]
+) -> list[dict]:
+    """Move staged chat files into the task ``uploads/`` (the agent's cwd).
+
+    Called at SEND time only — this is the ONE moment a chat attachment
+    becomes visible to the agent. Returns one dict per promoted file with
+    ``abs_path`` (for the agent to Read — images are vision input),
+    ``url`` (for the UI thumbnail) and ``filename``. Unknown, malformed,
+    or already-consumed ids are skipped rather than erroring, so a stale
+    client id can't fail an otherwise-valid send.
     """
     task_dir = _validate_task_id(task_id)
-    task_dir.mkdir(parents=True, exist_ok=True)
+    out_dir = task_dir / 'uploads'
+    promoted: list[dict] = []
+    for sid in staged_ids:
+        try:
+            item = _staging_item_dir(task_id, sid)
+        except HTTPException:
+            continue
+        src = _staged_file(item)
+        if src is None:
+            continue
+        out_dir.mkdir(parents=True, exist_ok=True)
+        dest = out_dir / src.name
+        if dest.exists():
+            dest = out_dir / f'{src.stem}-{uuid.uuid4().hex[:6]}{src.suffix}'
+        shutil.move(str(src), str(dest))
+        shutil.rmtree(item, ignore_errors=True)
+        promoted.append({
+            'abs_path': str(dest),
+            'filename': dest.name,
+            'url': f'/api/tasks/{task_id}/files/uploads/{dest.name}',
+        })
+    return promoted
+
+
+async def _read_validated_upload(file: UploadFile) -> bytes:
+    """Read an upload, enforcing the image/pdf allow-list and size cap."""
     if file.content_type not in _UPLOAD_ALLOWED_TYPES:
         raise HTTPException(
             status_code=400,
@@ -380,25 +483,67 @@ async def upload_task_file(
         raise HTTPException(status_code=400, detail='Empty file')
     if len(data) > _UPLOAD_MAX_SIZE:
         raise HTTPException(status_code=413, detail='File too large (max 15MB)')
+    return data
 
-    raw = Path(file.filename or 'upload').name
-    stem = re.sub(r'[^A-Za-z0-9._-]', '_', Path(raw).stem) or 'upload'
-    ext = Path(raw).suffix.lower()
-    if ext not in ('.png', '.jpg', '.jpeg', '.gif', '.webp', '.pdf'):
-        ext = mimetypes.guess_extension(file.content_type or '') or '.bin'
-    out_dir = task_dir / 'uploads'
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f'{stem}{ext}'
-    if out_path.exists():
-        out_path = out_dir / f'{stem}-{uuid.uuid4().hex[:6]}{ext}'
-    out_path.write_bytes(data)
 
-    rel_path = f'uploads/{out_path.name}'
-    return {
-        'path': rel_path,
-        'abs_path': str(out_path),
-        'url': f'/api/tasks/{task_id}/files/{rel_path}',
-    }
+@router.post('/{task_id}/staged')
+async def stage_task_file(
+    task_id: str,
+    file: UploadFile,
+    _user: User = Depends(get_current_user),
+) -> StagedAttachment:
+    """Stage a chat attachment WITHOUT exposing it to the agent yet.
+
+    The file lands under ``chat_staging/<task_id>/<id>/`` — a sibling of
+    the task workspace, never in the agent's cwd — so a running agent
+    can't pick it up by scanning its directory. It only reaches the agent
+    when the user sends a message referencing it (see
+    ``promote_staged_attachments``). Returns a preview URL, never a path.
+    """
+    data = await _read_validated_upload(file)
+    base = _staging_task_dir(task_id)
+    base.mkdir(parents=True, exist_ok=True)
+    _sweep_stale_staging(base)
+    staged_id = uuid.uuid4().hex
+    item = base / staged_id
+    item.mkdir()
+    name = _normalized_upload_name(file)
+    (item / name).write_bytes(data)
+    return StagedAttachment(
+        id=staged_id,
+        filename=name,
+        content_type=file.content_type or 'application/octet-stream',
+        url=f'/api/tasks/{task_id}/staged/{staged_id}',
+    )
+
+
+@router.get('/{task_id}/staged/{staged_id}')
+async def get_staged_file(
+    task_id: str,
+    staged_id: str,
+    _user: User = Depends(get_current_user),
+):
+    """Serve a staged attachment for the send-bar chip / thumbnail."""
+    resolved = _staged_file(_staging_item_dir(task_id, staged_id))
+    if resolved is None:
+        raise HTTPException(status_code=404, detail='Attachment not found')
+    mime, _ = mimetypes.guess_type(resolved.name)
+    return FileResponse(
+        path=str(resolved),
+        filename=resolved.name,
+        media_type=mime or 'application/octet-stream',
+    )
+
+
+@router.delete('/{task_id}/staged/{staged_id}')
+async def delete_staged_file(
+    task_id: str,
+    staged_id: str,
+    _user: User = Depends(get_current_user),
+):
+    """Discard a staged attachment (the send-bar chip's ✕ button)."""
+    shutil.rmtree(_staging_item_dir(task_id, staged_id), ignore_errors=True)
+    return {'ok': True}
 
 
 def record_agent_error(task, error_text: str) -> dict | None:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,7 +34,7 @@ import { sendChatMessage as sendChatMessageHandler } from './handlers/sendChatMe
 import type {
   Store, Task, TaskStep, AgentMessage, TodoItem, AuthUser, Profile,
   WsStructured, ZiniaoAccount, ZiniaoBrowserProfile,
-  AppView, PendingFile, Schedule, EmailAccount, ConversationItem,
+  AppView, PendingFile, Schedule, EmailAccount, ConversationItem, StagedAttachment,
 } from './types'
 
 export default function App() {
@@ -104,6 +104,7 @@ export default function App() {
   const [otherInputs, setOtherInputs] = useState<Record<string, string>>({})
   const [showOtherInput, setShowOtherInput] = useState<Record<string, boolean>>({})
   const [chatInput, setChatInput] = useState('')
+  const [chatAttachments, setChatAttachments] = useState<StagedAttachment[]>([])
   const [conversationItems, setConversationItems] = useState<ConversationItem[]>([])
   const questionBannerRef = useRef<HTMLDivElement>(null)
   const [debugMode, setDebugMode] = useState(false)
@@ -438,7 +439,7 @@ export default function App() {
     try { fullTask = await api.get(`/api/tasks/${taskId}`) } catch { return }
     setSelectedTask(fullTask); setLogs([]); setScreenshots({}); setAgentMessages([])
     if (fullTask.todos) { try { setTodoItems(JSON.parse(fullTask.todos)) } catch { setTodoItems([]) } } else { setTodoItems([]) }
-    setSelectedAnswers({}); setOtherInputs({}); setShowOtherInput({}); setChatInput('')
+    setSelectedAnswers({}); setOtherInputs({}); setShowOtherInput({}); setChatInput(''); setChatAttachments([])
     setPendingQuestions(null)  // Clear immediately to avoid stale UI
     // Recover pending question if agent is waiting
     try {
@@ -514,9 +515,10 @@ export default function App() {
   const sendingRef = useRef(false)
   const sendChatMessage = () =>
     sendChatMessageHandler({
-      api, selectedTask, chatInput, profileId: selectedProfileId,
-      conversationItems, sendingRef,
-      setChatInput, setAgentMessages, setConversationItems, setSelectedTask, setTasks,
+      api, selectedTask, chatInput, attachments: chatAttachments,
+      profileId: selectedProfileId, conversationItems, sendingRef,
+      setChatInput, setAttachments: setChatAttachments, setAgentMessages,
+      setConversationItems, setSelectedTask, setTasks,
     })
 
   // ─── Profile helpers ───────────────────────────────
@@ -604,7 +606,7 @@ export default function App() {
           await fetch(`/api/attachments/${taskId}`, { method: 'POST', body: form, credentials: 'include' })
         },
         onCreated: () => {
-          setSteps([]); setScreenshots({}); setLogs([]); setConversationItems([]); setAgentMessages([]); setTodoItems([]); setPendingQuestions(null); setSelectedAnswers({}); setOtherInputs({}); setShowOtherInput({}); setChatInput('')
+          setSteps([]); setScreenshots({}); setLogs([]); setConversationItems([]); setAgentMessages([]); setTodoItems([]); setPendingQuestions(null); setSelectedAnswers({}); setOtherInputs({}); setShowOtherInput({}); setChatInput(''); setChatAttachments([])
         },
       },
     )
@@ -662,7 +664,8 @@ export default function App() {
           agentMessages={agentMessages} todoItems={todoItems} pendingQuestions={pendingQuestions}
           conversationItems={conversationItems}
           selectedAnswers={selectedAnswers} otherInputs={otherInputs} showOtherInput={showOtherInput}
-          chatInput={chatInput} setChatInput={setChatInput} debugMode={debugMode} setDebugMode={setDebugMode}
+          chatInput={chatInput} setChatInput={setChatInput}
+          chatAttachments={chatAttachments} setChatAttachments={setChatAttachments} debugMode={debugMode} setDebugMode={setDebugMode}
           profiles={profiles} selectedProfileId={selectedProfileId} setSelectedProfileId={setSelectedProfileId}
           currentUser={currentUser} showAllTasks={showAllTasks}
           openCreateModal={() => setShowCreateTask(true)} selectTask={selectTask}

--- a/frontend/src/__tests__/chatAttachments.test.tsx
+++ b/frontend/src/__tests__/chatAttachments.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * Chat attachment UX (stage-until-send redesign):
+ *  - Picking a file uploads it to STAGING and shows a removable chip —
+ *    the message textarea is NEVER polluted with a raw path.
+ *  - The chip's ✕ discards the staged file.
+ *  - sendChatMessage sends {content, attachment_ids} for any combination
+ *    of text and attachments, and renders the server's canonical content.
+ *  - A user bubble renders attachment thumbnails, not the path/URL text.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { TasksView } from '../views/TasksView'
+import { MessageBubble } from '../components/conversation/MessageBubble'
+import { sendChatMessage } from '../handlers/sendChatMessage'
+import type { Task, StagedAttachment, ConversationItem } from '../types'
+
+vi.mock('../lib/telemetry', () => ({
+  sendEvent: vi.fn(),
+  lengthBucket: () => 'small',
+  ageBucket: () => 'new',
+}))
+
+// TasksView's subcomponents (SubtaskList etc.) fetch via the api wrapper;
+// keep those inert so only the raw-`fetch` staging upload is exercised.
+vi.mock('../api', () => ({
+  api: {
+    get: vi.fn(async () => []),
+    post: vi.fn(async () => ({})),
+    patch: vi.fn(async () => ({})),
+    put: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  },
+}))
+
+function runningTask(): Task {
+  return {
+    id: 'task-1', store_id: 'store-1', title: 'T', description: null,
+    status: 'completed', plan: null, result: null, todos: null,
+    wait_condition: null, error: null, plan_mode: false,
+    ai_profile_id: 'default', schedule_id: null, batch_id: null,
+    created_at: '', started_at: null, completed_at: null, is_plan_only: false,
+  } as Task
+}
+
+function makeProps(over: Record<string, unknown> = {}) {
+  const noop = vi.fn()
+  return {
+    taskPanelActive: true, taskPanelTitle: 'Tasks', tasks: [],
+    selectedTask: runningTask(), steps: [], screenshots: [], logs: [],
+    agentMessages: [], todoItems: [], pendingQuestions: null,
+    conversationItems: [], selectedAnswers: {}, otherInputs: {},
+    showOtherInput: {}, chatInput: '', setChatInput: noop,
+    chatAttachments: [], setChatAttachments: noop, debugMode: false,
+    setDebugMode: noop, profiles: [], selectedProfileId: 'default',
+    setSelectedProfileId: noop, currentUser: null, showAllTasks: false,
+    openCreateModal: noop, selectTask: noop, stopAgent: noop,
+    retryTask: noop, continueTask: noop, deleteTask: noop, selectAnswer: noop,
+    toggleOtherInput: noop, setOtherAnswer: noop, submitAllAnswers: noop,
+    sendChatMessage: noop, setSelectedTask: noop, setTasks: noop,
+    setCurrentUser: noop, setEditingProfile: noop, setShowProfileModal: noop,
+    questionBannerRef: { current: null }, taskSubTab: 'tasks',
+    setTaskSubTab: noop, schedules: [], selectedSchedule: null,
+    scheduleTasks: [], showCreateSchedule: false, setShowCreateSchedule: noop,
+    selectSchedule: noop, deleteSchedule: noop, toggleSchedulePause: noop,
+    triggerSchedule: noop, replanSchedule: noop, setSelectedSchedule: noop,
+    onScheduleUpdated: noop, selectedStore: null, stores: [],
+    ...over,
+  }
+}
+
+// Stateful wrapper so setChatAttachments actually updates rendered chips.
+function Harness(props: Record<string, unknown>) {
+  const [atts, setAtts] = useState<StagedAttachment[]>([])
+  const [input, setInput] = useState('')
+  return (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    <TasksView {...(props as any)} chatInput={input} setChatInput={setInput}
+      chatAttachments={atts} setChatAttachments={setAtts} />
+  )
+}
+
+describe('chat attachment chips (stage-until-send)', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('picking a file shows a chip and leaves the textarea untouched', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        filename: 'photo.png', content_type: 'image/png',
+        url: '/api/tasks/task-1/staged/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      }),
+    })))
+    render(<Harness {...makeProps()} />)
+
+    const input = screen.getByTestId('chat-file-input')
+    const file = new File([new Uint8Array([1, 2, 3])], 'photo.png', { type: 'image/png' })
+    fireEvent.change(input, { target: { files: [file] } })
+
+    const chip = await screen.findByTestId('chat-attachment-chip')
+    expect(chip).toHaveTextContent('photo.png')
+    // The textarea must NOT contain the path/URL.
+    const textarea = screen.getByTestId('chat-input') as HTMLTextAreaElement
+    expect(textarea.value).toBe('')
+    expect(textarea.value).not.toContain('/api/tasks')
+    // POSTed to the STAGING endpoint (outside the agent cwd), not the workspace.
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0])
+      .toBe('/api/tasks/task-1/staged')
+  })
+
+  it('the chip ✕ removes the staged attachment', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        id: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        filename: 'doc.pdf', content_type: 'application/pdf',
+        url: '/api/tasks/task-1/staged/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      }),
+    })))
+    render(<Harness {...makeProps()} />)
+    fireEvent.change(screen.getByTestId('chat-file-input'), {
+      target: { files: [new File(['x'], 'doc.pdf', { type: 'application/pdf' })] },
+    })
+    await screen.findByTestId('chat-attachment-chip')
+    fireEvent.click(screen.getByTestId('chat-attachment-remove'))
+    await waitFor(() =>
+      expect(screen.queryByTestId('chat-attachment-chip')).toBeNull())
+  })
+})
+
+describe('sendChatMessage: text / attachment / both combinations', () => {
+  function baseDeps(over: Record<string, unknown> = {}) {
+    const post = vi.fn(async () => ({ content: 'echo' }))
+    return {
+      deps: {
+        api: { post },
+        selectedTask: runningTask(),
+        chatInput: '', attachments: [] as StagedAttachment[],
+        profileId: 'default', conversationItems: [] as ConversationItem[],
+        sendingRef: { current: false },
+        setChatInput: vi.fn(), setAttachments: vi.fn(),
+        setAgentMessages: vi.fn(), setConversationItems: vi.fn(),
+        setSelectedTask: vi.fn(), setTasks: vi.fn(),
+        ...over,
+      },
+      post,
+    }
+  }
+
+  it('does nothing when there is neither text nor attachments', async () => {
+    const { deps, post } = baseDeps()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await sendChatMessage(deps as any)
+    expect(post).not.toHaveBeenCalled()
+  })
+
+  it('sends text only (no attachment ids)', async () => {
+    const { deps, post } = baseDeps({ chatInput: '  hello  ' })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await sendChatMessage(deps as any)
+    expect(post).toHaveBeenCalledWith('/api/tasks/task-1/messages', {
+      content: 'hello', profile_id: 'default', attachment_ids: [],
+    })
+  })
+
+  it('sends attachments only (empty content)', async () => {
+    const atts: StagedAttachment[] = [
+      { id: 'id1', filename: 'a.png', contentType: 'image/png', url: '/u1' },
+    ]
+    const { deps, post } = baseDeps({ chatInput: '', attachments: atts })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await sendChatMessage(deps as any)
+    expect(post).toHaveBeenCalledWith('/api/tasks/task-1/messages', {
+      content: '', profile_id: 'default', attachment_ids: ['id1'],
+    })
+    // Clears input + staged attachments after send.
+    expect(deps.setChatInput).toHaveBeenCalledWith('')
+    expect(deps.setAttachments).toHaveBeenCalledWith([])
+  })
+
+  it('sends text + attachments together', async () => {
+    const atts: StagedAttachment[] = [
+      { id: 'id1', filename: 'a.png', contentType: 'image/png', url: '/u1' },
+      { id: 'id2', filename: 'b.pdf', contentType: 'application/pdf', url: '/u2' },
+    ]
+    const { deps, post } = baseDeps({ chatInput: 'look', attachments: atts })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await sendChatMessage(deps as any)
+    expect(post).toHaveBeenCalledWith('/api/tasks/task-1/messages', {
+      content: 'look', profile_id: 'default', attachment_ids: ['id1', 'id2'],
+    })
+  })
+})
+
+describe('MessageBubble renders attachments as thumbnails, not paths', () => {
+  it('renders an <img> for a markdown-image attachment and hides the URL text', () => {
+    const content = 'here it is\n![photo.png](/api/tasks/task-1/files/uploads/photo.png)'
+    render(<MessageBubble role="user" content={content} />)
+    const img = screen.getByRole('img', { name: 'photo.png' })
+    expect(img).toHaveAttribute('src', '/api/tasks/task-1/files/uploads/photo.png')
+    expect(screen.getByText('here it is')).toBeInTheDocument()
+    // The raw markdown / path is not shown as text.
+    expect(screen.queryByText(/!\[/)).toBeNull()
+  })
+
+  it('renders a PDF chip (not a broken image) for a pdf attachment', () => {
+    const content = '![doc.pdf](/api/tasks/task-1/files/uploads/doc.pdf)'
+    render(<MessageBubble role="user" content={content} />)
+    expect(screen.queryByRole('img')).toBeNull()
+    expect(screen.getByText('doc.pdf')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/retryConfirmButtons.test.tsx
+++ b/frontend/src/__tests__/retryConfirmButtons.test.tsx
@@ -52,6 +52,8 @@ function makeProps(over: Record<string, unknown> = {}) {
     showOtherInput: {},
     chatInput: '',
     setChatInput: noop,
+    chatAttachments: [],
+    setChatAttachments: noop,
     debugMode: false,
     setDebugMode: noop,
     profiles: [],

--- a/frontend/src/__tests__/triggerScheduleChain.test.tsx
+++ b/frontend/src/__tests__/triggerScheduleChain.test.tsx
@@ -233,6 +233,8 @@ describe('TasksView Run Now button reflects scheduleTasks', () => {
     showOtherInput: {},
     chatInput: '',
     setChatInput: vi.fn(),
+    chatAttachments: [],
+    setChatAttachments: vi.fn(),
     sendChatMessage: vi.fn(),
     stopAgent: vi.fn(),
     retryTask: vi.fn(),

--- a/frontend/src/components/conversation/AttachmentChips.tsx
+++ b/frontend/src/components/conversation/AttachmentChips.tsx
@@ -1,0 +1,51 @@
+import type { StagedAttachment } from '../../types'
+
+interface AttachmentChipsProps {
+  attachments: StagedAttachment[]
+  onRemove: (id: string) => void
+}
+
+const isPdf = (a: StagedAttachment) =>
+  a.contentType === 'application/pdf' || /\.pdf$/i.test(a.filename)
+
+/** Removable preview chips for staged chat attachments, shown above the
+ *  send bar. Images render as thumbnails, PDFs as a labelled file chip —
+ *  the raw path is never shown. */
+export function AttachmentChips({ attachments, onRemove }: AttachmentChipsProps) {
+  if (!attachments.length) return null
+  return (
+    <div className="flex flex-wrap gap-2" data-testid="chat-attachment-chips">
+      {attachments.map(a => (
+        <div
+          key={a.id}
+          data-testid="chat-attachment-chip"
+          className="relative group flex items-center gap-2 pl-1 pr-2 py-1 bg-gray-50 border border-gray-200 rounded-lg"
+        >
+          {isPdf(a) ? (
+            <span className="flex items-center justify-center w-9 h-9 rounded bg-red-50 text-red-500 text-[10px] font-semibold">
+              PDF
+            </span>
+          ) : (
+            <img
+              src={a.url}
+              alt={a.filename}
+              className="w-9 h-9 rounded object-cover bg-gray-100"
+            />
+          )}
+          <span className="max-w-[10rem] truncate text-xs text-gray-600" title={a.filename}>
+            {a.filename}
+          </span>
+          <button
+            type="button"
+            data-testid="chat-attachment-remove"
+            onClick={() => onRemove(a.id)}
+            aria-label={`Remove ${a.filename}`}
+            className="flex items-center justify-center w-5 h-5 rounded-full bg-gray-200 text-gray-600 hover:bg-gray-300 hover:text-gray-800 transition-colors"
+          >
+            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" /></svg>
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/conversation/ChatComposer.tsx
+++ b/frontend/src/components/conversation/ChatComposer.tsx
@@ -1,0 +1,106 @@
+import { useTranslation } from 'react-i18next'
+import type { StagedAttachment } from '../../types'
+import { ChatAttachButton } from './ChatAttachButton'
+import { AttachmentChips } from './AttachmentChips'
+
+interface ChatComposerProps {
+  fileInputRef: React.RefObject<HTMLInputElement | null>
+  uploading: boolean
+  uploadFiles: (files: FileList | File[]) => void
+  attachments: StagedAttachment[]
+  onRemoveAttachment: (id: string) => void
+  inputRef: React.RefObject<HTMLTextAreaElement | null>
+  input: string
+  setInput: (v: string) => void
+  /** True when there is prose OR at least one attachment to send. */
+  hasContent: boolean
+  canSend: boolean
+  isActive: boolean
+  onSend: () => void
+  onStop: () => void
+  placeholder: string
+}
+
+/** The task chat send bar: removable attachment chips, attach button,
+ *  auto-growing textarea (drag/paste upload), and the Send/Stop button.
+ *  Attachments are staged and shown as thumbnails — never a raw path —
+ *  and only reach the agent when the user sends. */
+export function ChatComposer({
+  fileInputRef, uploading, uploadFiles, attachments, onRemoveAttachment,
+  inputRef, input, setInput, hasContent, canSend, isActive, onSend, onStop,
+  placeholder,
+}: ChatComposerProps) {
+  const { t } = useTranslation()
+  return (
+    <>
+      {/* Staged attachment chips (thumbnails, not paths) */}
+      <AttachmentChips attachments={attachments} onRemove={onRemoveAttachment} />
+
+      <div className="flex gap-2 items-end">
+        <ChatAttachButton
+          fileInputRef={fileInputRef}
+          uploading={uploading}
+          disabled={!canSend && !isActive}
+          onFiles={uploadFiles}
+        />
+        <textarea
+          ref={inputRef}
+          data-testid="chat-input"
+          rows={1}
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onDragOver={e => e.preventDefault()}
+          onDrop={e => {
+            e.preventDefault()
+            if (e.dataTransfer.files?.length) uploadFiles(e.dataTransfer.files)
+          }}
+          onPaste={e => {
+            const imgs = Array.from(e.clipboardData?.items || [])
+              .filter(i => i.kind === 'file' && i.type.startsWith('image/'))
+              .map(i => i.getAsFile())
+              .filter((f): f is File => !!f)
+            if (imgs.length) { e.preventDefault(); uploadFiles(imgs) }
+          }}
+          onKeyDown={e => {
+            // Bail on IME composition keystrokes. Chinese / Japanese /
+            // Korean IMEs dispatch an Enter `keydown` to confirm a
+            // composition BEFORE the real submit Enter ~50ms later —
+            // without this guard both fire onSend, producing duplicate
+            // user messages. keyCode===229 catches older Safari / Firefox
+            // builds where isComposing is unreliable.
+            if (e.nativeEvent.isComposing || e.keyCode === 229) return
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              if (hasContent) onSend()
+            }
+          }}
+          placeholder={placeholder}
+          disabled={!canSend && !isActive}
+          className="flex-1 px-3 py-2 text-sm leading-5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed resize-none overflow-y-auto"
+        />
+        {canSend && hasContent ? (
+          <button
+            onClick={onSend}
+            className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors"
+          >
+            {t('tasks.send')}
+          </button>
+        ) : isActive && !hasContent ? (
+          <button
+            onClick={onStop}
+            className="px-3 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 transition-colors"
+          >
+            {t('tasks.stopTask')}
+          </button>
+        ) : (
+          <button
+            disabled
+            className="px-4 py-2 text-sm font-medium text-white bg-gray-300 rounded-lg cursor-not-allowed"
+          >
+            {t('tasks.send')}
+          </button>
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/conversation/MessageBubble.tsx
+++ b/frontend/src/components/conversation/MessageBubble.tsx
@@ -21,12 +21,43 @@ interface MessageBubbleProps {
   onOpenVisionSetup?: () => void
 }
 
+// Attachments are encoded into a user message as markdown images
+// (``![filename](url)``) by the /messages endpoint. Parse them out so the
+// bubble shows a thumbnail (or a PDF chip), never the raw path/URL text.
+const ATTACHMENT_RE = /!\[([^\]]*)\]\(([^)]+)\)/g
+
+function parseUserContent(content: string) {
+  const images: { alt: string; url: string }[] = []
+  const text = content.replace(ATTACHMENT_RE, (_m, alt, url) => {
+    images.push({ alt, url })
+    return ''
+  }).trim()
+  return { text, images }
+}
+
 export function MessageBubble({ role, content, onOpenVisionSetup }: MessageBubbleProps) {
   if (role === 'user') {
+    const { text, images } = parseUserContent(content)
     return (
       <div className="flex justify-end">
-        <div className="max-w-[80%] bg-gray-100 rounded-2xl rounded-br-md px-4 py-3 text-[16px] leading-relaxed text-gray-800 whitespace-pre-wrap">
-          {content}
+        <div className="max-w-[80%] bg-gray-100 rounded-2xl rounded-br-md px-4 py-3 text-[16px] leading-relaxed text-gray-800">
+          {text && <div className="whitespace-pre-wrap">{text}</div>}
+          {images.length > 0 && (
+            <div className={`flex flex-wrap gap-2 justify-end ${text ? 'mt-2' : ''}`}>
+              {images.map((im, i) => /\.pdf$/i.test(im.alt) || /\.pdf$/i.test(im.url) ? (
+                <a key={i} href={im.url} target="_blank" rel="noreferrer"
+                  className="flex items-center gap-2 px-2 py-1.5 bg-white border border-gray-200 rounded-lg text-xs text-gray-600 hover:bg-gray-50">
+                  <span className="flex items-center justify-center w-6 h-6 rounded bg-red-50 text-red-500 text-[9px] font-semibold">PDF</span>
+                  <span className="max-w-[10rem] truncate">{im.alt || 'document.pdf'}</span>
+                </a>
+              ) : (
+                <a key={i} href={im.url} target="_blank" rel="noreferrer">
+                  <img src={im.url} alt={im.alt}
+                    className="max-h-40 max-w-[12rem] rounded-lg border border-gray-200 object-cover" />
+                </a>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     )

--- a/frontend/src/handlers/sendChatMessage.ts
+++ b/frontend/src/handlers/sendChatMessage.ts
@@ -1,19 +1,30 @@
 import { sendEvent, lengthBucket } from '../lib/telemetry'
 import { FrontendEvent } from '../lib/telemetryEvents'
-import type { Task, AgentMessage, ConversationItem } from '../types'
+import type { Task, AgentMessage, ConversationItem, StagedAttachment } from '../types'
+
+interface SendChatResponse {
+  woken?: boolean
+  profile_switched?: boolean
+  // Canonical transcript content (prose + markdown-image attachments) the
+  // server stored — the client echoes it so the optimistic bubble matches
+  // the SSE copy exactly (dedup by content) and shows thumbnails.
+  content?: string
+}
 
 export interface SendChatApi {
-  post(url: string, body: unknown): Promise<{ woken?: boolean; profile_switched?: boolean }>
+  post(url: string, body: unknown): Promise<SendChatResponse>
 }
 
 export interface SendChatDeps {
   api: SendChatApi
   selectedTask: Task | null
   chatInput: string
+  attachments: StagedAttachment[]
   profileId: string
   conversationItems: ConversationItem[]
   sendingRef: React.MutableRefObject<boolean>
   setChatInput: (v: string) => void
+  setAttachments: React.Dispatch<React.SetStateAction<StagedAttachment[]>>
   setAgentMessages: React.Dispatch<React.SetStateAction<AgentMessage[]>>
   setConversationItems: React.Dispatch<React.SetStateAction<ConversationItem[]>>
   setSelectedTask: React.Dispatch<React.SetStateAction<Task | null>>
@@ -21,31 +32,46 @@ export interface SendChatDeps {
 }
 
 /**
- * Send a follow-up message on the selected task. Optimistically appends
- * the user turn, POSTs it, and reconciles woken / profile-switch status
- * from the response. `sendingRef` de-dupes rapid double-submits.
+ * Send a follow-up message on the selected task. Sends the typed prose
+ * plus any staged attachment ids; the server promotes the attachments and
+ * returns the canonical transcript content, which we render (thumbnails,
+ * not paths). Sends fine with text only, attachments only, or both.
+ * `sendingRef` de-dupes rapid double-submits.
  */
 export async function sendChatMessage(deps: SendChatDeps): Promise<void> {
   const { selectedTask } = deps
-  if (!selectedTask || !deps.chatInput.trim() || deps.sendingRef.current) return
-  deps.sendingRef.current = true
   const content = deps.chatInput.trim()
+  const attachmentIds = deps.attachments.map(a => a.id)
+  if (!selectedTask || (!content && !attachmentIds.length) || deps.sendingRef.current) return
+  deps.sendingRef.current = true
   deps.setChatInput('')
+  deps.setAttachments([])
   sendEvent(FrontendEvent.TASK_MESSAGE_SUBMITTED, {
     length_bucket: lengthBucket(content.length),
     task_status_at_send: selectedTask.status,
     is_first_message_for_task: !deps.conversationItems.some(c => c.type === 'user_message'),
   })
-  // Optimistic add to both agentMessages (debug) and conversationItems
-  deps.setAgentMessages(prev => [...prev, { role: 'user', content }])
-  deps.setConversationItems(prev => [...prev, {
-    id: `user-opt-${Date.now()}`,
-    type: 'user_message',
-    timestamp: new Date().toISOString(),
-    message: { role: 'user', content },
-  }])
   try {
-    const response = await deps.api.post(`/api/tasks/${selectedTask.id}/messages`, { content, profile_id: deps.profileId })
+    const response = await deps.api.post(
+      `/api/tasks/${selectedTask.id}/messages`,
+      { content, profile_id: deps.profileId, attachment_ids: attachmentIds },
+    )
+    // Render the server's canonical content (falls back to prose if the
+    // response predates this field). SSE will dedup its own copy by content.
+    const canonical = response.content ?? content
+    deps.setAgentMessages(prev => [...prev, { role: 'user', content: canonical }])
+    deps.setConversationItems(prev => {
+      const dup = prev.some(c =>
+        c.type === 'user_message' && c.message?.content === canonical &&
+        Date.now() - new Date(c.timestamp).getTime() < 5000)
+      if (dup) return prev
+      return [...prev, {
+        id: `user-opt-${Date.now()}`,
+        type: 'user_message',
+        timestamp: new Date().toISOString(),
+        message: { role: 'user', content: canonical },
+      }]
+    })
     if (response.woken) {
       deps.setSelectedTask(prev => prev ? { ...prev, status: 'queued' } : prev)
       deps.setTasks(prev => prev.map(t2 => t2.id === selectedTask.id ? { ...t2, status: 'queued' } : t2))

--- a/frontend/src/hooks/useChatUploads.ts
+++ b/frontend/src/hooks/useChatUploads.ts
@@ -1,47 +1,56 @@
 import { useRef, useState } from 'react'
-import type { Task } from '../types'
+import type { StagedAttachment } from '../types'
 
-/** Chat attachments: upload files into the task workspace and insert
- *  each returned absolute path into the message text, so the agent can
- *  Read the file directly (images become vision input). Drag, paste
- *  and click-upload in the send bar all land here. */
+/** Chat attachments: upload files to STAGING (outside the agent's cwd)
+ *  and hold them as removable chips. Nothing is written into the message
+ *  text and nothing reaches the agent until the user hits Send — the
+ *  server promotes staged files into the workspace only then. Drag, paste
+ *  and click-upload in the send bar all land here.
+ *
+ *  Attachment state is owned by the caller (App) so the send handler can
+ *  read the ids and clear them after a successful send. */
 export function useChatUploads(
-  selectedTask: Task | null,
-  chatInput: string,
-  setChatInput: (v: string) => void,
-  chatInputRef: React.RefObject<HTMLTextAreaElement | null>,
-  attachedLabel: string,
+  taskId: string | null,
+  setAttachments: React.Dispatch<React.SetStateAction<StagedAttachment[]>>,
 ) {
   const chatFileInputRef = useRef<HTMLInputElement>(null)
   const [chatUploading, setChatUploading] = useState(false)
 
   const uploadChatFiles = async (files: FileList | File[]) => {
-    if (!selectedTask) return
+    if (!taskId) return
     setChatUploading(true)
     try {
-      const paths: string[] = []
       for (const f of Array.from(files)) {
         const fd = new FormData()
         fd.append('file', f)
         const resp = await fetch(
-          `/api/tasks/${selectedTask.id}/files/upload`,
+          `/api/tasks/${taskId}/staged`,
           { method: 'POST', body: fd, credentials: 'include' },
         )
         if (resp.ok) {
-          const data = await resp.json()
-          paths.push(data.abs_path)
+          const d = await resp.json()
+          setAttachments(prev => [...prev, {
+            id: d.id,
+            filename: d.filename,
+            contentType: d.content_type,
+            url: d.url,
+          }])
         }
-      }
-      if (paths.length) {
-        const cur = chatInput.trim()
-        const insert = paths.map(p => `${attachedLabel}: ${p}`).join('\n')
-        setChatInput(cur ? `${cur}\n${insert}` : insert)
-        chatInputRef.current?.focus()
       }
     } finally {
       setChatUploading(false)
     }
   }
 
-  return { chatFileInputRef, chatUploading, uploadChatFiles }
+  /** Drop a staged attachment before sending (the chip's ✕). Removes the
+   *  chip immediately; the server-side discard is best-effort. */
+  const removeAttachment = (id: string) => {
+    setAttachments(prev => prev.filter(a => a.id !== id))
+    if (taskId) {
+      fetch(`/api/tasks/${taskId}/staged/${id}`,
+        { method: 'DELETE', credentials: 'include' }).catch(() => {})
+    }
+  }
+
+  return { chatFileInputRef, chatUploading, uploadChatFiles, removeAttachment }
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -47,6 +47,14 @@ export interface PendingFile {
   preview: string;
   name: string;
 }
+/** A chat attachment uploaded to staging (outside the agent's cwd) and
+ *  waiting for Send. Carries a preview URL, never an absolute path. */
+export interface StagedAttachment {
+  id: string;
+  filename: string;
+  contentType: string;
+  url: string;
+}
 export interface WsFile {
   path: string;
   name: string;

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -7,7 +7,7 @@ import { formatScheduleBadge } from '../lib/scheduleBadge'
 import { StatusBadge } from '../components/ui'
 import { ConversationStream } from '../components/conversation/ConversationStream'
 import { useChatUploads } from '../hooks/useChatUploads'
-import { ChatAttachButton } from '../components/conversation/ChatAttachButton'
+import { ChatComposer } from '../components/conversation/ChatComposer'
 import { ScheduleList } from '../components/ScheduleList'
 import { ScheduleDetailView } from '../components/ScheduleDetailView'
 import { EditScheduleModal } from '../components/EditScheduleModal'
@@ -15,7 +15,7 @@ import { ExternalConfigOverrideErrorCard } from '../components/ExternalConfigOve
 import { SubtaskList } from '../components/SubtaskList'
 import { MobileMenuButton } from '../components/MobileMenuButton'
 import { getUI, hasProgressingTask } from '../taskStates'
-import type { Task, TaskStep, AgentMessage, TodoItem, AuthUser, Profile, Schedule, Store, ConversationItem } from '../types'
+import type { Task, TaskStep, AgentMessage, TodoItem, AuthUser, Profile, Schedule, Store, ConversationItem, StagedAttachment } from '../types'
 
 function formatDate(dateStr: string): string {
   const d = new Date(dateStr)
@@ -44,6 +44,8 @@ interface TasksViewProps {
   showOtherInput: Record<string, boolean>
   chatInput: string
   setChatInput: (v: string) => void
+  chatAttachments: StagedAttachment[]
+  setChatAttachments: React.Dispatch<React.SetStateAction<StagedAttachment[]>>
   debugMode: boolean
   setDebugMode: React.Dispatch<React.SetStateAction<boolean>>
   profiles: Profile[]
@@ -110,6 +112,8 @@ export function TasksView({
   showOtherInput,
   chatInput,
   setChatInput,
+  chatAttachments,
+  setChatAttachments,
   debugMode,
   setDebugMode,
   profiles,
@@ -186,8 +190,8 @@ export function TasksView({
     el.style.height = `${Math.min(el.scrollHeight, 192)}px`
   }, [chatInput, selectedTask?.id])
 
-  const { chatFileInputRef, chatUploading, uploadChatFiles } = useChatUploads(
-    selectedTask, chatInput, setChatInput, chatInputRef, t('tasks.attachedImage'))
+  const { chatFileInputRef, chatUploading, uploadChatFiles, removeAttachment } =
+    useChatUploads(selectedTask?.id ?? null, setChatAttachments)
 
   // Phase helpers — driven by centralized UI config
   const taskCfg = selectedTask ? getUI(selectedTask.status) : null
@@ -195,7 +199,8 @@ export function TasksView({
   // Unified send bar state
   const canSend = taskCfg?.canSendMessage ?? false
   const isActive = taskCfg?.isActive ?? false
-  const hasText = chatInput.trim().length > 0
+  // A message may be text-only, attachment-only, or both.
+  const hasText = chatInput.trim().length > 0 || chatAttachments.length > 0
 
   // Placeholder changes by state
   const getPlaceholder = () => {
@@ -708,74 +713,14 @@ export function TasksView({
                 </div>
               )}
 
-              {/* Unified send bar */}
-              <div className="flex gap-2 items-end">
-                <ChatAttachButton
-                  fileInputRef={chatFileInputRef}
-                  uploading={chatUploading}
-                  disabled={!canSend && !isActive}
-                  onFiles={uploadChatFiles}
-                />
-                <textarea
-                  ref={chatInputRef}
-                  data-testid="chat-input"
-                  rows={1}
-                  value={chatInput}
-                  onChange={e => setChatInput(e.target.value)}
-                  onDragOver={e => e.preventDefault()}
-                  onDrop={e => {
-                    e.preventDefault()
-                    if (e.dataTransfer.files?.length) uploadChatFiles(e.dataTransfer.files)
-                  }}
-                  onPaste={e => {
-                    const imgs = Array.from(e.clipboardData?.items || [])
-                      .filter(i => i.kind === 'file' && i.type.startsWith('image/'))
-                      .map(i => i.getAsFile())
-                      .filter((f): f is File => !!f)
-                    if (imgs.length) { e.preventDefault(); uploadChatFiles(imgs) }
-                  }}
-                  onKeyDown={e => {
-                    // Bail on IME composition keystrokes. Chinese /
-                    // Japanese / Korean IMEs dispatch an Enter
-                    // `keydown` to confirm a composition BEFORE the
-                    // real submit Enter ~50ms later — without this
-                    // guard both fire sendChatMessage, producing
-                    // duplicate user messages. keyCode===229 catches
-                    // older Safari / Firefox builds where
-                    // isComposing is unreliable.
-                    if (e.nativeEvent.isComposing || e.keyCode === 229) return
-                    if (e.key === 'Enter' && !e.shiftKey) {
-                      e.preventDefault()
-                      if (hasText) sendChatMessage()
-                    }
-                  }}
-                  placeholder={getPlaceholder()}
-                  disabled={!canSend && !isActive}
-                  className="flex-1 px-3 py-2 text-sm leading-5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed resize-none overflow-y-auto"
-                />
-                {canSend && hasText ? (
-                  <button
-                    onClick={sendChatMessage}
-                    className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors"
-                  >
-                    {t('tasks.send')}
-                  </button>
-                ) : isActive && !hasText ? (
-                  <button
-                    onClick={stopAgent}
-                    className="px-3 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 transition-colors"
-                  >
-                    {t('tasks.stopTask')}
-                  </button>
-                ) : (
-                  <button
-                    disabled
-                    className="px-4 py-2 text-sm font-medium text-white bg-gray-300 rounded-lg cursor-not-allowed"
-                  >
-                    {t('tasks.send')}
-                  </button>
-                )}
-              </div>
+              <ChatComposer
+                fileInputRef={chatFileInputRef} uploading={chatUploading}
+                uploadFiles={uploadChatFiles} attachments={chatAttachments}
+                onRemoveAttachment={removeAttachment} inputRef={chatInputRef}
+                input={chatInput} setInput={setChatInput} hasContent={hasText}
+                canSend={canSend} isActive={isActive} onSend={sendChatMessage}
+                onStop={stopAgent} placeholder={getPlaceholder()}
+              />
               </div>
             </div>
           </>

--- a/tests/workflow/test_wf_chat_attachments.py
+++ b/tests/workflow/test_wf_chat_attachments.py
@@ -1,0 +1,226 @@
+"""Workflow tests for chat attachments (stage-until-send redesign).
+
+Invariant under test: a user attachment becomes visible to the AGENT
+only when the user SENDS the message that carries it. Uploads land in a
+staging area OUTSIDE the task workspace (the agent's cwd); the /messages
+endpoint promotes them into ``uploads/`` at send time and hands the agent
+the absolute paths, while the transcript stores a thumbnail (markdown
+image), never the raw path.
+
+Filename handling is exercised for English, Chinese, and
+Windows-illegal-character names so the same code path is safe on macOS,
+Linux, and Windows.
+"""
+
+from pathlib import Path
+import shutil
+import uuid
+
+import pytest
+
+from app.workspace.manager import VIBE_SELLER_DIR
+from tests.workflow.conftest import wait_for_task
+
+pytestmark = pytest.mark.workflow
+
+_TASKS_DIR = VIBE_SELLER_DIR / 'tasks'
+_STAGING_DIR = VIBE_SELLER_DIR / 'chat_staging'
+
+_PNG = b'\x89PNG\r\n\x1a\n' + b'\x00' * 16
+# Windows forbids <>:"/\|?* and control chars in filenames.
+_WIN_ILLEGAL = '<>:"/\\|?*'
+
+
+async def _stage(client, task_id, filename, data=_PNG, ctype='image/png'):
+    r = await client.post(
+        f'/api/tasks/{task_id}/staged',
+        files={'file': (filename, data, ctype)},
+    )
+    return r
+
+
+async def _create_store_task(client):
+    """Create a store + auto task and let it settle (no agent needed)."""
+    rs = await client.post('/api/stores', json={'name': 'Attach Store'})
+    assert rs.status_code == 200
+    store_id = rs.json()['id']
+    rt = await client.post(
+        '/api/tasks',
+        json={'title': 'Attach task', 'plan_mode': False, 'store_id': store_id},
+    )
+    assert rt.status_code == 200
+    return rt.json()['id']
+
+
+async def test_stage_lands_outside_agent_cwd(admin_client):
+    """Staged files are invisible to the agent until Send."""
+    tid = str(uuid.uuid4())
+    task_dir = _TASKS_DIR / tid
+    task_dir.mkdir(parents=True, exist_ok=True)
+    staging = _STAGING_DIR / tid
+    try:
+        r = await _stage(admin_client, tid, 'photo.png')
+        assert r.status_code == 200
+        body = r.json()
+        assert body['filename'] == 'photo.png'
+        assert body['content_type'] == 'image/png'
+        assert body['url'] == f'/api/tasks/{tid}/staged/{body["id"]}'
+        # The response must NOT leak a filesystem path.
+        assert 'abs_path' not in body and 'path' not in body
+        # File is in staging, NOT anywhere under the agent's cwd.
+        assert staging.is_dir()
+        staged_bytes = [p for p in staging.rglob('*') if p.is_file()]
+        assert len(staged_bytes) == 1
+        assert not any(p.is_file() for p in task_dir.rglob('*')), (
+            'staged file must not appear in the task workspace before Send'
+        )
+        # The preview URL serves the bytes back.
+        rg = await admin_client.get(body['url'])
+        assert rg.status_code == 200
+        assert rg.content.startswith(b'\x89PNG')
+    finally:
+        shutil.rmtree(task_dir, ignore_errors=True)
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+async def test_stage_english_and_chinese_names_are_ascii_safe(admin_client):
+    """Chinese and English uploads both stage to a valid ASCII filename."""
+    tid = str(uuid.uuid4())
+    staging = _STAGING_DIR / tid
+    try:
+        for name in ('photo.png', '样图 1.png', '产品主图.png'):
+            r = await _stage(admin_client, tid, name)
+            assert r.status_code == 200, name
+            fn = r.json()['filename']
+            assert fn.endswith('.png')
+            # ASCII-only → safe for the serve URL and cross-platform paths.
+            assert fn.isascii(), fn
+            assert fn == fn.encode('ascii', 'ignore').decode()
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+async def test_stage_rejects_disallowed_type(admin_client):
+    tid = str(uuid.uuid4())
+    try:
+        r = await _stage(
+            admin_client, tid, 'x.sh', data=b'#!/bin/sh', ctype='text/x-sh'
+        )
+        assert r.status_code == 400
+    finally:
+        shutil.rmtree(_STAGING_DIR / tid, ignore_errors=True)
+
+
+async def test_delete_staged_discards_it(admin_client):
+    tid = str(uuid.uuid4())
+    staging = _STAGING_DIR / tid
+    try:
+        body = (await _stage(admin_client, tid, 'photo.png')).json()
+        rd = await admin_client.delete(f'/api/tasks/{tid}/staged/{body["id"]}')
+        assert rd.status_code == 200
+        # Gone: serving it now 404s.
+        rg = await admin_client.get(body['url'])
+        assert rg.status_code == 404
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+class TestPromoteOnSend:
+    """The /messages endpoint promotes staged files at send time."""
+
+    async def _running_task(self, client, fake):
+        tid = await _create_store_task(client)
+        await wait_for_task(client, tid)
+        # Force the live-agent send path.
+        fake._running[tid] = True
+        return tid
+
+    async def test_promote_moves_into_workspace_and_splits_content(
+        self, admin_client, install_fake_agent
+    ):
+        tid = await self._running_task(admin_client, install_fake_agent)
+        staged = (await _stage(admin_client, tid, 'photo.png')).json()
+
+        r = await admin_client.post(
+            f'/api/tasks/{tid}/messages',
+            json={'content': 'look at this', 'attachment_ids': [staged['id']]},
+        )
+        assert r.status_code == 200
+        body = r.json()
+
+        # Response (transcript) content: prose + markdown image, NO raw path.
+        assert 'look at this' in body['content']
+        assert '![' in body['content']
+        assert 'Attached file:' not in body['content']
+        att = body['attachments'][0]
+        assert att['url'] == f'/api/tasks/{tid}/files/uploads/{att["filename"]}'
+
+        # The promoted file now lives in the agent's cwd under uploads/.
+        promoted = Path(att['abs_path'])
+        assert promoted.is_file()
+        assert promoted.parent == (_TASKS_DIR / tid / 'uploads')
+        # Staging for this item is consumed.
+        assert not (_STAGING_DIR / tid / staged['id']).exists()
+
+        # The AGENT received the absolute path (vision input), not markdown.
+        msg = install_fake_agent.get_calls(task_id=tid, action='send_message')
+        assert len(msg) == 1
+        assert 'Attached file:' in msg[0].message
+        assert str(promoted) in msg[0].message
+        assert '![' not in msg[0].message
+
+    async def test_attachments_only_no_text(
+        self, admin_client, install_fake_agent
+    ):
+        tid = await self._running_task(admin_client, install_fake_agent)
+        staged = (await _stage(admin_client, tid, 'photo.png')).json()
+        r = await admin_client.post(
+            f'/api/tasks/{tid}/messages',
+            json={'content': '', 'attachment_ids': [staged['id']]},
+        )
+        assert r.status_code == 200
+        msg = install_fake_agent.get_calls(task_id=tid, action='send_message')
+        assert msg[0].message.startswith('Attached file:')
+
+    async def test_windows_illegal_chars_stripped(
+        self, admin_client, install_fake_agent
+    ):
+        tid = await self._running_task(admin_client, install_fake_agent)
+        staged = (
+            await _stage(admin_client, tid, f'a{_WIN_ILLEGAL}b.png')
+        ).json()
+        r = await admin_client.post(
+            f'/api/tasks/{tid}/messages',
+            json={'content': 'x', 'attachment_ids': [staged['id']]},
+        )
+        assert r.status_code == 200
+        fn = r.json()['attachments'][0]['filename']
+        # None of the Windows-forbidden characters survive.
+        assert not any(c in fn for c in _WIN_ILLEGAL)
+        assert fn.endswith('.png') and len(fn) > len('.png')
+
+    async def test_unknown_attachment_id_is_skipped(
+        self, admin_client, install_fake_agent
+    ):
+        tid = await self._running_task(admin_client, install_fake_agent)
+        r = await admin_client.post(
+            f'/api/tasks/{tid}/messages',
+            json={
+                'content': 'hi',
+                'attachment_ids': ['not-a-real-id', 'x' * 32],
+            },
+        )
+        assert r.status_code == 200
+        assert r.json()['attachments'] == []
+        msg = install_fake_agent.get_calls(task_id=tid, action='send_message')
+        assert msg[0].message == 'hi'
+
+    async def test_empty_message_without_attachments_rejected(
+        self, admin_client, install_fake_agent
+    ):
+        tid = await self._running_task(admin_client, install_fake_agent)
+        r = await admin_client.post(
+            f'/api/tasks/{tid}/messages',
+            json={'content': '   '},
+        )
+        assert r.status_code == 400

--- a/tests/workflow/test_wf_vision_image.py
+++ b/tests/workflow/test_wf_vision_image.py
@@ -231,30 +231,8 @@ async def test_new_request_supersedes_pending(admin_client, monkeypatch):
         shutil.rmtree(task_dir, ignore_errors=True)
 
 
-async def test_chat_upload_returns_abs_path(admin_client):
-    """Chat attachments land in the workspace and return an abs path
-    (inserted into the message so the agent can Read the image)."""
-    tid = str(uuid.uuid4())
-    task_dir = _TASKS_DIR / tid
-    try:
-        r = await admin_client.post(
-            f'/api/tasks/{tid}/files/upload',
-            files={'file': ('样图 1.png', b'\x89PNG\r\n\x1a\nx', 'image/png')},
-        )
-        assert r.status_code == 200
-        body = r.json()
-        assert body['path'].startswith('uploads/')
-        abs_path = body['abs_path']
-        assert abs_path.startswith(str(task_dir))
-        assert (task_dir / body['path']).read_bytes().startswith(b'\x89PNG')
-        # Unsupported type fails fast.
-        r2 = await admin_client.post(
-            f'/api/tasks/{tid}/files/upload',
-            files={'file': ('x.sh', b'#!/bin/sh', 'text/x-sh')},
-        )
-        assert r2.status_code == 400
-    finally:
-        shutil.rmtree(task_dir, ignore_errors=True)
+# Chat-attachment upload coverage moved to
+# tests/workflow/test_wf_chat_attachments.py (stage-until-send redesign).
 
 
 async def test_ref_proxy_rejects_bad_and_private_urls(admin_client):


### PR DESCRIPTION
## Problem

Picking a chat attachment uploaded it straight into `tasks/<id>/uploads/` — **the agent's working directory** — the instant it was selected, and surfaced it by pasting the **raw absolute path as editable text** into the message box.

- **The agent grabbed files before Send.** A running agent scanned its cwd (`ls`/`find`) and acted on the image *before the user pressed Send* — the reported "I didn't click Send, so how did the agent get the image?". The invariant *"an attachment reaches the agent only when the user sends the message carrying it"* was never enforced.
- **The path was the UX.** Unreadable, leaked internal layout, corruptible with one keystroke, and had no thumbnail, filename, or remove button.

## Fix — move the contract into code

An attachment may enter the agent's cwd **only at Send**:

1. **Stage outside the cwd.** New endpoints under `chat_staging/<task_id>/` (a sibling of the task workspace, never in the agent's `ls`/`find` scope): upload, serve (preview), delete. The response returns a **preview URL, never a path**.
2. **Promote on Send.** `POST /messages` moves staged files into `uploads/` only at send time and keeps two content strings — transcript content (markdown image → thumbnail) and agent content (absolute paths it Reads as vision input).
3. **Chips, not path text.** The send bar shows removable thumbnail chips; the textarea stays prose-only. Sends with **text only, attachments only, or both**.
4. **Thumbnails in the transcript.** The user bubble renders image thumbnails / a PDF chip, never the raw path.
5. **Cross-platform filenames.** Names are sanitised to ASCII, which also strips every Windows-forbidden character — a Chinese-named upload lands as a valid path on macOS, Linux, and Windows.

The old agent-cwd upload endpoint is removed so the bug class can't recur.

## Tests

- **Frontend** (`chatAttachments.test.tsx`): file pick → chip appears + textarea untouched; chip ✕ removes it; `sendChatMessage` for text-only / attachment-only / both; bubble renders thumbnail (not path) + PDF chip.
- **Backend** (`test_wf_chat_attachments.py`): staged file invisible under the task cwd before Send; promote moves into `uploads/` and splits display vs agent content; English / Chinese / Windows-illegal filenames; unknown ids skipped; empty-message rejected.
- Full frontend suite (375) + affected backend workflow suites (123: task-chat, conversation, status-gating, contracts, vision-image) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg5csnfP39iFPAEqcEnqwK