### PR TITLE
fix(tasks): guard task selection against stale-response race on fast switch

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,7 @@ import { WorkspaceAssistantView } from './views/WorkspaceAssistantView'
 import { SettingsView, type SettingsTab } from './views/SettingsView'
 import { useSSE } from './hooks/useSSE'
 import { parseNav, settingsTabToSlug } from './lib/route'
-import { buildConversationItems } from './lib/conversation'
+import { loadTaskById as loadTaskByIdHandler } from './handlers/loadTaskById'
 import { api, AUTH_EXPIRED_EVENT } from './api'
 import { triggerSchedule as triggerScheduleHandler } from './handlers/triggerSchedule'
 import { replanSchedule as replanScheduleHandler } from './handlers/replanSchedule'
@@ -74,6 +74,9 @@ export default function App() {
   // changed, so a slow response for the previous store can't clobber
   // the newly-selected store's list (stale-response-wins race).
   const inFlightTasksKeyRef = useRef<string | null>(null)
+  // Monotonic token for loadTaskById: only the latest selection applies
+  // its fetched state (stale-response-wins guard for fast task switches).
+  const loadTaskSeqRef = useRef(0)
   const [selectedTask, setSelectedTask] = useState<Task | null>(null)
   const [steps, setSteps] = useState<TaskStep[]>([])
   const [screenshots, setScreenshots] = useState<Record<string, string>>({})
@@ -434,40 +437,13 @@ export default function App() {
         })
       : navigate({ to: '/tasks/$taskId', params: { taskId: task.id } })
 
-  const loadTaskById = async (taskId: string) => {
-    let fullTask: Task
-    try { fullTask = await api.get(`/api/tasks/${taskId}`) } catch { return }
-    setSelectedTask(fullTask); setLogs([]); setScreenshots({}); setAgentMessages([])
-    if (fullTask.todos) { try { setTodoItems(JSON.parse(fullTask.todos)) } catch { setTodoItems([]) } } else { setTodoItems([]) }
-    setSelectedAnswers({}); setOtherInputs({}); setShowOtherInput({}); setChatInput(''); setChatAttachments([])
-    setPendingQuestions(null)  // Clear immediately to avoid stale UI
-    // Recover pending question if agent is waiting
-    try {
-      const q = await api.get(`/api/tasks/${fullTask.id}/questions/pending`)
-      if (q.pending) { setPendingQuestions({ request_id: q.request_id, questions: q.questions }) }
-      else { setPendingQuestions(null) }
-    } catch { setPendingQuestions(null) }
-
-    // Rebuild the conversation stream from persisted messages + task
-    // state (pure logic in lib/conversation).
-    let convItems: ConversationItem[] = []
-    try {
-      const msgs = await api.get(`/api/tasks/${taskId}/messages`)
-      setAgentMessages(msgs.map((m: { role: string; content: string }) => ({ role: m.role, content: m.content })))
-      convItems = buildConversationItems(msgs, fullTask)
-    } catch { /* ignore */ }
-    setConversationItems(convItems)
-
-    const stepsData = await api.get(`/api/tasks/${taskId}/steps`); setSteps(stepsData)
-    for (const s of stepsData) {
-      if (s.screenshot_id) {
-        try {
-          const resp = await fetch(`/api/screenshots/${s.screenshot_id}`, { credentials: 'include' })
-          if (resp.ok) { const blob = await resp.blob(); const reader = new FileReader(); reader.onload = () => { const b64 = (reader.result as string).split(',')[1]; setScreenshots(prev => ({ ...prev, [s.id]: b64 })) }; reader.readAsDataURL(blob) }
-        } catch { /* ignore */ }
-      }
-    }
-  }
+  const loadTaskById = (taskId: string) =>
+    loadTaskByIdHandler(taskId, {
+      api, seqRef: loadTaskSeqRef,
+      setSelectedTask, setLogs, setScreenshots, setAgentMessages, setTodoItems,
+      setSelectedAnswers, setOtherInputs, setShowOtherInput, setChatInput,
+      setChatAttachments, setPendingQuestions, setConversationItems, setSteps,
+    })
 
   const stopAgent = async () => { if (!selectedTask) return; try { await api.post(`/api/tasks/${selectedTask.id}/agent/stop`) } catch { /* ignore */ }; setPendingQuestions(null) }
   const handlerDeps = {

--- a/frontend/src/__tests__/createTaskStateReset.test.tsx
+++ b/frontend/src/__tests__/createTaskStateReset.test.tsx
@@ -33,10 +33,10 @@ function extractResetCalls(code: string): Set<string> {
 
 /**
  * Extract the body of a function defined as `const name = async (...) => {`
- * with brace-matching to handle nested blocks.
+ * or `function name(...) {` with brace-matching to handle nested blocks.
  */
 function extractFunctionBody(source: string, name: string): string {
-  const startPattern = new RegExp(`const\\s+${name}\\s*=`)
+  const startPattern = new RegExp(`const\\s+${name}\\s*=|function\\s+${name}\\b`)
   const match = startPattern.exec(source)
   if (!match) throw new Error(`Function ${name} not found in source`)
 
@@ -62,10 +62,16 @@ describe('submitCreateTask state reset contract', () => {
     path.resolve(__dirname, '../App.tsx'),
     'utf-8',
   )
+  // loadTaskById was extracted into its own handler; its per-task state
+  // resets (and the guard) now live there.
+  const loadTaskSource = fs.readFileSync(
+    path.resolve(__dirname, '../handlers/loadTaskById.ts'),
+    'utf-8',
+  )
 
   // The task loader (opening a task now navigates; the route effect
   // calls loadTaskById, which holds the per-task state resets).
-  const selectTaskBody = extractFunctionBody(appSource, 'loadTaskById')
+  const selectTaskBody = extractFunctionBody(loadTaskSource, 'loadTaskById')
   const submitCreateBody = extractFunctionBody(appSource, 'submitCreateTask')
 
   const selectTaskResets = extractResetCalls(selectTaskBody)

--- a/frontend/src/__tests__/loadTaskById.test.ts
+++ b/frontend/src/__tests__/loadTaskById.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression: switching tasks must not be clobbered by a slower earlier
+ * load. Selecting a task fans out several awaited fetches; if the user
+ * clicks a second task before the first resolves, the first (slower)
+ * load's responses used to land LAST and revert the selection — the
+ * detail pane snapped back to the task you navigated away from
+ * ("clicking the other task does nothing"), most visibly when leaving a
+ * running task whose message/step load is heavy.
+ *
+ * loadTaskById claims a monotonic seq and drops its state writes once a
+ * newer load has superseded it. These tests pin that guard.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { loadTaskById, type LoadTaskDeps } from '../handlers/loadTaskById'
+
+function deferred<T>() {
+  let resolve!: (v: T) => void
+  const promise = new Promise<T>(r => { resolve = r })
+  return { promise, resolve }
+}
+
+function makeDeps(getImpl: (url: string) => Promise<unknown>) {
+  const seqRef = { current: 0 }
+  const fns = {
+    setSelectedTask: vi.fn(), setLogs: vi.fn(), setScreenshots: vi.fn(),
+    setAgentMessages: vi.fn(), setTodoItems: vi.fn(), setSelectedAnswers: vi.fn(),
+    setOtherInputs: vi.fn(), setShowOtherInput: vi.fn(), setChatInput: vi.fn(),
+    setChatAttachments: vi.fn(), setPendingQuestions: vi.fn(),
+    setConversationItems: vi.fn(), setSteps: vi.fn(),
+  }
+  const deps = { api: { get: getImpl }, seqRef, ...fns } as unknown as LoadTaskDeps
+  return { deps, seqRef, fns }
+}
+
+// Immediate responses for the secondary fetches; the task GET is routed
+// per-id so a specific task can be made slow.
+function router(taskGet: (id: string) => Promise<unknown>) {
+  return (url: string): Promise<unknown> => {
+    if (/\/api\/tasks\/[^/]+$/.test(url)) return taskGet(url.split('/').pop() as string)
+    if (url.endsWith('/questions/pending')) return Promise.resolve({ pending: false })
+    if (url.endsWith('/messages')) return Promise.resolve([])
+    if (url.endsWith('/steps')) return Promise.resolve([])
+    return Promise.resolve({})
+  }
+}
+
+describe('loadTaskById stale-response guard', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('a slow earlier load does NOT clobber a newer selection', async () => {
+    const slowA = deferred<unknown>()
+    const { deps, fns } = makeDeps(router(id =>
+      id === 'A' ? slowA.promise : Promise.resolve({ id, todos: null }),
+    ))
+
+    // Click A (its task GET hangs), then click B (resolves immediately).
+    const pA = loadTaskById('A', deps)
+    const pB = loadTaskById('B', deps)
+    await pB
+
+    // B is fully applied.
+    expect(fns.setSelectedTask).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'B' }))
+
+    // Now A finally resolves — it must apply NOTHING (superseded).
+    fns.setSelectedTask.mockClear()
+    fns.setConversationItems.mockClear()
+    fns.setSteps.mockClear()
+    slowA.resolve({ id: 'A', todos: null })
+    await pA
+
+    expect(fns.setSelectedTask).not.toHaveBeenCalled()
+    expect(fns.setConversationItems).not.toHaveBeenCalled()
+    expect(fns.setSteps).not.toHaveBeenCalled()
+  })
+
+  it('the latest selection always wins regardless of resolve order', async () => {
+    const slowA = deferred<unknown>()
+    const { deps, fns } = makeDeps(router(id =>
+      id === 'A' ? slowA.promise : Promise.resolve({ id, todos: null }),
+    ))
+    const pA = loadTaskById('A', deps)
+    const pB = loadTaskById('B', deps)
+    await pB
+    slowA.resolve({ id: 'A', todos: null })
+    await pA
+    // Every setSelectedTask call that happened was for B, never A.
+    for (const call of fns.setSelectedTask.mock.calls) {
+      expect(call[0]).toEqual(expect.objectContaining({ id: 'B' }))
+    }
+    expect(fns.setSelectedTask).toHaveBeenCalled()
+  })
+
+  it('a single (uncontested) load applies its full state', async () => {
+    const { deps, fns } = makeDeps(router(id => Promise.resolve({ id, todos: null })))
+    await loadTaskById('solo', deps)
+    expect(fns.setSelectedTask).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'solo' }))
+    expect(fns.setConversationItems).toHaveBeenCalled()
+    expect(fns.setSteps).toHaveBeenCalledWith([])
+  })
+})

--- a/frontend/src/handlers/loadTaskById.ts
+++ b/frontend/src/handlers/loadTaskById.ts
@@ -1,0 +1,94 @@
+import { buildConversationItems } from '../lib/conversation'
+import type { Task, TaskStep, TodoItem, AgentMessage, ConversationItem, StagedAttachment } from '../types'
+
+interface PendingQuestions {
+  request_id: string
+  questions: { header?: string; question: string; options?: { label: string; description?: string }[] }[]
+}
+
+export interface LoadTaskDeps {
+  api: { get(url: string): Promise<unknown> }
+  // Monotonic token ref shared with App: each call claims the next value;
+  // a load only applies its state while it is still the current one.
+  seqRef: React.MutableRefObject<number>
+  setSelectedTask: React.Dispatch<React.SetStateAction<Task | null>>
+  setLogs: (v: string[]) => void
+  setScreenshots: React.Dispatch<React.SetStateAction<Record<string, string>>>
+  setAgentMessages: (v: AgentMessage[]) => void
+  setTodoItems: (v: TodoItem[]) => void
+  setSelectedAnswers: (v: Record<string, string>) => void
+  setOtherInputs: (v: Record<string, string>) => void
+  setShowOtherInput: (v: Record<string, boolean>) => void
+  setChatInput: (v: string) => void
+  setChatAttachments: (v: StagedAttachment[]) => void
+  setPendingQuestions: (v: PendingQuestions | null) => void
+  setConversationItems: (v: ConversationItem[]) => void
+  setSteps: (v: TaskStep[]) => void
+}
+
+/**
+ * Load a task's full detail (task, pending question, messages, steps,
+ * screenshots) into App state when its route param appears.
+ *
+ * Stale-response guard: selecting a task fans out several awaited
+ * fetches. If the user switches to another task before they resolve, the
+ * slower load's responses would otherwise land LAST and clobber the newer
+ * selection — the detail pane snaps back to the task you navigated away
+ * from ("clicking the other task does nothing"), most visibly when
+ * switching AWAY from a running task whose message/step load is heavy.
+ * Each call claims the next `seqRef` value; after every await we bail
+ * unless this load is still the current one. Mirrors the
+ * inFlightTasksKeyRef / inFlightScheduleIdRef guards used elsewhere.
+ */
+export async function loadTaskById(taskId: string, deps: LoadTaskDeps): Promise<void> {
+  const { api } = deps
+  const seq = ++deps.seqRef.current
+  const fresh = () => deps.seqRef.current === seq
+
+  let fullTask: Task
+  try { fullTask = (await api.get(`/api/tasks/${taskId}`)) as Task } catch { return }
+  if (!fresh()) return
+  deps.setSelectedTask(fullTask); deps.setLogs([]); deps.setScreenshots({}); deps.setAgentMessages([])
+  if (fullTask.todos) { try { deps.setTodoItems(JSON.parse(fullTask.todos)) } catch { deps.setTodoItems([]) } } else { deps.setTodoItems([]) }
+  deps.setSelectedAnswers({}); deps.setOtherInputs({}); deps.setShowOtherInput({}); deps.setChatInput(''); deps.setChatAttachments([])
+  deps.setPendingQuestions(null)  // Clear immediately to avoid stale UI
+
+  // Recover pending question if agent is waiting
+  try {
+    const q = (await api.get(`/api/tasks/${fullTask.id}/questions/pending`)) as { pending?: boolean } & PendingQuestions
+    if (!fresh()) return
+    if (q.pending) deps.setPendingQuestions({ request_id: q.request_id, questions: q.questions })
+    else deps.setPendingQuestions(null)
+  } catch { if (fresh()) deps.setPendingQuestions(null) }
+
+  // Rebuild the conversation stream from persisted messages + task state.
+  let convItems: ConversationItem[] = []
+  try {
+    const msgs = (await api.get(`/api/tasks/${taskId}/messages`)) as { role: string; content: string }[]
+    if (!fresh()) return
+    deps.setAgentMessages(msgs.map(m => ({ role: m.role, content: m.content })))
+    convItems = buildConversationItems(msgs, fullTask)
+  } catch { /* ignore */ }
+  if (!fresh()) return
+  deps.setConversationItems(convItems)
+
+  const stepsData = (await api.get(`/api/tasks/${taskId}/steps`)) as TaskStep[]
+  if (!fresh()) return
+  deps.setSteps(stepsData)
+  for (const s of stepsData) {
+    if (!s.screenshot_id) continue
+    try {
+      const resp = await fetch(`/api/screenshots/${s.screenshot_id}`, { credentials: 'include' })
+      if (resp.ok) {
+        const blob = await resp.blob()
+        const reader = new FileReader()
+        reader.onload = () => {
+          if (!fresh()) return
+          const b64 = (reader.result as string).split(',')[1]
+          deps.setScreenshots(prev => ({ ...prev, [s.id]: b64 }))
+        }
+        reader.readAsDataURL(blob)
+      }
+    } catch { /* ignore */ }
+  }
+}


### PR DESCRIPTION
## Problem

Clicking a second task before the first task's detail finished loading could leave you **stuck on the first task** — the detail pane snapped back to the one you navigated away from, so "clicking the other task does nothing." Most visible when switching **away from a running task**, whose message/step load is heavy and resolves last. Reproduced on a remote deployment (remote latency widens the window); on a fast local connection the window is ~0ms.

## Root cause

Selecting a task fans out several awaited fetches — task, pending question, messages, steps, screenshots — in `loadTaskById`, which had **no stale-response guard**. Two overlapping loads race and the slower one's `setState` calls land *last*, clobbering the newer selection. The task **list** load (`inFlightTasksKeyRef`) and the **schedule** load (`inFlightScheduleIdRef`) already guard exactly this hazard; the single-task load did not.

## Fix (design, not symptom)

`loadTaskById` now claims a monotonic sequence number; after every `await` it applies its fetched state **only while it is still the current load** (mirrors the existing in-flight guards). Extracted into `handlers/loadTaskById.ts` — keeps `App.tsx` under the 800-line cap and makes the guard unit-testable.

## Tests

- `loadTaskById.test.ts` (new): a slow earlier load must **not** clobber a newer selection; latest-wins regardless of resolve order; a single uncontested load still applies its full state. These fail without the guard.
- `createTaskStateReset` contract updated to read the extracted handler.
- Full frontend suite (379) green locally.

## Verified

Reproduced/characterized live against a remote deployment via Playwright (switching works when loads are fast; the race is the overlapping-load window). The new test reproduces the race deterministically and passes with the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg5csnfP39iFPAEqcEnqwK
