### PR TITLE
fix(tasks): make task switching latency-resilient (clear stale, parallelize, stop superseded loads)

### DIFF
--- a/frontend/src/__tests__/loadTaskById.test.ts
+++ b/frontend/src/__tests__/loadTaskById.test.ts
@@ -99,4 +99,51 @@ describe('loadTaskById stale-response guard', () => {
     expect(fns.setConversationItems).toHaveBeenCalled()
     expect(fns.setSteps).toHaveBeenCalledWith([])
   })
+
+  it('clears the previous task detail up front so the switch is instant', async () => {
+    const { deps, fns } = makeDeps(router(id => Promise.resolve({ id, todos: null })))
+    await loadTaskById('X', deps)
+    // Conversation + steps are cleared to [] before the (async) refill,
+    // so a slow link never shows the old task's content under the new head.
+    expect(fns.setConversationItems).toHaveBeenNthCalledWith(1, [])
+    expect(fns.setSteps).toHaveBeenNthCalledWith(1, [])
+  })
+
+  it('a superseded load stops fetching screenshots (frees the connection pool)', async () => {
+    // Global fetch counts screenshot requests; first one hangs so we can
+    // supersede mid-loop.
+    const firstFetch = deferred<unknown>()
+    let fetchCalls = 0
+    const fetchSpy = vi.fn(() => {
+      fetchCalls++
+      const body = { ok: true, blob: async () => ({}) }
+      return fetchCalls === 1 ? (firstFetch.promise as Promise<unknown>) : Promise.resolve(body)
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+    vi.stubGlobal('FileReader', class { onload: (() => void) | null = null; readAsDataURL() {} } as unknown as typeof FileReader)
+
+    const steps = [
+      { id: 's1', screenshot_id: 'a' }, { id: 's2', screenshot_id: 'b' },
+      { id: 's3', screenshot_id: 'c' },
+    ]
+    const get = (url: string): Promise<unknown> => {
+      if (url.endsWith('/steps')) return Promise.resolve(steps)
+      if (/\/api\/tasks\/[^/]+$/.test(url)) return Promise.resolve({ id: 'A', todos: null })
+      if (url.endsWith('/questions/pending')) return Promise.resolve({ pending: false })
+      return Promise.resolve([])
+    }
+    const { deps, seqRef } = makeDeps(get)
+
+    const pA = loadTaskById('A', deps)      // reaches the screenshot loop, hangs on fetch #1
+    // Wait until A has issued its first screenshot fetch (it's now in the loop).
+    while (fetchCalls === 0) await new Promise(r => setTimeout(r, 0))
+    seqRef.current++                        // a newer selection supersedes A
+    firstFetch.resolve({ ok: true, blob: async () => ({}) })
+    await pA
+
+    // Only the in-flight first screenshot was requested; the loop bailed
+    // instead of fetching s2 and s3.
+    expect(fetchCalls).toBe(1)
+    vi.unstubAllGlobals()
+  })
 })

--- a/frontend/src/handlers/loadTaskById.ts
+++ b/frontend/src/handlers/loadTaskById.ts
@@ -48,34 +48,40 @@ export async function loadTaskById(taskId: string, deps: LoadTaskDeps): Promise<
   let fullTask: Task
   try { fullTask = (await api.get(`/api/tasks/${taskId}`)) as Task } catch { return }
   if (!fresh()) return
-  deps.setSelectedTask(fullTask); deps.setLogs([]); deps.setScreenshots({}); deps.setAgentMessages([])
+  // Switch the selection AND clear ALL of the previous task's detail up
+  // front — conversation and steps included. On a high-latency link the
+  // follow-up fetches take a moment; without clearing here the OLD task's
+  // conversation/steps linger under the new header, so the switch reads
+  // as "nothing happened" until the new data lands. Clear now → the pane
+  // flips to the new task immediately and fills in as data arrives.
+  deps.setSelectedTask(fullTask)
+  deps.setLogs([]); deps.setScreenshots({}); deps.setAgentMessages([])
+  deps.setConversationItems([]); deps.setSteps([])
   if (fullTask.todos) { try { deps.setTodoItems(JSON.parse(fullTask.todos)) } catch { deps.setTodoItems([]) } } else { deps.setTodoItems([]) }
   deps.setSelectedAnswers({}); deps.setOtherInputs({}); deps.setShowOtherInput({}); deps.setChatInput(''); deps.setChatAttachments([])
   deps.setPendingQuestions(null)  // Clear immediately to avoid stale UI
 
-  // Recover pending question if agent is waiting
-  try {
-    const q = (await api.get(`/api/tasks/${fullTask.id}/questions/pending`)) as { pending?: boolean } & PendingQuestions
-    if (!fresh()) return
-    if (q.pending) deps.setPendingQuestions({ request_id: q.request_id, questions: q.questions })
-    else deps.setPendingQuestions(null)
-  } catch { if (fresh()) deps.setPendingQuestions(null) }
-
-  // Rebuild the conversation stream from persisted messages + task state.
-  let convItems: ConversationItem[] = []
-  try {
-    const msgs = (await api.get(`/api/tasks/${taskId}/messages`)) as { role: string; content: string }[]
-    if (!fresh()) return
-    deps.setAgentMessages(msgs.map(m => ({ role: m.role, content: m.content })))
-    convItems = buildConversationItems(msgs, fullTask)
-  } catch { /* ignore */ }
+  // Fetch the detail pieces CONCURRENTLY rather than in series — on a
+  // slow link four sequential round-trips (question + messages + steps)
+  // stack up into a visible delay; in parallel it is a single round-trip.
+  const [q, msgs, stepsData] = await Promise.all([
+    api.get(`/api/tasks/${fullTask.id}/questions/pending`).catch(() => null) as Promise<({ pending?: boolean } & PendingQuestions) | null>,
+    api.get(`/api/tasks/${taskId}/messages`).catch(() => []) as Promise<{ role: string; content: string }[]>,
+    api.get(`/api/tasks/${taskId}/steps`).catch(() => []) as Promise<TaskStep[]>,
+  ])
   if (!fresh()) return
-  deps.setConversationItems(convItems)
 
-  const stepsData = (await api.get(`/api/tasks/${taskId}/steps`)) as TaskStep[]
-  if (!fresh()) return
+  deps.setPendingQuestions(q?.pending ? { request_id: q.request_id, questions: q.questions } : null)
+  deps.setAgentMessages(msgs.map(m => ({ role: m.role, content: m.content })))
+  deps.setConversationItems(buildConversationItems(msgs, fullTask))
   deps.setSteps(stepsData)
+
   for (const s of stepsData) {
+    // Bail the whole loop the moment a newer selection supersedes this
+    // one — otherwise a stale load keeps fetching screenshots one by one,
+    // hogging the browser's connection pool and delaying the NEW task's
+    // requests (the "switch releases after a few seconds" symptom).
+    if (!fresh()) return
     if (!s.screenshot_id) continue
     try {
       const resp = await fetch(`/api/screenshots/${s.screenshot_id}`, { credentials: 'include' })


### PR DESCRIPTION
Follow-up to the stale-response guard (#100). On a **high-latency link** (remote Tailscale, not LAN) switching tasks still felt **"locked for a few seconds, then released"** — the guard stopped the permanent stick, but three latency amplifiers in `loadTaskById` remained:

1. **Stale detail lingered.** Conversation + steps were replaced only *after* their fetches returned, so on a slow link the previous task's content showed under the new header for a beat — the switch looked like it did nothing. Now the previous task's conversation + steps are cleared **immediately** when the selection flips.
2. **Serial round-trips.** The pending-question / messages / steps GETs ran sequentially (three stacked round-trips). They now run **concurrently** (`Promise.all`) — ~one round-trip.
3. **Superseded loads kept fetching screenshots.** A stale load's screenshot loop had no early-out, so it kept fetching one-by-one and **hogged the browser's ~6-connection pool**, delaying the new task's requests until it drained — the "releases after a few seconds" symptom. The loop now **bails the moment a newer selection supersedes it**.

## Tests
`loadTaskById.test.ts` gains: up-front clear of conversation/steps, and a superseded load halting its screenshot loop (frees the connection pool). Full frontend suite (387) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg5csnfP39iFPAEqcEnqwK