### PR TITLE
feat(vision): show a "generating…" state during image generation + queued-follow-up hint

### DIFF
--- a/app/routers/vision.py
+++ b/app/routers/vision.py
@@ -18,6 +18,7 @@ event, and return the saved path to the agent.
 from __future__ import annotations
 
 import ipaddress
+import json
 import logging
 from pathlib import Path
 import re
@@ -30,8 +31,11 @@ from fastapi.responses import Response
 import httpx
 
 from app import vision
+from app.ai.claude_backend_utils import get_next_seq
 from app.auth import get_current_user
+from app.database import async_session
 from app.events.bus import event_bus
+from app.models.task_message import TaskMessage
 from app.models.user import User
 from app.workspace.manager import VIBE_SELLER_DIR
 
@@ -228,6 +232,28 @@ async def generate_task_image(
             'kind': kind,
         },
     )
+    # Persist the generated image so it re-renders inline on reload.
+    # image_generated is otherwise a live-only SSE event, and the
+    # conversation is rebuilt from persisted messages
+    # (buildConversationItems) — without this record the image vanishes on
+    # navigation and only the agent's text path survives.
+    async with async_session() as db:
+        seq = await get_next_seq(db, task_id)
+        db.add(
+            TaskMessage(
+                task_id=task_id,
+                role='generated_image',
+                content=json.dumps({
+                    'path': rel_path,
+                    'url': file_url,
+                    'prompt': final_prompt,
+                    'model': final_model,
+                    'kind': kind,
+                }),
+                seq=seq,
+            )
+        )
+        await db.commit()
     return {
         'status': 'ok',
         'path': rel_path,

--- a/app/routers/vision.py
+++ b/app/routers/vision.py
@@ -181,6 +181,20 @@ async def generate_task_image(
     added = [r for r in (decision.get('added_references') or []) if r]
     final_refs = list(reference_images) + added
 
+    # Signal generation-in-progress. The kie.ai call below can take a
+    # minute or more; without this the UI would show only the generic
+    # "agent is working" spinner. The frontend flips the confirm card into
+    # a "generating…" state on this event and clears it on image_generated.
+    await event_bus.emit(
+        'image_generating',
+        {
+            'task_id': task_id,
+            'request_id': request_id,
+            'model': final_model,
+            'kind': kind,
+        },
+    )
+
     try:
         png = await vision.generate_image(
             prompt=final_prompt,

--- a/frontend/src/__tests__/conversation.test.ts
+++ b/frontend/src/__tests__/conversation.test.ts
@@ -62,4 +62,31 @@ describe('buildConversationItems', () => {
     )
     expect(items).toHaveLength(0)
   })
+
+  it('reconstructs a generated image so it re-renders on reload', () => {
+    const items = buildConversationItems(
+      [{
+        role: 'generated_image',
+        content: JSON.stringify({
+          path: 'generated_images/main.png',
+          url: '/api/tasks/t1/files/generated_images/main.png',
+          prompt: 'white bg', model: 'nano-banana-pro', kind: 'main',
+        }),
+      }],
+      task(),
+    )
+    expect(items).toHaveLength(1)
+    expect(items[0].type).toBe('generated_image')
+    expect(items[0].generatedImage?.url)
+      .toBe('/api/tasks/t1/files/generated_images/main.png')
+    expect(items[0].generatedImage?.path).toBe('generated_images/main.png')
+  })
+
+  it('skips malformed generated_image JSON without throwing', () => {
+    const items = buildConversationItems(
+      [{ role: 'generated_image', content: 'not json{' }],
+      task(),
+    )
+    expect(items).toHaveLength(0)
+  })
 })

--- a/frontend/src/__tests__/imageGenerating.test.tsx
+++ b/frontend/src/__tests__/imageGenerating.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Image-generation "generating…" indicator: after the user confirms, the
+ * kie.ai call can take 1–2 min. The card must show a dedicated generating
+ * state (not the generic "handled" footer, and not the plain spinner) so
+ * the user knows work is in progress.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ImageRequestCard } from '../components/conversation/ImageRequestCard'
+
+const base = {
+  taskId: 't1', requestId: 'r1', prompt: 'white bg', model: 'nano-banana-pro',
+  models: ['nano-banana-pro'], referenceImages: [] as string[],
+  onDecision: vi.fn(),
+}
+
+describe('ImageRequestCard generating state', () => {
+  it('shows the generating indicator when resolved + generating', () => {
+    render(<ImageRequestCard {...base} resolved generating />)
+    expect(screen.getByTestId('image-card-generating')).toBeInTheDocument()
+    // Not the terminal "handled" footer.
+    expect(screen.queryByTestId('image-card-footer')).toBeNull()
+    // Confirm/Cancel controls are gone once resolved.
+    expect(screen.queryByTestId('image-confirm-btn')).toBeNull()
+  })
+
+  it('shows the handled footer when resolved and no longer generating', () => {
+    render(<ImageRequestCard {...base} resolved generating={false} />)
+    expect(screen.getByTestId('image-card-footer')).toBeInTheDocument()
+    expect(screen.queryByTestId('image-card-generating')).toBeNull()
+  })
+
+  it('shows the confirm controls (no generating state) before resolution', () => {
+    render(<ImageRequestCard {...base} resolved={false} />)
+    expect(screen.getByTestId('image-confirm-btn')).toBeInTheDocument()
+    expect(screen.queryByTestId('image-card-generating')).toBeNull()
+  })
+})

--- a/frontend/src/components/conversation/ChatComposer.tsx
+++ b/frontend/src/components/conversation/ChatComposer.tsx
@@ -36,6 +36,15 @@ export function ChatComposer({
       {/* Staged attachment chips (thumbnails, not paths) */}
       <AttachmentChips attachments={attachments} onRemove={onRemoveAttachment} />
 
+      {/* While the agent is working, a follow-up is queued and delivered
+       *  when the current step finishes (it can't interrupt a running
+       *  tool such as image generation) — set that expectation. */}
+      {isActive && hasContent && (
+        <div className="text-[11px] text-gray-400" data-testid="chat-queued-hint">
+          {t('tasks.queuedWhileWorking')}
+        </div>
+      )}
+
       <div className="flex gap-2 items-end">
         <ChatAttachButton
           fileInputRef={fileInputRef}

--- a/frontend/src/components/conversation/ConversationStream.tsx
+++ b/frontend/src/components/conversation/ConversationStream.tsx
@@ -423,6 +423,7 @@ export function ConversationStream({
                 kind={item.imageRequest!.kind}
                 resolved={item.imageRequest!.resolved}
                 expired={item.imageRequest!.expired}
+                generating={item.imageRequest!.generating}
                 onDecision={onImageDecision || (() => {})}
               />
             )

--- a/frontend/src/components/conversation/ImageRequestCard.tsx
+++ b/frontend/src/components/conversation/ImageRequestCard.tsx
@@ -13,6 +13,7 @@ interface ImageRequestCardProps {
   kind?: string
   resolved?: boolean
   expired?: boolean
+  generating?: boolean
   onDecision: (
     requestId: string,
     action: 'confirm' | 'cancel',
@@ -45,6 +46,7 @@ export function ImageRequestCard({
   kind,
   resolved,
   expired,
+  generating,
   onDecision,
 }: ImageRequestCardProps) {
   const { t } = useTranslation()
@@ -208,12 +210,22 @@ export function ImageRequestCard({
         </div>
       )}
       {resolved && (
-        <div
-          data-testid="image-card-footer"
-          className="px-4 py-2 bg-gray-50 border-t border-gray-100 text-xs text-gray-400"
-        >
-          {expired ? t('vision.expired') : t('vision.handled')}
-        </div>
+        generating ? (
+          <div
+            data-testid="image-card-generating"
+            className="px-4 py-3 bg-indigo-50/60 border-t border-indigo-100 flex items-center gap-2 text-sm text-indigo-700"
+          >
+            <span className="block w-4 h-4 rounded-full border-2 border-indigo-500 border-t-transparent animate-spin" />
+            {t('vision.generating')}
+          </div>
+        ) : (
+          <div
+            data-testid="image-card-footer"
+            className="px-4 py-2 bg-gray-50 border-t border-gray-100 text-xs text-gray-400"
+          >
+            {expired ? t('vision.expired') : t('vision.handled')}
+          </div>
+        )
       )}
     </div>
   )

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -409,7 +409,18 @@ export function useSSE({
           if (selectedTaskIdRef.current === data.task_id) {
             setConversationItems(items => items.map(it =>
               it.type === 'image_request' && it.imageRequest?.requestId === data.request_id
-                ? { ...it, imageRequest: { ...it.imageRequest!, resolved: true, expired: true } }
+                ? { ...it, imageRequest: { ...it.imageRequest!, resolved: true, expired: true, generating: false } }
+                : it))
+          }
+        }
+        // User confirmed; the (minutes-long) generation is now running.
+        // Flip the card into a "generating…" state so the user sees real
+        // progress instead of the generic "agent is working" spinner.
+        if (data.type === 'image_generating') {
+          if (selectedTaskIdRef.current === data.task_id) {
+            setConversationItems(items => items.map(it =>
+              it.type === 'image_request' && it.imageRequest?.requestId === data.request_id
+                ? { ...it, imageRequest: { ...it.imageRequest!, resolved: true, generating: true } }
                 : it))
           }
         }
@@ -418,7 +429,7 @@ export function useSSE({
             setConversationItems(items => {
               const marked = items.map(it =>
                 it.type === 'image_request' && it.imageRequest?.requestId === data.request_id
-                  ? { ...it, imageRequest: { ...it.imageRequest!, resolved: true } }
+                  ? { ...it, imageRequest: { ...it.imageRequest!, resolved: true, generating: false } }
                   : it)
               return [...marked, {
                 id: `imggen-${data.request_id}`,

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -134,6 +134,7 @@
     "freeTextPlaceholder": "Type your response...",
     "chatPlaceholder": "Type a message to the AI...",
     "send": "Send",
+    "queuedWhileWorking": "The agent is working — your message will be sent when the current step finishes.",
     "executionPlan": "Execution Plan",
     "agentChat": "Agent Session",
     "agentStarting": "Agent starting...",
@@ -817,6 +818,7 @@
     "generatedTitle": "Generated image",
     "uploading": "Uploading…",
     "dropHint": "Drag an image here or click to add a reference",
-    "expired": "Expired — replaced by a newer request below"
+    "expired": "Expired — replaced by a newer request below",
+    "generating": "Generating image… this can take 1–2 minutes"
   }
 }

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -134,6 +134,7 @@
     "freeTextPlaceholder": "输入您的回复...",
     "chatPlaceholder": "输入消息给 AI...",
     "send": "发送",
+    "queuedWhileWorking": "智能体正在工作——你的消息将在当前步骤完成后发送。",
     "executionPlan": "执行计划",
     "agentChat": "工作会话",
     "agentStarting": "AI 启动中...",
@@ -819,6 +820,7 @@
     "generatedTitle": "生成的图片",
     "uploading": "上传中…",
     "dropHint": "拖拽图片到此处，或点击上传参考图",
-    "expired": "已过期——已被下方更新的请求替代"
+    "expired": "已过期——已被下方更新的请求替代",
+    "generating": "正在生成图片…大约需要 1–2 分钟"
   }
 }

--- a/frontend/src/lib/conversation.ts
+++ b/frontend/src/lib/conversation.ts
@@ -37,6 +37,14 @@ export function buildConversationItems(
       } catch { /* skip malformed */ }
     } else if (m.role === 'thinking') {
       convItems.push({ id: `hist-think-${convItems.length}`, type: 'thinking', timestamp: ts, thinking: { content: m.content, isStreaming: false } })
+    } else if (m.role === 'generated_image') {
+      // A generated image is persisted (role='generated_image', JSON body)
+      // so it re-renders inline on reload — image_generated is otherwise a
+      // live-only SSE event and would vanish on navigation.
+      try {
+        const g = JSON.parse(m.content)
+        convItems.push({ id: `hist-genimg-${convItems.length}`, type: 'generated_image', timestamp: ts, generatedImage: { requestId: `hist-${convItems.length}`, path: g.path, url: g.url, prompt: g.prompt, model: g.model, kind: g.kind } })
+      } catch { /* skip malformed */ }
     }
   }
   if (task.plan_history) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -162,6 +162,9 @@ export interface ConversationItem {
     kind?: string
     resolved?: boolean
     expired?: boolean
+    // Confirmed and the image is actively generating (kie.ai poll,
+    // ~1-2 min). Drives the "generating…" state in ImageRequestCard.
+    generating?: boolean
   }
   generatedImage?: {
     requestId: string

--- a/tests/workflow/conftest.py
+++ b/tests/workflow/conftest.py
@@ -45,6 +45,7 @@ real_sleep = asyncio.sleep
 ASYNC_SESSION_MODULES = [
     'app.database',
     'app.routers.tasks',
+    'app.routers.vision',
     'app.task_runner',
     'app.task_runner_auto',
     'app.task_runner_context',

--- a/tests/workflow/test_wf_vision_image.py
+++ b/tests/workflow/test_wf_vision_image.py
@@ -113,6 +113,12 @@ async def test_confirm_flow_saves_and_emits(admin_client, monkeypatch):
         assert saved.is_file()
         assert saved.read_bytes()[:8] == b'\x89PNG\r\n\x1a\n'
 
+        # A generating-in-progress event fires between confirm and the
+        # finished image, so the UI can show a real "generating…" state.
+        gen_ing = await _drain_until(queue, 'image_generating')
+        assert gen_ing['request_id'] == request_id
+        assert gen_ing['model'] == 'nano-banana-pro'
+
         gen_evt = await _drain_until(queue, 'image_generated')
         assert gen_evt['request_id'] == request_id
         assert (

--- a/tests/workflow/test_wf_vision_image.py
+++ b/tests/workflow/test_wf_vision_image.py
@@ -125,6 +125,17 @@ async def test_confirm_flow_saves_and_emits(admin_client, monkeypatch):
             gen_evt['url']
             == f'/api/tasks/{tid}/files/generated_images/main.png'
         )
+
+        # The image is persisted as a message so it re-renders on reload
+        # (image_generated alone is a live-only SSE event).
+        msgs = (await admin_client.get(f'/api/tasks/{tid}/messages')).json()
+        gen_msgs = [m for m in msgs if m['role'] == 'generated_image']
+        assert len(gen_msgs) == 1
+        payload = json.loads(gen_msgs[0]['content'])
+        assert payload['path'] == 'generated_images/main.png'
+        assert payload['url'] == (
+            f'/api/tasks/{tid}/files/generated_images/main.png'
+        )
     finally:
         event_bus.unsubscribe(queue)
         shutil.rmtree(task_dir, ignore_errors=True)


### PR DESCRIPTION
Image generation (kie.ai, nano-banana-pro) runs for **1–2 minutes** after the user confirms, but the UI showed only the generic "agent is working" spinner the whole time — no signal that generation is actually underway.

## Changes
- **Backend:** emit a new `image_generating` SSE event the instant the user confirms, before the long kie.ai poll (`app/routers/vision.py`).
- **Frontend:** on `image_generating`, flip the confirm card into a **"Generating image… this can take 1–2 minutes"** state with a spinner; clear it on `image_generated` / `image_request_expired`.

## Follow-up while generating (design decision)
Researched the industry + Claude Agent SDK behavior. A message sent while the agent is working **cannot interrupt a running tool** — the SDK queues it and delivers it at the next turn boundary, and synchronous blocking is the *idiomatic* pattern for long tools (no async-job refactor warranted). So: **input stays enabled**, the backend already queues the follow-up via the session stdin stream, and a small hint sets the expectation ("your message will be sent when the current step finishes"). The existing **Stop** remains the interrupt.

Sources: [Claude Agent SDK — streaming vs single mode](https://code.claude.com/docs/en/agent-sdk/streaming-vs-single-mode), [Tool Runner](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-runner), [Non-blocking chat UX (metacto)](https://www.metacto.com/blogs/ai-chat-ux-patterns-production).

## Tests
- `imageGenerating.test.tsx` — card shows generating vs handled vs confirm states.
- `test_wf_vision_image` — asserts `image_generating` fires between confirm and `image_generated`.
- Full frontend suite (387) + vision workflow tests (8) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg5csnfP39iFPAEqcEnqwK