### PR TITLE
fix(tasks): don't strand a finished Q&A task in WAITING (completed result wins)

### DIFF
--- a/app/ai/task_status_reconcile.py
+++ b/app/ai/task_status_reconcile.py
@@ -62,3 +62,36 @@ def qa_followup_needs_input(session) -> bool:
     return bool(
         getattr(session, '_asked_user_question', False)
     ) and not getattr(session, '_tool_use_since_answer', False)
+
+
+def agent_completed_with_result(session, task_result) -> bool:
+    """True when the agent GENUINELY finished this session: it exited
+    successfully, did real (non-question) tool work, and produced a
+    substantive result.
+
+    Guard for ``qa_followup_needs_input``. That heuristic parks a task in
+    WAITING when an interactive-Q&A turn ends with prose only (no closing
+    tool / ``set_task_result``) — assuming the agent is "asking again".
+    But an agent that actually finished (e.g. generated the image and
+    reported its path in prose, exiting cleanly with a 200+char result)
+    hits the same shape and would be stranded in WAITING forever. When
+    this returns True the finalizer COMPLETEs instead of parking. If the
+    agent truly meant to ask again, the task still COMPLETEs but a user
+    follow-up resumes it — recoverable, unlike a permanent WAITING.
+    """
+    return (
+        bool(getattr(session, '_agent_success', False))
+        and bool(getattr(session, '_had_tool_use', False))
+        and bool(task_result and str(task_result).strip())
+    )
+
+
+def should_park_qa_followup(session, task_result) -> bool:
+    """Finalizer decision: park an interactive-Q&A turn in WAITING because
+    it ended prose-only (``qa_followup_needs_input``) — UNLESS the agent
+    genuinely completed (``agent_completed_with_result``). Combines the
+    two so the finalizer call site stays a one-liner.
+    """
+    return qa_followup_needs_input(session) and not agent_completed_with_result(
+        session, task_result
+    )

--- a/app/task_runner_auto.py
+++ b/app/task_runner_auto.py
@@ -10,7 +10,7 @@ from app.ai.external_config import (
     assert_profile_compatible,
 )
 from app.ai.profiles import DEFAULT_PROFILE_ID
-from app.ai.task_status_reconcile import qa_followup_needs_input
+from app.ai.task_status_reconcile import should_park_qa_followup
 from app.browser.manager import browser_manager, store_slug as _store_slug
 from app.database import async_session
 from app.events.bus import event_bus
@@ -783,7 +783,7 @@ async def _finalize_terminal_state(
             )
             return
 
-        if qa_followup_needs_input(session):  # prose-only after answer
+        if should_park_qa_followup(session, task.result):
             await park_waiting_for_text_only_response(task, db, task_id)
             return
         if await maybe_wait_for_children(task, task_id, db):

--- a/tests/unit/test_task_status_reconcile.py
+++ b/tests/unit/test_task_status_reconcile.py
@@ -10,8 +10,10 @@ from types import SimpleNamespace
 import pytest
 
 from app.ai.task_status_reconcile import (
+    agent_completed_with_result,
     qa_followup_needs_input,
     reconcile_streaming_run_status,
+    should_park_qa_followup,
 )
 from app.task_states import TaskStatus
 
@@ -75,3 +77,69 @@ class TestQaFollowupNeedsInput:
     def test_missing_attrs_default_false(self):
         # FakeAgent / non-ClaudeCode sessions lack the attrs entirely.
         assert qa_followup_needs_input(SimpleNamespace()) is False
+
+
+class TestAgentCompletedWithResult:
+    """The guard that stops qa_followup_needs_input from stranding a
+    genuinely-finished task in WAITING (regression: rc=0 + result parked)."""
+
+    def _session(self, success=True, tool=True):
+        return SimpleNamespace(_agent_success=success, _had_tool_use=tool)
+
+    def test_success_plus_tool_plus_result_is_complete(self):
+        assert (
+            agent_completed_with_result(
+                self._session(),
+                '白底主图已生成，路径：generated_images/main.png',
+            )
+            is True
+        )
+
+    def test_no_result_is_not_complete(self):
+        assert agent_completed_with_result(self._session(), '') is False
+        assert agent_completed_with_result(self._session(), '   ') is False
+        assert agent_completed_with_result(self._session(), None) is False
+
+    def test_no_success_is_not_complete(self):
+        assert (
+            agent_completed_with_result(self._session(success=False), 'done')
+            is False
+        )
+
+    def test_no_tool_work_is_not_complete(self):
+        # Prose-only with no real work is exactly the "asking again" shape
+        # the heuristic must still park.
+        assert (
+            agent_completed_with_result(self._session(tool=False), 'done')
+            is False
+        )
+
+    def test_missing_attrs_default_false(self):
+        assert agent_completed_with_result(SimpleNamespace(), 'done') is False
+
+    def test_combined_gate_completes_finished_qa_task(self):
+        # The exact stuck-task shape: asked a question, prose-only after
+        # the last answer, BUT finished cleanly with a real result → the
+        # finalizer must NOT park (qa_followup True yet completion True).
+        s = SimpleNamespace(
+            _asked_user_question=True,
+            _tool_use_since_answer=False,
+            _agent_success=True,
+            _had_tool_use=True,
+        )
+        assert qa_followup_needs_input(s) is True
+        assert (
+            agent_completed_with_result(s, 'image generated: main.png') is True
+        )
+        # The finalizer uses the combined decision: DO NOT park.
+        assert should_park_qa_followup(s, 'image generated: main.png') is False
+
+    def test_should_park_when_prose_only_and_not_finished(self):
+        # Asked, prose-only after answer, and did NOT finish → park.
+        s = SimpleNamespace(
+            _asked_user_question=True,
+            _tool_use_since_answer=False,
+            _agent_success=True,
+            _had_tool_use=False,  # no real work
+        )
+        assert should_park_qa_followup(s, '') is True


### PR DESCRIPTION
**Confirmed from server logs, not guessed.** A task that generated its image and reported the path — `RETRY_CHECK rc=0 result_len=218`, a clean successful completion — was left in `WAITING` forever (badge 等待中).

## Root cause
The finalizer's second, **unlogged** text-only park (`task_runner_auto.py`) calls `qa_followup_needs_input`, which fires when an interactive-Q&A turn ends **prose-only** (no closing tool / `set_task_result`), on the theory "the agent is asking again". Unlike the other text-only park it is **not gated on `task.result`**, and `_tool_use_since_answer` is reset on every answered `AskUserQuestion` — so an agent that finished its work but whose final post-answer words were prose gets classified as "asking again" and parked, **even with a full result and a clean exit**.

## Fix — a genuine completion wins (per maintainer decision)
New pure helper `agent_completed_with_result(session, task_result)`: true when the agent **exited successfully AND did real (non-question) tool work AND produced a substantive result**. Combined into `should_park_qa_followup(session, task_result)` (keeps the finalizer call site a one-liner and the file within the 800-line cap). The finalizer now **COMPLETEs instead of parking** when the agent genuinely finished.

Tradeoff (accepted): an agent that truly meant to *ask again in prose* after finishing work would COMPLETE rather than WAIT — but that's **recoverable** (a user follow-up resumes a completed task), unlike a permanent WAITING.

## Recovering the already-stuck task
The code fix prevents recurrence. An already-stuck task can be un-stuck now by sending it any follow-up message — that goes through the resume path, which clears `wait_condition` and completes it.

## Tests
Unit coverage for `agent_completed_with_result` (success/tool/result matrix + missing-attr default), `should_park_qa_followup`, and the **exact stuck-task shape** (qa-followup True yet completion True → do not park). Affected workflow suites (auto-mode, task-chat, status-gating) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg5csnfP39iFPAEqcEnqwK