### PR TITLE
fix(vision): treat multiple photos of one product as angles, not separate products

### DIFF
--- a/app/mcp_tool_schemas.py
+++ b/app/mcp_tool_schemas.py
@@ -596,7 +596,15 @@ TOOLS = [
                         'Reference image URLs and/or workspace-relative '
                         'file paths, in the order the prompt refers to '
                         "them. Up to 14. The referenced subject's true "
-                        'appearance is taken from these.'
+                        'appearance is taken from these. When the user '
+                        'provides MULTIPLE photos of the SAME product '
+                        '(different angles/views/details), pass them ALL '
+                        'as references for ONE generation — they are views '
+                        'of a single subject, not separate products. Do '
+                        'NOT generate one image per photo. Only make '
+                        'separate calls if the user clearly asked for '
+                        'several DISTINCT products/images; if unsure which '
+                        'they meant, ask before generating.'
                     ),
                 },
                 'model': {


### PR DESCRIPTION
**Reported (#3 + #4):** A user uploaded **2 photos of the same product** in a follow-up; the agent generated **two** main images (one per photo, each with a single reference) — two 确认图片生成 popups, each showing 参考图(1).

**Root cause (from server logs — not a code/delivery bug):** the agent *received both paths* (two `Attached file:` lines) and even listed them, but **the configured model interpreted the two photos as two distinct products** and issued one single-reference `generate_image` call per photo. The tool schema never told the model how to treat multiple references of the same subject.

**Fix:** add explicit guidance to the `reference_images` schema description — multiple photos of the **same** product (different angles/views) must **all** be passed to **one** generation; only make separate calls for clearly distinct products; ask if unsure. Description-only change to the MCP tool schema (no code paths altered).

Note: this steers model behavior via the tool contract; its effect is a model-guidance improvement, best confirmed with a live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg5csnfP39iFPAEqcEnqwK
