### PR TITLE
fix(tasks): make images uploaded at task-creation reach the agent

### DIFF
--- a/app/routers/attachments.py
+++ b/app/routers/attachments.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
@@ -7,11 +8,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user
-from app.config import ATTACHMENTS_DIR
 from app.database import get_db
 from app.models.task import Task
 from app.models.task_attachment import TaskAttachment
 from app.models.user import User
+from app.workspace.manager import VIBE_SELLER_DIR
+
+_TASKS_DIR = VIBE_SELLER_DIR / 'tasks'
 
 router = APIRouter(prefix='/api/attachments', tags=['attachments'])
 
@@ -47,8 +50,20 @@ async def upload_attachment(
         raise HTTPException(status_code=400, detail='File too large (max 10MB)')
 
     attachment_id = str(uuid.uuid4())
-    ext = Path(file.filename or 'file').suffix or '.bin'
-    file_path = ATTACHMENTS_DIR / f'{attachment_id}{ext}'
+    # Write into the TASK WORKSPACE uploads/ (the agent's cwd) so the agent
+    # can Read it — data/attachments was a DB blob invisible to the agent,
+    # so create-time uploads never reached it (unlike the chat flow, which
+    # promotes into uploads/). build_system_extra surfaces these paths.
+    ext = Path(file.filename or 'file').suffix.lower() or '.bin'
+    stem = (
+        re.sub(r'[^A-Za-z0-9._-]', '_', Path(file.filename or 'upload').stem)
+        or 'upload'
+    )
+    out_dir = _TASKS_DIR / task_id / 'uploads'
+    out_dir.mkdir(parents=True, exist_ok=True)
+    file_path = out_dir / f'{stem}{ext}'
+    if file_path.exists():
+        file_path = out_dir / f'{stem}-{attachment_id[:6]}{ext}'
     file_path.write_bytes(content)
 
     attachment = TaskAttachment(

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -199,8 +199,12 @@ async def create_task(
 
     # Route through queue for store tasks (enforces
     # platform/country concurrency rules), or launch
-    # directly for no-store tasks.
-    await schedule_or_run(task.id, store)
+    # directly for no-store tasks. When the client will upload
+    # attachments first (defer_start), skip the launch — the client
+    # POSTs /start once the files are in the workspace, so the agent's
+    # prompt sees them (see build_system_extra uploaded-files note).
+    if not data.defer_start:
+        await schedule_or_run(task.id, store)
 
     return task
 

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -12,6 +12,10 @@ class TaskCreate(BaseModel):
     skip_reflection: bool | None = None
     profile_id: str | None = None
     schedule_id: str | None = None
+    # When true, create the task PENDING but do NOT auto-start it — the
+    # client uploads attachments into the workspace first, then POSTs
+    # /start, so the files are present before the agent reads its prompt.
+    defer_start: bool = False
 
 
 class TaskResponse(BaseModel):

--- a/app/task_runner_context.py
+++ b/app/task_runner_context.py
@@ -477,6 +477,13 @@ async def build_system_context(task: Task) -> str:
         'sub-tasks.',
     ])
 
+    # Files the user uploaded to this task (create-time attachments or
+    # chat uploads) — surfaced so the agent reads them instead of asking
+    # where the image is. Guarded: only added when uploads exist.
+    note = uploaded_files_note(task)
+    if note:
+        lines.append('\n' + note)
+
     return '\n'.join(lines)
 
 
@@ -596,3 +603,28 @@ async def build_all_stores_context(
         *_NO_STORE_WRITE_POLICY,
     ])
     return '\n'.join(lines)
+
+
+def uploaded_files_note(task: Task) -> str:
+    """Surface files the user uploaded to this task so the agent reads
+    them directly instead of asking where the image is.
+
+    Create-time attachments and chat uploads both land in the task
+    workspace ``uploads/`` dir. Listing their absolute paths here (rather
+    than in ``task.description``) keeps the visible description clean while
+    still reaching the agent — the create-flow equivalent of the chat
+    flow's ``Attached file:`` lines.
+    """
+    up = VIBE_SELLER_DIR / 'tasks' / task.id / 'uploads'
+    try:
+        files = sorted(str(p) for p in up.iterdir() if p.is_file())
+    except OSError:
+        return ''
+    if not files:
+        return ''
+    listing = '\n'.join(f'- {p}' for p in files)
+    return (
+        'The user attached the following file(s) to this task. Read them '
+        'directly (images are visual references / product photos — do NOT '
+        'ask the user to provide them again):\n' + listing
+    )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -581,6 +581,7 @@ export default function App() {
           form.append('file', pf.file)
           await fetch(`/api/attachments/${taskId}`, { method: 'POST', body: form, credentials: 'include' })
         },
+        startTask: async (taskId) => { await api.post(`/api/tasks/${taskId}/start`, {}) },
         onCreated: () => {
           setSteps([]); setScreenshots({}); setLogs([]); setConversationItems([]); setAgentMessages([]); setTodoItems([]); setPendingQuestions(null); setSelectedAnswers({}); setOtherInputs({}); setShowOtherInput({}); setChatInput(''); setChatAttachments([])
         },

--- a/frontend/src/__tests__/submitCreateTaskAttachments.test.ts
+++ b/frontend/src/__tests__/submitCreateTaskAttachments.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Create-task with attachments: the task is created with defer_start so it
+ * doesn't launch before its files exist; the modal closes immediately;
+ * attachments upload in the background; then the task is started. Without
+ * files, it launches normally (no defer, no start call).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { submitCreateTask } from '../handlers/submitCreateTask'
+import type { PendingFile, Task } from '../types'
+
+const flush = () => new Promise(r => setTimeout(r, 0))
+
+function deps(over: Record<string, unknown> = {}) {
+  const created = { id: 'task-1' } as Task
+  const post = vi.fn(async () => created)
+  const get = vi.fn(async () => created)
+  return {
+    created, post, get,
+    d: {
+      api: { post, get }, storeId: 'store-1', planMode: false,
+      setTasks: vi.fn(), setSelectedTask: vi.fn(), onCreated: vi.fn(),
+      uploadAttachment: vi.fn(async () => {}),
+      startTask: vi.fn(async () => {}),
+      ...over,
+    },
+  }
+}
+
+const file = (name: string): PendingFile =>
+  ({ id: name, file: new File(['x'], name), preview: '', name }) as PendingFile
+
+describe('submitCreateTask with attachments', () => {
+  it('defers start, closes modal, uploads then starts (with files)', async () => {
+    const { d, post } = deps()
+    await submitCreateTask(
+      { title: 't', description: '', files: [file('a.png'), file('b.png')] },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      d as any,
+    )
+    // Created with defer_start:true
+    expect(post).toHaveBeenCalledWith('/api/tasks', expect.objectContaining({ defer_start: true }))
+    // Modal closed immediately (before the background upload work).
+    expect(d.onCreated).toHaveBeenCalled()
+    await flush(); await flush()
+    // Both files uploaded, then the task started — start AFTER uploads.
+    expect(d.uploadAttachment).toHaveBeenCalledTimes(2)
+    expect(d.startTask).toHaveBeenCalledWith('task-1')
+    const startOrder = d.startTask.mock.invocationCallOrder[0]
+    const lastUpload = Math.max(...d.uploadAttachment.mock.invocationCallOrder)
+    expect(startOrder).toBeGreaterThan(lastUpload)
+  })
+
+  it('launches normally with no files (no defer, no explicit start)', async () => {
+    const { d, post } = deps()
+    await submitCreateTask({ title: 't', description: '', files: [] },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      d as any)
+    await flush()
+    expect(post).toHaveBeenCalledWith('/api/tasks', expect.objectContaining({ defer_start: false }))
+    expect(d.uploadAttachment).not.toHaveBeenCalled()
+    expect(d.startTask).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/handlers/submitCreateTask.ts
+++ b/frontend/src/handlers/submitCreateTask.ts
@@ -41,6 +41,8 @@ export interface SubmitCreateTaskDeps {
   onCreated?: (task: Task) => void
   /** Optional per-attachment uploader (UI runs the real fetch). */
   uploadAttachment?: (taskId: string, pf: PendingFile) => Promise<void>
+  /** Launch a deferred task after its attachments are uploaded. */
+  startTask?: (taskId: string) => Promise<void>
 }
 
 export interface SubmitCreateTaskInput {
@@ -55,6 +57,10 @@ export async function submitCreateTask(
   input: SubmitCreateTaskInput,
   deps: SubmitCreateTaskDeps,
 ): Promise<Task> {
+  const hasFiles = input.files.length > 0
+  // Defer the agent start when there are attachments: the files must be
+  // uploaded into the workspace BEFORE the agent reads its prompt,
+  // otherwise it starts with no image and asks "where is the image?".
   const task = await deps.api.post('/api/tasks', {
     store_id: deps.storeId,
     title: input.title,
@@ -62,13 +68,8 @@ export async function submitCreateTask(
     plan_mode: deps.planMode,
     platform: input.platform || null,
     country: input.country || null,
+    defer_start: hasFiles,
   })
-
-  if (deps.uploadAttachment) {
-    for (const pf of input.files) {
-      await deps.uploadAttachment(task.id, pf)
-    }
-  }
 
   // Dedup-on-prepend: SSE `task_created` may have arrived first
   // (see header comment).  Both insert sites must enforce the
@@ -77,7 +78,19 @@ export async function submitCreateTask(
     prev.some(p => p.id === task.id) ? prev : [task, ...prev],
   )
   deps.setSelectedTask(task)
-  deps.onCreated?.(task)
+  deps.onCreated?.(task)  // close the modal immediately — don't block on uploads
+
+  // Upload attachments, THEN launch. Runs in the background so the modal
+  // closes at once; the deferred task only starts once its files are in
+  // the workspace (agent-visible).
+  if (hasFiles) {
+    void (async () => {
+      if (deps.uploadAttachment) {
+        for (const pf of input.files) await deps.uploadAttachment(task.id, pf)
+      }
+      await deps.startTask?.(task.id)
+    })().catch(() => { /* SSE / status will reflect any failure */ })
+  }
 
   // Race-guard refetch — see header comment.
   deps.api

--- a/tests/unit/test_uploaded_files_note.py
+++ b/tests/unit/test_uploaded_files_note.py
@@ -1,0 +1,42 @@
+"""The create-time / uploaded-files note surfaced to the agent prompt.
+
+Regression: an image uploaded when creating a task never reached the
+agent (it went to a DB blob dir, and its path was never in the prompt),
+so the agent asked "where is the image?". Now uploads land in the task
+workspace ``uploads/`` and their paths are surfaced here.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import app.task_runner_context as trc
+
+pytestmark = pytest.mark.unit
+
+
+def _task(tid='t-abc'):
+    return SimpleNamespace(id=tid)
+
+
+def test_lists_uploaded_files(tmp_path, monkeypatch):
+    monkeypatch.setattr(trc, 'VIBE_SELLER_DIR', tmp_path)
+    up = tmp_path / 'tasks' / 't-abc' / 'uploads'
+    up.mkdir(parents=True)
+    (up / 'photo.jpg').write_bytes(b'\x89PNG')
+    (up / 'doc.pdf').write_bytes(b'%PDF')
+
+    note = trc.uploaded_files_note(_task())
+    assert str(up / 'photo.jpg') in note
+    assert str(up / 'doc.pdf') in note
+    # Instructs the agent to read them, not re-ask.
+    assert 'do NOT ask' in note or 'do not ask' in note.lower()
+
+
+def test_empty_when_no_uploads(tmp_path, monkeypatch):
+    monkeypatch.setattr(trc, 'VIBE_SELLER_DIR', tmp_path)
+    # No uploads dir at all.
+    assert trc.uploaded_files_note(_task()) == ''
+    # Uploads dir exists but empty.
+    (tmp_path / 'tasks' / 't-abc' / 'uploads').mkdir(parents=True)
+    assert trc.uploaded_files_note(_task()) == ''

--- a/tests/workflow/test_wf_create_attachments.py
+++ b/tests/workflow/test_wf_create_attachments.py
@@ -1,0 +1,72 @@
+"""Create-task attachments must reach the agent.
+
+Regression: uploading an image while creating a task stored it in a DB
+blob dir invisible to the agent, and the agent auto-started before the
+upload landed — so it asked "where is the image?". Now attachments write
+into the task workspace ``uploads/`` (agent-visible) and create can defer
+the start until the client has uploaded them.
+"""
+
+import shutil
+
+import pytest
+
+from app.workspace.manager import VIBE_SELLER_DIR
+
+pytestmark = pytest.mark.workflow
+
+_TASKS_DIR = VIBE_SELLER_DIR / 'tasks'
+
+
+async def _store(client):
+    r = await client.post('/api/stores', json={'name': 'Attach Create Store'})
+    assert r.status_code == 200
+    return r.json()['id']
+
+
+async def test_defer_start_leaves_task_pending(admin_client):
+    """defer_start=true creates the task but does NOT launch it, so the
+    client can upload attachments before the agent reads its prompt."""
+    store_id = await _store(admin_client)
+    r = await admin_client.post(
+        '/api/tasks',
+        json={
+            'title': 'deferred',
+            'store_id': store_id,
+            'plan_mode': False,
+            'defer_start': True,
+        },
+    )
+    assert r.status_code == 200
+    tid = r.json()['id']
+    try:
+        got = (await admin_client.get(f'/api/tasks/{tid}')).json()
+        # Not launched: still PENDING (schedule_or_run was skipped).
+        assert got['status'] == 'pending'
+    finally:
+        shutil.rmtree(_TASKS_DIR / tid, ignore_errors=True)
+
+
+async def test_attachment_lands_in_agent_workspace(admin_client):
+    """Create-time upload is written into tasks/<id>/uploads/ (the agent's
+    cwd), not an invisible blob dir."""
+    store_id = await _store(admin_client)
+    r = await admin_client.post(
+        '/api/tasks',
+        json={'title': 'with image', 'store_id': store_id, 'defer_start': True},
+    )
+    tid = r.json()['id']
+    task_dir = _TASKS_DIR / tid
+    try:
+        up = await admin_client.post(
+            f'/api/attachments/{tid}',
+            files={'file': ('样图 1.png', b'\x89PNG\r\n\x1a\nx', 'image/png')},
+        )
+        assert up.status_code == 200
+        uploads = task_dir / 'uploads'
+        saved = [p for p in uploads.iterdir() if p.is_file()]
+        assert len(saved) == 1
+        assert saved[0].suffix == '.png'
+        assert saved[0].read_bytes().startswith(b'\x89PNG')
+    finally:
+        shutil.rmtree(task_dir, ignore_errors=True)


### PR DESCRIPTION
**Reported:** uploading an image in the **New Task** dialog did nothing useful — the agent started with a text-only prompt and asked "where is the image?". (The follow-up-message upload works, because that flow lands the file in the workspace and references it.)

## Root cause
- Create-time attachments were written to `data/attachments/` — a **DB blob dir the agent can't see** — and the path was **never injected into the prompt**.
- The agent **auto-starts on create**, before the (post-create) upload lands.

## Fix (mirrors the working chat flow)
1. **Attachments → workspace.** `upload_attachment` now writes into `tasks/<id>/uploads/` (the agent's cwd), not the invisible blob dir.
2. **Surface to the agent.** `build_system_context` lists any `tasks/<id>/uploads/` files ("read them … do NOT ask the user again") — kept **out of the visible description**. Guarded: added only when uploads exist, so upload-less prompts (and their snapshots) are unchanged.
3. **Timing.** `create` accepts `defer_start`: with attachments the frontend creates the task PENDING, **closes the modal immediately**, uploads in the background, then `POST /start` — so files are present before the agent reads its prompt (this also takes the upload off the modal's critical path).

## Tests
- `uploaded_files_note` (lists files / empty when none)
- create `defer_start` leaves the task PENDING (not launched)
- create-time upload lands in `tasks/<id>/uploads/`
- `submitCreateTask` sends `defer_start`, uploads, then starts (and does neither without files)
- Full frontend suite (394) + prompt-assembly/contracts backend suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg5csnfP39iFPAEqcEnqwK