### PR TITLE
fix(vision): revise a generated image by referencing the prior result (any change, incl. added photos)

### DIFF
--- a/app/mcp_tool_schemas.py
+++ b/app/mcp_tool_schemas.py
@@ -572,7 +572,21 @@ TOOLS = [
             'in Settings → AI → Vision. On success it returns the saved '
             'workspace `path`; view the file to self-audit against the '
             'references and the requested text, and regenerate with a '
-            'corrected prompt if anything differs.'
+            'corrected prompt if anything differs. (5) REVISING an image you '
+            'already generated — for ANY follow-up change the user asks '
+            '(lighter/darker, bigger/smaller, recolour, remove or add an '
+            'element, change composition, etc.): call this tool again and '
+            'ALWAYS include the PREVIOUS generated image (its workspace '
+            '`path`, e.g. generated_images/…) as a reference_image, with a '
+            'prompt describing ONLY the change — so the model EDITS that '
+            'result and preserves what the user already liked, instead of '
+            'regenerating from scratch and drifting. If the user also '
+            'supplies NEW photo(s) for the change (e.g. "this image is good, '
+            'add the dog from this photo into the middle"), pass BOTH the '
+            'previous generated image AND the new photo(s) as '
+            "reference_images, and state each image's role by position in "
+            'the prompt (e.g. "image 1 is the current design to keep; image '
+            '2 is the dog — place it in the center").'
         ),
         'inputSchema': {
             'type': 'object',

--- a/app/skills_v2/amazon-image-studio/SKILL.md
+++ b/app/skills_v2/amazon-image-studio/SKILL.md
@@ -68,5 +68,18 @@ prompt and proofread the result character by character.
   compare against the ORIGINAL supplier photo item by item (shape,
   colour, texture, proportions; infographic wording). Regenerate with a
   prompt naming the specific fix if anything differs.
+- **Revising on user feedback** — for ANY change the user asks after
+  seeing a generated image (lighter/darker, bigger/smaller, recolour,
+  remove or add an element, change composition, …): call
+  `vibe_seller_generate_image` again and ALWAYS pass the PREVIOUSLY
+  GENERATED image (its `generated_images/…` path) as a `reference_image`,
+  with a prompt describing ONLY the requested change. This EDITS the
+  prior result — keeping what the user was happy with — instead of
+  regenerating from the supplier photo and drifting. If the user also
+  drops a NEW photo for the change (e.g. "this one's good, add my dog in
+  the middle"), pass BOTH the previous generated image AND the new photo
+  as `reference_images` and name each image's role by position in the
+  prompt ("image 1 is the current design to keep; image 2 is the dog to
+  add in the center").
 - Putting the images ON a listing is the `amazon-listing` flow (Manage
   Images / flat file) — this skill only produces the files.


### PR DESCRIPTION
**Problem:** After an image is generated, when the user asks for a change ("background too dark, make it lighter", "make the product bigger", "add my dog from this photo into the middle"), the agent regenerated **from the original supplier photo** — drifting on everything the user was already happy with. Neither the `generate_image` tool contract nor the amazon-image-studio skill said anything about how to revise.

**Fix (general guidance, both surfaces):** for **any** follow-up change to a generated image, call `generate_image` again and **always include the previously-generated image** (its `generated_images/…` path) as a `reference_image`, describing only the change — so the model **edits the prior result** instead of regenerating. If the user also drops a **new** photo for the change, pass **both** the previous generated image and the new photo as references and state each image's role by position in the prompt.

## Verified live (e2e on a real image generation)
Generated a real image, then sent "背景太暗了，帮我把背景调亮一点，产品保持不变":
- 1st call `reference_images = [uploads/<product>.png]`
- revision call (agent re-generated on its own, no "which image?" question):
  `reference_images = [generated_images/<generated>.png, uploads/<product>.png]`

i.e. it referenced the **previously-generated image first** (to edit it) plus the original for product fidelity — exactly the intended behavior.

Description-only change to the tool schema + skill (no code paths altered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg5csnfP39iFPAEqcEnqwK