### PR TITLE
fix(vision): recover the image-confirm card on reconnect (don't strand a task)

### DIFF
--- a/app/routers/vision.py
+++ b/app/routers/vision.py
@@ -139,19 +139,20 @@ async def generate_task_image(
         )
 
     request_id = uuid.uuid4().hex
-    fut = vision.create_confirm(request_id, task_id)
+    card = {
+        'prompt': prompt,
+        'model': model,
+        'models': list(vision.MODELS.keys()),
+        'reference_images': reference_images,
+        'output_name': output_name,
+        'kind': kind,
+    }
+    # Keep the card payload so a client that opens the task AFTER this
+    # event fires can recover the confirm via GET …/image/pending.
+    fut = vision.create_confirm(request_id, task_id, card)
     await event_bus.emit(
         'image_request',
-        {
-            'task_id': task_id,
-            'request_id': request_id,
-            'prompt': prompt,
-            'model': model,
-            'models': list(vision.MODELS.keys()),
-            'reference_images': reference_images,
-            'output_name': output_name,
-            'kind': kind,
-        },
+        {'task_id': task_id, 'request_id': request_id, **card},
     )
 
     # NO timeout — mirror AskUserQuestion: the tool call simply waits
@@ -291,6 +292,24 @@ async def confirm_task_image(
             detail='No pending image request (expired or already handled)',
         )
     return {'ok': True}
+
+
+@router.get('/tasks/{task_id}/image/pending')
+async def get_pending_image_request(
+    task_id: str,
+    current_user: User = Depends(get_current_user),
+):
+    """Recover the pending image-confirm card for a task.
+
+    The confirm gate emits ``image_request`` once over SSE, then the tool
+    blocks on a future until the user confirms. A client that opens the
+    task AFTER that event (reload, other tab, headless start) never saw
+    the card and the task would appear stuck. The frontend calls this on
+    load to re-render the card (mirrors ``/questions/pending``)."""
+    req = vision.get_pending_request(task_id)
+    if not req:
+        return {'pending': False}
+    return {'pending': True, **req}
 
 
 # ─────────────────── upload a reference image ─────────────────

--- a/app/vision.py
+++ b/app/vision.py
@@ -99,19 +99,42 @@ def is_fake() -> bool:
 
 _pending_confirms: dict[str, asyncio.Future] = {}
 _pending_by_task: dict[str, str] = {}  # task_id -> request_id
+# request_id -> card payload (prompt/model/models/reference_images/…), so
+# the confirm card can be re-served when a client opens the task AFTER the
+# image_request SSE already fired (the tool blocks on the future until the
+# user confirms; without this the card is unrecoverable on reconnect).
+_pending_payload: dict[str, dict] = {}
 
 
-def create_confirm(request_id: str, task_id: str) -> asyncio.Future:
+def create_confirm(
+    request_id: str, task_id: str, payload: dict | None = None
+) -> asyncio.Future:
     """Register a pending confirmation and return its future.
 
-    Returns the request_id of a superseded prior request via
-    ``supersede_pending`` — call that first (it needs the event loop
-    running) if you want to notify the frontend.
+    ``payload`` is the card data (prompt/model/models/reference_images/
+    output_name/kind) kept so ``get_pending_request`` can re-serve the
+    card on reconnect. Returns the request_id of a superseded prior
+    request via ``supersede_pending`` — call that first (it needs the
+    event loop running) if you want to notify the frontend.
     """
     fut: asyncio.Future = asyncio.get_event_loop().create_future()
     _pending_confirms[request_id] = fut
     _pending_by_task[task_id] = request_id
+    _pending_payload[request_id] = payload or {}
     return fut
+
+
+def get_pending_request(task_id: str) -> dict | None:
+    """The still-pending confirm card for ``task_id`` (payload + id), or
+    None. Lets a client that connected after the ``image_request`` event
+    recover the card instead of the task blocking forever."""
+    req_id = _pending_by_task.get(task_id)
+    if not req_id:
+        return None
+    fut = _pending_confirms.get(req_id)
+    if fut is None or fut.done():
+        return None
+    return {'request_id': req_id, **_pending_payload.get(req_id, {})}
 
 
 def supersede_pending(task_id: str) -> str | None:
@@ -140,6 +163,7 @@ def resolve_confirm(request_id: str, payload: dict) -> bool:
 
 def discard_confirm(request_id: str, task_id: str | None = None) -> None:
     _pending_confirms.pop(request_id, None)
+    _pending_payload.pop(request_id, None)
     if task_id and _pending_by_task.get(task_id) == request_id:
         _pending_by_task.pop(task_id, None)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -288,6 +288,7 @@ Note: SSE endpoint was renamed from `/api/events` to `/api/sse` to free up `/api
 | PUT | `/api/vision/config` | Set the kie.ai key (admin only) |
 | POST | `/api/tasks/{id}/image/generate` | MCP-tool entry; confirm-gated generation |
 | POST | `/api/tasks/{id}/image/confirm` | Resolve a pending image request (confirm/edit/cancel) |
+| GET | `/api/tasks/{id}/image/pending` | Recover a still-pending confirm card (for clients that connect after `image_request` fired) |
 
 See [vision.md](vision.md) for the confirm-gate flow and SSE events
 (`image_request`, `image_generated`).

--- a/frontend/src/__tests__/loadTaskById.test.ts
+++ b/frontend/src/__tests__/loadTaskById.test.ts
@@ -100,6 +100,35 @@ describe('loadTaskById stale-response guard', () => {
     expect(fns.setSteps).toHaveBeenCalledWith([])
   })
 
+  it('recovers a pending image-confirm card on load', async () => {
+    const get = (url: string): Promise<unknown> => {
+      if (url.endsWith('/image/pending')) return Promise.resolve({
+        pending: true, request_id: 'r9', prompt: 'white bg',
+        model: 'nano-banana-pro', models: ['nano-banana-pro'],
+        reference_images: ['uploads/a.png'], kind: 'main',
+      })
+      if (/\/api\/tasks\/[^/]+$/.test(url)) return Promise.resolve({ id: 'T', todos: null })
+      if (url.endsWith('/questions/pending')) return Promise.resolve({ pending: false })
+      return Promise.resolve([])  // messages, steps
+    }
+    const { deps, fns } = makeDeps(get)
+    await loadTaskById('T', deps)
+    // The final conversation set includes the re-rendered confirm card.
+    const items = fns.setConversationItems.mock.calls.at(-1)![0] as { type: string; imageRequest?: { requestId: string; resolved?: boolean; referenceImages?: string[] } }[]
+    const card = items.find(i => i.type === 'image_request')
+    expect(card).toBeTruthy()
+    expect(card!.imageRequest!.requestId).toBe('r9')
+    expect(card!.imageRequest!.resolved).toBe(false)
+    expect(card!.imageRequest!.referenceImages).toEqual(['uploads/a.png'])
+  })
+
+  it('does not add a card when no image is pending', async () => {
+    const { deps, fns } = makeDeps(router(id => Promise.resolve({ id, todos: null })))
+    await loadTaskById('none', deps)
+    const items = fns.setConversationItems.mock.calls.at(-1)![0] as { type: string }[]
+    expect(items.some(i => i.type === 'image_request')).toBe(false)
+  })
+
   it('clears the previous task detail up front so the switch is instant', async () => {
     const { deps, fns } = makeDeps(router(id => Promise.resolve({ id, todos: null })))
     await loadTaskById('X', deps)

--- a/frontend/src/handlers/loadTaskById.ts
+++ b/frontend/src/handlers/loadTaskById.ts
@@ -64,16 +64,42 @@ export async function loadTaskById(taskId: string, deps: LoadTaskDeps): Promise<
   // Fetch the detail pieces CONCURRENTLY rather than in series — on a
   // slow link four sequential round-trips (question + messages + steps)
   // stack up into a visible delay; in parallel it is a single round-trip.
-  const [q, msgs, stepsData] = await Promise.all([
+  type PendingImage = {
+    pending?: boolean; request_id: string; prompt?: string; model?: string
+    models?: string[]; reference_images?: string[]; output_name?: string; kind?: string
+  }
+  const [q, msgs, stepsData, pendingImg] = await Promise.all([
     api.get(`/api/tasks/${fullTask.id}/questions/pending`).catch(() => null) as Promise<({ pending?: boolean } & PendingQuestions) | null>,
     api.get(`/api/tasks/${taskId}/messages`).catch(() => []) as Promise<{ role: string; content: string }[]>,
     api.get(`/api/tasks/${taskId}/steps`).catch(() => []) as Promise<TaskStep[]>,
+    api.get(`/api/tasks/${taskId}/image/pending`).catch(() => null) as Promise<PendingImage | null>,
   ])
   if (!fresh()) return
 
   deps.setPendingQuestions(q?.pending ? { request_id: q.request_id, questions: q.questions } : null)
   deps.setAgentMessages(msgs.map(m => ({ role: m.role, content: m.content })))
-  deps.setConversationItems(buildConversationItems(msgs, fullTask))
+  const convItems = buildConversationItems(msgs, fullTask)
+  // Re-render a still-pending image-confirm card (the SSE image_request
+  // fired before this client connected — recover it so the task isn't
+  // stuck waiting on a confirm the UI never showed).
+  if (pendingImg?.pending) {
+    convItems.push({
+      id: `imgreq-${pendingImg.request_id}`,
+      type: 'image_request',
+      timestamp: new Date().toISOString(),
+      imageRequest: {
+        requestId: pendingImg.request_id,
+        prompt: pendingImg.prompt || '',
+        model: pendingImg.model || 'nano-banana-pro',
+        models: pendingImg.models || [],
+        referenceImages: pendingImg.reference_images || [],
+        outputName: pendingImg.output_name,
+        kind: pendingImg.kind,
+        resolved: false,
+      },
+    })
+  }
+  deps.setConversationItems(convItems)
   deps.setSteps(stepsData)
 
   for (const s of stepsData) {

--- a/tests/workflow/test_wf_vision_image.py
+++ b/tests/workflow/test_wf_vision_image.py
@@ -141,6 +141,58 @@ async def test_confirm_flow_saves_and_emits(admin_client, monkeypatch):
         shutil.rmtree(task_dir, ignore_errors=True)
 
 
+async def test_no_pending_image_request(admin_client):
+    r = await admin_client.get(f'/api/tasks/{uuid.uuid4()}/image/pending')
+    assert r.status_code == 200
+    assert r.json() == {'pending': False}
+
+
+async def test_pending_image_request_recoverable(admin_client, monkeypatch):
+    """A client that opens the task AFTER image_request fired can recover
+    the confirm card via GET …/image/pending, then confirm it."""
+    monkeypatch.setenv('VISION_FAKE', '1')
+    tid = str(uuid.uuid4())
+    task_dir = _TASKS_DIR / tid
+    queue = event_bus.subscribe()
+    try:
+        gen = asyncio.create_task(
+            admin_client.post(
+                f'/api/tasks/{tid}/image/generate',
+                json={
+                    'prompt': '主图：纯白背景',
+                    'model': 'nano-banana-pro',
+                    'reference_images': ['uploads/ref.png'],
+                    'output_name': 'main.png',
+                    'kind': 'main',
+                },
+            )
+        )
+        req = await _drain_until(queue, 'image_request')
+        rid = req['request_id']
+
+        # Recover the card (no SSE replay — this is the reconnect path).
+        p = (await admin_client.get(f'/api/tasks/{tid}/image/pending')).json()
+        assert p['pending'] is True
+        assert p['request_id'] == rid
+        assert p['prompt'] == '主图：纯白背景'
+        assert p['reference_images'] == ['uploads/ref.png']
+        assert p['kind'] == 'main'
+        assert 'nano-banana-pro' in p['models']
+
+        # Confirming it clears the pending state.
+        c = await admin_client.post(
+            f'/api/tasks/{tid}/image/confirm',
+            json={'request_id': rid, 'action': 'confirm'},
+        )
+        assert c.json()['ok'] is True
+        await asyncio.wait_for(gen, timeout=10)
+        p2 = (await admin_client.get(f'/api/tasks/{tid}/image/pending')).json()
+        assert p2 == {'pending': False}
+    finally:
+        event_bus.unsubscribe(queue)
+        shutil.rmtree(task_dir, ignore_errors=True)
+
+
 async def test_upload_reference_saves_file(admin_client):
     tid = str(uuid.uuid4())
     task_dir = _TASKS_DIR / tid


### PR DESCRIPTION
(Reopens #107, which got orphaned by a rebase — same change.)

**Problem:** the image confirm-gate emits `image_request` over SSE **once**, then the tool blocks on a future until the user confirms. A client that opens the task **after** that event (reload, another tab, a headless start) never saw the card — so the task looks **stuck forever** with no way to confirm. (AskUserQuestion doesn't have this problem because the frontend recovers it via `/questions/pending`.) Surfaced during the #106 e2e.

**Fix — mirror the AskUserQuestion recovery path:**
- The vision registry now keeps the **card payload** (prompt/model/models/reference_images/output_name/kind), cleared on confirm/supersede/discard; new `get_pending_request(task_id)`.
- New **`GET /api/tasks/{id}/image/pending`** returns the still-pending card (or `{pending:false}`).
- `loadTaskById` fetches it alongside `questions/pending` and **re-renders the confirm card** on load.

## Tests
- Backend: recover the pending card (matches request_id/prompt/refs/kind), then confirm clears it; no pending → `{pending:false}`.
- Frontend: `loadTaskById` re-adds the `image_request` card when pending, adds nothing when not.
- Full frontend suite (396) + vision workflow (10) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg5csnfP39iFPAEqcEnqwK