### PR TITLE
feat(vision): multi-provider image-model catalog with per-image price hints

### DIFF
--- a/app/mcp_tool_schemas.py
+++ b/app/mcp_tool_schemas.py
@@ -643,7 +643,8 @@ TOOLS = [
                         'safest for on-image TEXT (infographics, banners) '
                         'and highest quality; cheaper lanes exist for '
                         'plain images. Options and rough per-image cost: '
-                        + _IMAGE_MODEL_GUIDE + '.'
+                        + _IMAGE_MODEL_GUIDE
+                        + '.'
                     ),
                 },
                 'output_name': {

--- a/app/mcp_tool_schemas.py
+++ b/app/mcp_tool_schemas.py
@@ -572,7 +572,14 @@ TOOLS = [
             'in Settings → AI → Vision. On success it returns the saved '
             'workspace `path`; view the file to self-audit against the '
             'references and the requested text, and regenerate with a '
-            'corrected prompt if anything differs.'
+            'corrected prompt if anything differs. (5) To REVISE an image '
+            'you already generated after the user asks for a change (e.g. '
+            '"lighter background", "make the product bigger", "remove the '
+            'shadow"), call this tool again and pass the PREVIOUS generated '
+            'image (its workspace `path`, e.g. generated_images/…) as a '
+            'reference_image, with a prompt describing ONLY the change — so '
+            'the model EDITS the prior result and preserves everything else, '
+            'instead of regenerating from scratch and drifting.'
         ),
         'inputSchema': {
             'type': 'object',

--- a/app/mcp_tool_schemas.py
+++ b/app/mcp_tool_schemas.py
@@ -5,6 +5,18 @@ Split out of ``app/mcp_server.py`` to keep each module under the
 the matching dispatch branches in ``handle_tool_call``.
 """
 
+from app import vision
+
+# Agent-facing image-model enum + one-line-per-model guidance, both
+# derived from the single source of truth in ``app/vision.py`` so the
+# tool schema never drifts from the catalog the confirm card offers.
+_IMAGE_MODEL_IDS = vision.model_ids()
+_IMAGE_MODEL_GUIDE = '; '.join(
+    f'{m["id"]} ({m["provider"]}, ~${m["usd"]:.2f}/image'
+    + (', default)' if m['default'] else ')')
+    for m in vision.catalog_public()
+)
+
 TOOLS = [
     {
         'name': 'vibe_seller_list_stores',
@@ -572,14 +584,21 @@ TOOLS = [
             'in Settings → AI → Vision. On success it returns the saved '
             'workspace `path`; view the file to self-audit against the '
             'references and the requested text, and regenerate with a '
-            'corrected prompt if anything differs. (5) To REVISE an image '
-            'you already generated after the user asks for a change (e.g. '
-            '"lighter background", "make the product bigger", "remove the '
-            'shadow"), call this tool again and pass the PREVIOUS generated '
-            'image (its workspace `path`, e.g. generated_images/…) as a '
-            'reference_image, with a prompt describing ONLY the change — so '
-            'the model EDITS the prior result and preserves everything else, '
-            'instead of regenerating from scratch and drifting.'
+            'corrected prompt if anything differs. (5) REVISING an image you '
+            'already generated — for ANY follow-up change the user asks '
+            '(lighter/darker, bigger/smaller, recolour, remove or add an '
+            'element, change composition, etc.): call this tool again and '
+            'ALWAYS include the PREVIOUS generated image (its workspace '
+            '`path`, e.g. generated_images/…) as a reference_image, with a '
+            'prompt describing ONLY the change — so the model EDITS that '
+            'result and preserves what the user already liked, instead of '
+            'regenerating from scratch and drifting. If the user also '
+            'supplies NEW photo(s) for the change (e.g. "this image is good, '
+            'add the dog from this photo into the middle"), pass BOTH the '
+            'previous generated image AND the new photo(s) as '
+            "reference_images, and state each image's role by position in "
+            'the prompt (e.g. "image 1 is the current design to keep; image '
+            '2 is the dog — place it in the center").'
         ),
         'inputSchema': {
             'type': 'object',
@@ -616,12 +635,15 @@ TOOLS = [
                 },
                 'model': {
                     'type': 'string',
-                    'enum': ['nano-banana-pro', 'nano-banana-2'],
+                    'enum': _IMAGE_MODEL_IDS,
                     'description': (
-                        'nano-banana-pro (default): highest quality and '
-                        'reliable on-image text rendering. '
-                        'nano-banana-2: cheaper/faster, good for images '
-                        'without text.'
+                        'Image model to use. The user can override this on '
+                        'the confirm card, so pick a sensible default and '
+                        'let them adjust. nano-banana-pro (default) is the '
+                        'safest for on-image TEXT (infographics, banners) '
+                        'and highest quality; cheaper lanes exist for '
+                        'plain images. Options and rough per-image cost: '
+                        + _IMAGE_MODEL_GUIDE + '.'
                     ),
                 },
                 'output_name': {

--- a/app/routers/vision.py
+++ b/app/routers/vision.py
@@ -67,7 +67,7 @@ async def get_vision_config(current_user: User = Depends(get_current_user)):
     return {
         'kie_api_key_set': bool(key),
         'kie_api_key_masked': vision.mask_key(key),
-        'models': list(vision.MODELS.keys()),
+        'models': vision.catalog_public(),
         'default_model': vision.DEFAULT_MODEL,
         # Surfaced so e2e tests can refuse to run against a server that
         # would hit the real image API (they must be offline-only).
@@ -122,7 +122,7 @@ async def generate_task_image(
     if not prompt:
         raise HTTPException(status_code=400, detail='prompt is required')
     model = body.get('model') or vision.DEFAULT_MODEL
-    if model not in vision.MODELS:
+    if model not in vision.model_ids():
         model = vision.DEFAULT_MODEL
     reference_images = body.get('reference_images') or []
     output_name = _safe_name(body.get('output_name') or 'image.png')
@@ -147,7 +147,7 @@ async def generate_task_image(
             'request_id': request_id,
             'prompt': prompt,
             'model': model,
-            'models': list(vision.MODELS.keys()),
+            'models': vision.catalog_public(),
             'reference_images': reference_images,
             'output_name': output_name,
             'kind': kind,
@@ -178,7 +178,7 @@ async def generate_task_image(
     # User-edited values win over the agent's proposal.
     final_prompt = (decision.get('prompt') or prompt).strip()
     final_model = decision.get('model') or model
-    if final_model not in vision.MODELS:
+    if final_model not in vision.model_ids():
         final_model = model
     # References the user added in the confirm card (uploaded files →
     # workspace-relative paths, or pasted URLs) are appended.

--- a/app/skills_v2/amazon-image-studio/SKILL.md
+++ b/app/skills_v2/amazon-image-studio/SKILL.md
@@ -68,12 +68,18 @@ prompt and proofread the result character by character.
   compare against the ORIGINAL supplier photo item by item (shape,
   colour, texture, proportions; infographic wording). Regenerate with a
   prompt naming the specific fix if anything differs.
-- **Revising on user feedback** (e.g. "background too dark, make it
-  lighter", "product too small", "remove the shadow"): call
-  `vibe_seller_generate_image` again and pass the PREVIOUSLY GENERATED
-  image (its `generated_images/…` path) as a `reference_image`, with a
-  prompt describing ONLY the requested change. This EDITS the prior
-  result — keeping the product and everything else the user was happy
-  with — instead of regenerating from the supplier photo and drifting.
+- **Revising on user feedback** — for ANY change the user asks after
+  seeing a generated image (lighter/darker, bigger/smaller, recolour,
+  remove or add an element, change composition, …): call
+  `vibe_seller_generate_image` again and ALWAYS pass the PREVIOUSLY
+  GENERATED image (its `generated_images/…` path) as a `reference_image`,
+  with a prompt describing ONLY the requested change. This EDITS the
+  prior result — keeping what the user was happy with — instead of
+  regenerating from the supplier photo and drifting. If the user also
+  drops a NEW photo for the change (e.g. "this one's good, add my dog in
+  the middle"), pass BOTH the previous generated image AND the new photo
+  as `reference_images` and name each image's role by position in the
+  prompt ("image 1 is the current design to keep; image 2 is the dog to
+  add in the center").
 - Putting the images ON a listing is the `amazon-listing` flow (Manage
   Images / flat file) — this skill only produces the files.

--- a/app/skills_v2/amazon-image-studio/SKILL.md
+++ b/app/skills_v2/amazon-image-studio/SKILL.md
@@ -68,5 +68,12 @@ prompt and proofread the result character by character.
   compare against the ORIGINAL supplier photo item by item (shape,
   colour, texture, proportions; infographic wording). Regenerate with a
   prompt naming the specific fix if anything differs.
+- **Revising on user feedback** (e.g. "background too dark, make it
+  lighter", "product too small", "remove the shadow"): call
+  `vibe_seller_generate_image` again and pass the PREVIOUSLY GENERATED
+  image (its `generated_images/…` path) as a `reference_image`, with a
+  prompt describing ONLY the requested change. This EDITS the prior
+  result — keeping the product and everything else the user was happy
+  with — instead of regenerating from the supplier photo and drifting.
 - Putting the images ON a listing is the `amazon-listing` flow (Manage
   Images / flat file) — this skill only produces the files.

--- a/app/vision.py
+++ b/app/vision.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import dataclasses
 import json
 import os
 from pathlib import Path
@@ -35,14 +36,149 @@ VISION_CONFIG_PATH = VIBE_SELLER_DIR / 'vision.json'
 _KIE_BASE = 'https://api.kie.ai'
 _KIE_UPLOAD_BASE = 'https://kieai.redpandaai.co'
 
-# Models we expose in the confirm dropdown. Keys are the values the
-# frontend/agent pass; values are the exact kie.ai model identifiers.
-# Kept small on purpose — a quality lane and a fast/cheap lane.
-MODELS: dict[str, str] = {
-    'nano-banana-pro': 'nano-banana-pro',
-    'nano-banana-2': 'nano-banana-2',
-}
-DEFAULT_MODEL = 'nano-banana-pro'
+# kie.ai bills in credits at a flat $0.005/credit ($50 = 10,000 credits).
+# We surface a per-image price *hint* on the confirm card, not a bill —
+# actual cost varies by resolution/tier, so these are the representative
+# (typically 2K / standard) image-to-image prices from kie.ai's public
+# pricing API (POST api.kie.ai/client/v1/model-pricing/page), captured
+# 2026-07. Refresh manually if kie.ai revises them.
+CREDIT_USD = 0.005
+# Fixed USD→CNY for the ¥ hint shown to Chinese users. Illustrative, not
+# a live FX rate — the price itself is already approximate.
+USD_CNY = 7.2
+
+
+@dataclasses.dataclass(frozen=True)
+class ImageModel:
+    """One selectable image model, served through kie.ai's unified
+    ``jobs/createTask`` API.
+
+    ``id`` is OUR stable contract (what the agent/frontend/tool pass and
+    what we validate); ``slug`` is kie.ai's exact ``model`` string, which
+    we own the mapping to so kie's naming (slashes, ``-image-to-image``
+    variants) never leaks into our API. ``ref_field`` / ``ref_array``
+    capture the one thing that genuinely differs per model: the name and
+    cardinality of the reference-image input — ``image_input`` (nano),
+    ``input_urls`` (gpt/flux), ``image_urls`` (seedream), or a single
+    ``image_url`` (qwen/ideogram). ``extra`` is static per-model input
+    that the model's schema documents (aspect ratio, resolution, etc.).
+    """
+
+    id: str
+    slug: str
+    provider: str
+    label: str
+    ref_field: str
+    ref_array: bool
+    usd: float
+    extra: dict = dataclasses.field(default_factory=dict)
+
+
+# Curated shortlist across the major providers — all image-to-image
+# capable, all on the one configured kie.ai key. Slugs + reference field
+# names + prices verified against kie.ai docs/pricing (2026-07). The
+# FIRST entry is the default. Not exhaustive: kie.ai lists ~78 image
+# models; this is the quality-vs-cost spread most sellers want.
+IMAGE_MODELS: list[ImageModel] = [
+    ImageModel(
+        id='nano-banana-pro',
+        slug='nano-banana-pro',
+        provider='Google',
+        label='Nano Banana Pro',
+        ref_field='image_input',
+        ref_array=True,
+        usd=0.09,
+        extra={'aspect_ratio': '1:1', 'resolution': '2K',
+               'output_format': 'png'},
+    ),
+    ImageModel(
+        id='nano-banana-2',
+        slug='nano-banana-2',
+        provider='Google',
+        label='Nano Banana 2',
+        ref_field='image_input',
+        ref_array=True,
+        usd=0.04,
+        extra={'aspect_ratio': '1:1'},
+    ),
+    ImageModel(
+        id='gpt-image-2',
+        slug='gpt-image-2-image-to-image',
+        provider='OpenAI',
+        label='GPT Image 2',
+        ref_field='input_urls',
+        ref_array=True,
+        usd=0.05,
+        extra={'aspect_ratio': '1:1'},
+    ),
+    ImageModel(
+        id='seedream-5-pro',
+        slug='seedream/5-pro-image-to-image',
+        provider='ByteDance',
+        label='Seedream 5 Pro',
+        ref_field='image_urls',
+        ref_array=True,
+        usd=0.07,
+    ),
+    ImageModel(
+        id='flux-2-pro',
+        slug='flux-2/pro-image-to-image',
+        provider='Black Forest Labs',
+        label='Flux-2 Pro',
+        ref_field='input_urls',
+        ref_array=True,
+        usd=0.035,
+    ),
+    ImageModel(
+        id='qwen-image-edit',
+        slug='qwen/image-edit',
+        provider='Qwen',
+        label='Qwen Image Edit',
+        ref_field='image_url',
+        ref_array=False,
+        usd=0.03,
+    ),
+    ImageModel(
+        id='ideogram-v3-remix',
+        slug='ideogram/v3-remix',
+        provider='Ideogram',
+        label='Ideogram V3 Remix',
+        ref_field='image_url',
+        ref_array=False,
+        usd=0.035,
+        extra={'rendering_speed': 'BALANCED'},
+    ),
+]
+
+_MODELS_BY_ID: dict[str, ImageModel] = {m.id: m for m in IMAGE_MODELS}
+DEFAULT_MODEL = IMAGE_MODELS[0].id
+
+
+def model_ids() -> list[str]:
+    """Valid model ids, in display order (default first)."""
+    return [m.id for m in IMAGE_MODELS]
+
+
+def get_model(model_id: str | None) -> ImageModel:
+    """Resolve a model id to its ``ImageModel`` (falls back to default)."""
+    return _MODELS_BY_ID.get(model_id or '', _MODELS_BY_ID[DEFAULT_MODEL])
+
+
+def catalog_public() -> list[dict]:
+    """The catalog as the frontend/agent see it: id, provider, label, and
+    a per-image price hint in both USD and (fixed-rate) CNY. Never the
+    kie.ai slug — that stays server-side."""
+    return [
+        {
+            'id': m.id,
+            'provider': m.provider,
+            'label': m.label,
+            'usd': round(m.usd, 4),
+            'cny': round(m.usd * USD_CNY, 2),
+            'default': m.id == DEFAULT_MODEL,
+        }
+        for m in IMAGE_MODELS
+    ]
 
 
 # ─────────────────────────── config ───────────────────────────
@@ -189,12 +325,17 @@ async def generate_image(
     model: str,
     reference_images: list[str],
     task_dir: Path,
-    aspect_ratio: str = '1:1',
-    resolution: str = '2K',
 ) -> bytes:
     """Generate one image via kie.ai and return the PNG bytes.
 
     Raises RuntimeError on any kie.ai failure. Honours ``VISION_FAKE``.
+
+    The ``input`` payload is assembled per-model: every model here goes
+    through the same ``jobs/createTask`` endpoint, but the reference-image
+    field name and cardinality differ (see ``ImageModel``), and each model
+    carries its own static ``extra`` params. Getting this right is what
+    makes a non-nano model actually receive its references instead of
+    silently dropping them.
     """
     if is_fake():
         return _fake_png(prompt, model)
@@ -202,28 +343,28 @@ async def generate_image(
     api_key = get_kie_api_key()
     if not api_key:
         raise RuntimeError('kie.ai API key not configured')
-    kie_model = MODELS.get(model, MODELS[DEFAULT_MODEL])
+    m = get_model(model)
 
     async with httpx.AsyncClient(timeout=120) as client:
-        image_input: list[str] = []
+        resolved: list[str] = []
         for ref in reference_images or []:
             url = await _resolve_reference(client, ref, task_dir, api_key)
             if url:
-                image_input.append(url)
+                resolved.append(url)
+
+        image_input: dict = {'prompt': prompt}
+        if m.ref_array:
+            image_input[m.ref_field] = resolved
+        elif resolved:
+            # Single-reference models (qwen/image-edit, ideogram remix)
+            # take exactly one image; use the primary reference.
+            image_input[m.ref_field] = resolved[0]
+        image_input.update(m.extra)
 
         create = await client.post(
             f'{_KIE_BASE}/api/v1/jobs/createTask',
             headers={'Authorization': f'Bearer {api_key}'},
-            json={
-                'model': kie_model,
-                'input': {
-                    'prompt': prompt,
-                    'image_input': image_input,
-                    'aspect_ratio': aspect_ratio,
-                    'resolution': resolution,
-                    'output_format': 'png',
-                },
-            },
+            json={'model': m.slug, 'input': image_input},
         )
         cbody = create.json()
         task_id = (cbody.get('data') or {}).get('taskId')

--- a/app/vision.py
+++ b/app/vision.py
@@ -88,8 +88,11 @@ IMAGE_MODELS: list[ImageModel] = [
         ref_field='image_input',
         ref_array=True,
         usd=0.09,
-        extra={'aspect_ratio': '1:1', 'resolution': '2K',
-               'output_format': 'png'},
+        extra={
+            'aspect_ratio': '1:1',
+            'resolution': '2K',
+            'output_format': 'png',
+        },
     ),
     ImageModel(
         id='nano-banana-2',

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -2,10 +2,34 @@
 
 General-purpose image generation for tasks: product photos, marketplace
 listing images, infographics, banners, or an image the user just wants,
-via kie.ai (Nano Banana Pro / Nano Banana 2). The agent proposes; the
-**user confirms and can edit** the prompt/model before anything is
-generated; the result renders inline in the task stream and is saved in
-the task workspace.
+via kie.ai's unified API. The agent proposes; the **user confirms and can
+edit** the prompt/model before anything is generated; the result renders
+inline in the task stream and is saved in the task workspace.
+
+## Model catalog (one key, many providers)
+
+kie.ai is a unified aggregator — a **single** configured key reaches every
+image model through the same `POST /api/v1/jobs/createTask` endpoint. The
+selectable set is a curated, static catalog in `app/vision.py`
+(`IMAGE_MODELS`), one `ImageModel` per row: our stable `id` (the contract
+the agent/frontend/tool pass and we validate) → kie.ai's exact `slug`,
+plus the `provider`/`label` for the two-level Provider→Model picker and a
+representative per-image `usd` price. The confirm card and Settings show
+the price as **$** (English) or **¥** (Chinese, fixed `USD_CNY` rate — an
+illustrative hint, not a bill). Default is **Nano Banana Pro**.
+
+The one thing that genuinely differs per model is the **reference-image
+input**: field name and cardinality (`image_input`/`input_urls`/
+`image_urls` arrays, or a single `image_url`). `generate_image()` builds
+the `input` payload from each model's `ref_field`/`ref_array`, so a
+non-nano model actually receives its references instead of silently
+dropping them — this is the load-bearing part, pinned by
+`test_generate_image_builds_per_model_input`. Prices/slugs were captured
+from kie.ai's public pricing API + docs (2026-07); refresh manually.
+
+Current curated models: Google Nano Banana Pro (default) / Nano Banana 2,
+OpenAI GPT Image 2, ByteDance Seedream 5 Pro, Black Forest Flux-2 Pro,
+Qwen Image Edit, Ideogram V3 Remix.
 
 **Layering**: the MCP tool is platform-agnostic infrastructure. Platform
 knowledge lives in skills — `amazon-image-studio` (Amazon image

--- a/frontend/src/__tests__/imageGenerating.test.tsx
+++ b/frontend/src/__tests__/imageGenerating.test.tsx
@@ -10,7 +10,11 @@ import { ImageRequestCard } from '../components/conversation/ImageRequestCard'
 
 const base = {
   taskId: 't1', requestId: 'r1', prompt: 'white bg', model: 'nano-banana-pro',
-  models: ['nano-banana-pro'], referenceImages: [] as string[],
+  models: [{
+    id: 'nano-banana-pro', provider: 'Google', label: 'Nano Banana Pro',
+    usd: 0.09, cny: 0.65, default: true,
+  }],
+  referenceImages: [] as string[],
   onDecision: vi.fn(),
 }
 
@@ -34,5 +38,32 @@ describe('ImageRequestCard generating state', () => {
     render(<ImageRequestCard {...base} resolved={false} />)
     expect(screen.getByTestId('image-confirm-btn')).toBeInTheDocument()
     expect(screen.queryByTestId('image-card-generating')).toBeNull()
+  })
+})
+
+describe('ImageRequestCard model selector', () => {
+  const multi = {
+    ...base,
+    models: [
+      { id: 'nano-banana-pro', provider: 'Google', label: 'Nano Banana Pro', usd: 0.09, cny: 0.65, default: true },
+      { id: 'nano-banana-2', provider: 'Google', label: 'Nano Banana 2', usd: 0.04, cny: 0.29 },
+      { id: 'gpt-image-2', provider: 'OpenAI', label: 'GPT Image 2', usd: 0.05, cny: 0.36 },
+    ],
+  }
+
+  it('offers a Provider level and a Model level, with a price hint', () => {
+    render(<ImageRequestCard {...multi} resolved={false} />)
+    const providerSel = screen.getByTestId('image-provider-select') as HTMLSelectElement
+    const modelSel = screen.getByTestId('image-model-select') as HTMLSelectElement
+    // Two providers, de-duplicated.
+    const provOpts = Array.from(providerSel.querySelectorAll('option')).map(o => o.textContent)
+    expect(provOpts).toEqual(['Google', 'OpenAI'])
+    // Default provider (Google) → only its two models are listed.
+    const modelOpts = Array.from(modelSel.querySelectorAll('option'))
+    expect(modelOpts.map(o => o.value)).toEqual(['nano-banana-pro', 'nano-banana-2'])
+    // USD hint on the option label by default (test i18n has no zh).
+    expect(modelOpts[0].textContent).toContain('$0.09')
+    // The standalone hint row is present for the selected model.
+    expect(screen.getByTestId('image-price-hint')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/conversation/ImageRequestCard.tsx
+++ b/frontend/src/components/conversation/ImageRequestCard.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import type { ImageModelOption } from '../../types'
 
 interface AddedRef { path: string; url: string }
 
@@ -8,7 +9,7 @@ interface ImageRequestCardProps {
   requestId: string
   prompt: string
   model: string
-  models: string[]
+  models: ImageModelOption[]
   referenceImages: string[]
   kind?: string
   resolved?: boolean
@@ -49,7 +50,7 @@ export function ImageRequestCard({
   generating,
   onDecision,
 }: ImageRequestCardProps) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const [editedPrompt, setEditedPrompt] = useState(prompt)
   const [editedModel, setEditedModel] = useState(model)
   const [added, setAdded] = useState<AddedRef[]>([])
@@ -87,7 +88,32 @@ export function ImageRequestCard({
     }
   }
 
-  const modelOptions = models.length ? models : [model]
+  // Two-level select: provider (level 1) → model (level 2). Fall back to
+  // a synthetic single option if the catalog didn't reach us.
+  const catalog: ImageModelOption[] = models.length
+    ? models
+    : [{ id: model, provider: '', label: model, usd: 0, cny: 0 }]
+  const selected =
+    catalog.find(m => m.id === editedModel) ?? catalog[0]
+  const providers = [...new Set(catalog.map(m => m.provider))]
+  const modelsForProvider = catalog.filter(
+    m => m.provider === selected.provider,
+  )
+
+  // ¥ for Chinese, $ for English — a per-image hint, not a bill. The ≈
+  // keeps it honest: real cost varies by resolution/tier. Form:
+  // "≈$0.09/image" / "≈¥0.65/张".
+  const zh = (i18n?.language || '').startsWith('zh')
+  const unit = t('vision.perImageUnit')
+  const priceHint = (m: ImageModelOption): string => {
+    if (!m.usd && !m.cny) return ''
+    return zh ? `≈¥${m.cny}/${unit}` : `≈$${m.usd}/${unit}`
+  }
+  const onProviderChange = (provider: string) => {
+    const first = catalog.find(m => m.provider === provider)
+    if (first) setEditedModel(first.id)
+  }
+
   const thumbClass =
     'h-28 w-28 object-contain rounded border border-gray-200 bg-white'
 
@@ -119,22 +145,51 @@ export function ImageRequestCard({
             className="w-full min-h-[160px] px-3 py-2 text-sm leading-relaxed border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent resize-y disabled:bg-gray-50 disabled:text-gray-400"
           />
         </div>
-        <div className="space-y-1">
-          <label className="text-sm font-medium text-gray-700">
-            {t('vision.modelLabel')}
-          </label>
-          <select
-            data-testid="image-model-select"
-            value={editedModel}
-            onChange={e => setEditedModel(e.target.value)}
-            disabled={resolved || busy}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white disabled:bg-gray-50 disabled:text-gray-400"
-          >
-            {modelOptions.map(m => (
-              <option key={m} value={m}>{m}</option>
-            ))}
-          </select>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">
+              {t('vision.providerLabel')}
+            </label>
+            <select
+              data-testid="image-provider-select"
+              value={selected.provider}
+              onChange={e => onProviderChange(e.target.value)}
+              disabled={resolved || busy || providers.length <= 1}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white disabled:bg-gray-50 disabled:text-gray-400"
+            >
+              {providers.map(p => (
+                <option key={p} value={p}>{p || '—'}</option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium text-gray-700">
+              {t('vision.modelLabel')}
+            </label>
+            <select
+              data-testid="image-model-select"
+              value={editedModel}
+              onChange={e => setEditedModel(e.target.value)}
+              disabled={resolved || busy}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white disabled:bg-gray-50 disabled:text-gray-400"
+            >
+              {modelsForProvider.map(m => (
+                <option key={m.id} value={m.id}>
+                  {m.label}
+                  {priceHint(m) && ` · ${priceHint(m)}`}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
+        {priceHint(selected) && (
+          <p
+            data-testid="image-price-hint"
+            className="-mt-2 text-xs text-gray-500 tabular-nums"
+          >
+            {priceHint(selected)}
+          </p>
+        )}
 
         <div className="space-y-2">
           <label className="text-sm font-medium text-gray-700">

--- a/frontend/src/components/settings/VisionPanel.tsx
+++ b/frontend/src/components/settings/VisionPanel.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api } from '../../api'
+import type { ImageModelOption } from '../../types'
 
 interface VisionConfig {
   kie_api_key_set: boolean
   kie_api_key_masked: string
-  models?: string[]
+  models?: ImageModelOption[]
   default_model?: string
 }
 
@@ -16,7 +17,7 @@ interface VisionPanelProps {
 /** Settings → AI → Vision. Configure the kie.ai image-generation key.
  *  Self-contained (own fetch/save), mirroring the other settings panels. */
 export function VisionPanel({ isAdmin }: VisionPanelProps) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const [config, setConfig] = useState<VisionConfig | null>(null)
   const [keyInput, setKeyInput] = useState('')
   const [saving, setSaving] = useState(false)
@@ -90,6 +91,42 @@ export function VisionPanel({ isAdmin }: VisionPanelProps) {
         <p data-testid="vision-saved" className="text-xs text-green-600 mt-2">
           {t('settings.visionSaved')}
         </p>
+      )}
+
+      {config?.models && config.models.length > 0 && (
+        <div data-testid="vision-models" className="mt-4 border-t border-gray-100 pt-3">
+          <p className="text-xs font-medium text-gray-600 mb-2">
+            {t('settings.visionModels')}
+          </p>
+          <ul className="space-y-1">
+            {config.models.map(m => {
+              const unit = t('settings.visionPerImage')
+              const price = i18n.language.startsWith('zh')
+                ? `≈¥${m.cny}/${unit}`
+                : `≈$${m.usd}/${unit}`
+              return (
+                <li
+                  key={m.id}
+                  className="flex items-center justify-between text-xs text-gray-600"
+                >
+                  <span className="truncate">
+                    <span className="text-gray-400">{m.provider}</span>
+                    {' · '}
+                    {m.label}
+                    {m.default && (
+                      <span className="ml-1.5 px-1 py-0.5 bg-indigo-100 text-indigo-700 rounded text-[10px] font-medium">
+                        {t('settings.visionDefaultModel')}
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-gray-500 tabular-nums ml-2 shrink-0">
+                    {price}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -500,7 +500,10 @@
     "visionKeyMissing": "Not configured",
     "visionKeyPlaceholder": "kie.ai API key",
     "visionAdminOnly": "Only an admin can set the Vision API key.",
-    "visionSaved": "Saved."
+    "visionSaved": "Saved.",
+    "visionModels": "Available image models",
+    "visionDefaultModel": "default",
+    "visionPerImage": "image"
   },
   "integrations": {
     "gws": {
@@ -811,6 +814,8 @@
     "confirmTitle": "Review image generation",
     "promptLabel": "Prompt (edit before generating)",
     "modelLabel": "Model",
+    "providerLabel": "Provider",
+    "perImageUnit": "image",
     "referencesLabel": "Reference images",
     "confirmGenerate": "Generate",
     "cancel": "Cancel",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -502,7 +502,10 @@
     "visionKeyMissing": "未配置",
     "visionKeyPlaceholder": "kie.ai API 密钥",
     "visionAdminOnly": "仅管理员可设置视觉 API 密钥。",
-    "visionSaved": "已保存。"
+    "visionSaved": "已保存。",
+    "visionModels": "可用图片模型",
+    "visionDefaultModel": "默认",
+    "visionPerImage": "张"
   },
   "integrations": {
     "gws": {
@@ -813,6 +816,8 @@
     "confirmTitle": "确认图片生成",
     "promptLabel": "提示词（生成前可编辑）",
     "modelLabel": "模型",
+    "providerLabel": "厂商",
+    "perImageUnit": "张",
     "referencesLabel": "参考图",
     "confirmGenerate": "生成",
     "cancel": "取消",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -129,6 +129,18 @@ export interface EventActivity {
   action: string; content: string; extra_data: string | null; created_at: string;
 }
 
+// One selectable image model, as served by GET /api/vision/config and
+// the image_request SSE event. Price is a per-image hint in both USD
+// and (fixed-rate) CNY; the UI shows one based on the active language.
+export interface ImageModelOption {
+  id: string
+  provider: string
+  label: string
+  usd: number
+  cny: number
+  default?: boolean
+}
+
 // ─── Conversation stream types ───────────────────────
 export type ConversationItemType =
   | 'plan' | 'user_message' | 'agent_message'
@@ -156,7 +168,7 @@ export interface ConversationItem {
     requestId: string
     prompt: string
     model: string
-    models: string[]
+    models: ImageModelOption[]
     referenceImages: string[]
     outputName?: string
     kind?: string

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -56,7 +56,10 @@ def test_models_registry():
         assert m.slug and m.slug not in slugs
         slugs.add(m.slug)
         assert m.ref_field in (
-            'image_input', 'input_urls', 'image_urls', 'image_url'
+            'image_input',
+            'input_urls',
+            'image_urls',
+            'image_url',
         )
         assert m.usd > 0
     assert vision.get_model('does-not-exist').id == vision.DEFAULT_MODEL
@@ -104,10 +107,12 @@ class _FakeKieClient:
 
     async def get(self, url, params=None, headers=None):
         if 'recordInfo' in url:
-            return _FakeResp({'data': {
-                'state': 'success',
-                'resultJson': '{"resultUrls": ["http://img/out.png"]}',
-            }})
+            return _FakeResp({
+                'data': {
+                    'state': 'success',
+                    'resultJson': '{"resultUrls": ["http://img/out.png"]}',
+                }
+            })
         return _FakeResp(content=b'PNG')  # image download
 
 
@@ -129,8 +134,10 @@ async def test_generate_image_builds_per_model_input(monkeypatch, tmp_path):
 
     # Single-reference model → plain string, primary ref only.
     await vision.generate_image(
-        prompt='p', model='qwen-image-edit',
-        reference_images=refs, task_dir=tmp_path,
+        prompt='p',
+        model='qwen-image-edit',
+        reference_images=refs,
+        task_dir=tmp_path,
     )
     body = _FakeKieClient.last_body
     assert body['model'] == 'qwen/image-edit'
@@ -138,8 +145,10 @@ async def test_generate_image_builds_per_model_input(monkeypatch, tmp_path):
 
     # Array-reference model → full list under the model's own field name.
     await vision.generate_image(
-        prompt='p', model='gpt-image-2',
-        reference_images=refs, task_dir=tmp_path,
+        prompt='p',
+        model='gpt-image-2',
+        reference_images=refs,
+        task_dir=tmp_path,
     )
     body = _FakeKieClient.last_body
     assert body['model'] == 'gpt-image-2-image-to-image'

--- a/tests/unit/test_vision.py
+++ b/tests/unit/test_vision.py
@@ -42,9 +42,108 @@ def test_is_fake(monkeypatch):
 
 
 def test_models_registry():
-    assert vision.DEFAULT_MODEL in vision.MODELS
-    assert 'nano-banana-pro' in vision.MODELS
-    assert 'nano-banana-2' in vision.MODELS
+    ids = vision.model_ids()
+    # Default is first and resolvable.
+    assert vision.DEFAULT_MODEL == 'nano-banana-pro'
+    assert ids[0] == vision.DEFAULT_MODEL
+    assert 'nano-banana-pro' in ids
+    assert 'nano-banana-2' in ids
+    # Every model resolves to a distinct kie.ai slug and a valid
+    # reference-image field, and an unknown id falls back to default.
+    slugs = set()
+    for mid in ids:
+        m = vision.get_model(mid)
+        assert m.slug and m.slug not in slugs
+        slugs.add(m.slug)
+        assert m.ref_field in (
+            'image_input', 'input_urls', 'image_urls', 'image_url'
+        )
+        assert m.usd > 0
+    assert vision.get_model('does-not-exist').id == vision.DEFAULT_MODEL
+
+
+def test_catalog_public_shape():
+    cat = vision.catalog_public()
+    assert len(cat) == len(vision.model_ids())
+    first = cat[0]
+    assert set(first) == {'id', 'provider', 'label', 'usd', 'cny', 'default'}
+    assert first['default'] is True
+    # CNY is the fixed-rate conversion of USD.
+    assert first['cny'] == round(first['usd'] * vision.USD_CNY, 2)
+    # Exactly one default.
+    assert sum(1 for m in cat if m['default']) == 1
+
+
+class _FakeResp:
+    def __init__(self, payload=None, content=b'PNG'):
+        self._p = payload
+        self.content = content
+
+    def json(self):
+        return self._p
+
+
+class _FakeKieClient:
+    """Records the createTask body and returns a successful poll +
+    a stub image download, so ``generate_image`` runs end-to-end offline."""
+
+    last_body: dict = {}
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, url, headers=None, json=None):
+        _FakeKieClient.last_body = json
+        return _FakeResp({'data': {'taskId': 'x'}})
+
+    async def get(self, url, params=None, headers=None):
+        if 'recordInfo' in url:
+            return _FakeResp({'data': {
+                'state': 'success',
+                'resultJson': '{"resultUrls": ["http://img/out.png"]}',
+            }})
+        return _FakeResp(content=b'PNG')  # image download
+
+
+async def test_generate_image_builds_per_model_input(monkeypatch, tmp_path):
+    """The reference field name/cardinality must follow the model spec —
+    an array field for nano/gpt/seedream/flux, a single string for qwen/
+    ideogram — so a non-nano model actually receives its references
+    instead of silently dropping them."""
+    monkeypatch.setattr(vision.httpx, 'AsyncClient', _FakeKieClient)
+    monkeypatch.setattr(vision, 'get_kie_api_key', lambda: 'k')
+
+    async def _no_sleep(*a, **k):
+        return None
+
+    monkeypatch.setattr(vision.asyncio, 'sleep', _no_sleep)
+    monkeypatch.setenv('VISION_FAKE', '0')
+
+    refs = ['http://a/1.png', 'http://a/2.png']
+
+    # Single-reference model → plain string, primary ref only.
+    await vision.generate_image(
+        prompt='p', model='qwen-image-edit',
+        reference_images=refs, task_dir=tmp_path,
+    )
+    body = _FakeKieClient.last_body
+    assert body['model'] == 'qwen/image-edit'
+    assert body['input']['image_url'] == 'http://a/1.png'
+
+    # Array-reference model → full list under the model's own field name.
+    await vision.generate_image(
+        prompt='p', model='gpt-image-2',
+        reference_images=refs, task_dir=tmp_path,
+    )
+    body = _FakeKieClient.last_body
+    assert body['model'] == 'gpt-image-2-image-to-image'
+    assert body['input']['input_urls'] == refs
 
 
 async def test_confirm_registry_resolve():

--- a/tests/workflow/test_wf_vision_image.py
+++ b/tests/workflow/test_wf_vision_image.py
@@ -56,7 +56,9 @@ async def test_config_put_get_masked(admin_client, tmp_path, monkeypatch):
     ids = [m['id'] for m in body['models']]
     assert 'nano-banana-pro' in ids
     assert body['default_model'] == 'nano-banana-pro'
-    assert all({'provider', 'label', 'usd', 'cny'} <= set(m) for m in body['models'])
+    assert all(
+        {'provider', 'label', 'usd', 'cny'} <= set(m) for m in body['models']
+    )
 
 
 async def test_generate_fails_without_key(admin_client, monkeypatch):

--- a/tests/workflow/test_wf_vision_image.py
+++ b/tests/workflow/test_wf_vision_image.py
@@ -52,7 +52,11 @@ async def test_config_put_get_masked(admin_client, tmp_path, monkeypatch):
     assert body['kie_api_key_set'] is True
     assert body['kie_api_key_masked'].endswith('9876')
     assert 'secret' not in body['kie_api_key_masked']  # body never leaks
-    assert 'nano-banana-pro' in body['models']
+    # models is the rich catalog (id + provider + label + price hints).
+    ids = [m['id'] for m in body['models']]
+    assert 'nano-banana-pro' in ids
+    assert body['default_model'] == 'nano-banana-pro'
+    assert all({'provider', 'label', 'usd', 'cny'} <= set(m) for m in body['models'])
 
 
 async def test_generate_fails_without_key(admin_client, monkeypatch):


### PR DESCRIPTION
## What

Lets the user pick the image model at generation time from a curated **multi-provider catalog**, with a **per-image price hint** — instead of the previous fixed two-model dropdown. All models run through kie.ai's one unified `jobs/createTask` API on the **single key already configured** (kie.ai is an aggregator), so no new credentials.

**Curated set (all image-to-image):** Google Nano Banana Pro (default) / Nano Banana 2 · OpenAI GPT Image 2 · ByteDance Seedream 5 Pro · Black Forest Flux-2 Pro · Qwen Image Edit · Ideogram V3 Remix.

## Design

- **`app/vision.py`** — `ImageModel` dataclass is the single source of truth: our stable `id` → kie.ai `slug`, the per-model reference-image field, and a representative per-image USD price. `catalog_public()` adds a fixed-rate CNY. The MCP tool enum + agent guidance are generated from it, so they can't drift.
- **Load-bearing fix:** `generate_image()` builds the createTask `input` from each model's `ref_field`/`ref_array`. The reference-image field differs per model (`image_input` / `input_urls` / `image_urls` / single `image_url`) and the img2img variant is a distinct slug for some — so without this a non-nano model would silently drop its references.
- **UI:** confirm card gets a two-level **Provider → Model** select + price hint; **$** for English, **≈¥** for Chinese (fixed rate). Approximate by design — real cost varies by resolution/tier. Settings → AI → Vision lists the full catalog with prices.

Prices/slugs were captured from kie.ai's public pricing API + docs (2026-07); the catalog is static and refreshed manually (per product decision).

## Note on scope

This also folds in a **small pre-existing uncommitted revision-guidance polish** (`SKILL.md` + the MCP tool description) that was entangled in `mcp_tool_schemas.py`: when the user drops a *new* photo during a revision, pass both the previous generated image and the new photo, naming each image's role by position. Clean, vision-related, no customer data.

## Testing

- Backend **62 pass** — catalog integrity + per-model input assembly (`test_vision.py`), rich `/vision/config` shape (`test_wf_vision_image.py`), tool visibility, prompt assembly.
- Frontend **395 pass** — incl. a new two-level-selector + currency-hint test.
- `tsc` / `ruff` / `eslint` clean.
- Verified live end-to-end with `VISION_FAKE=1`: card renders in EN/ZH, provider switch updates model + price, and the generated image is tagged with the selected model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9p1mvGVPimwVG3WcQ7P26