### PR TITLE
fix(mcp): internal loopback API calls bypass the proxy (trust_env=False)

### DIFF
--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -75,7 +75,16 @@ async def call_api(
     cookies: dict[str, str] = {}
     if _config['auth_token']:
         cookies['auth_token'] = _config['auth_token']
-    async with httpx.AsyncClient(timeout=timeout) as client:
+    # ``trust_env=False`` is load-bearing: this client ONLY ever talks to
+    # the local backend over loopback (``api_base`` is 127.0.0.1:<port>).
+    # httpx honours ``HTTP_PROXY``/``ALL_PROXY`` by default, and a machine
+    # running a proxy (e.g. clash) typically exports those with an EMPTY
+    # ``NO_PROXY`` — so without this, every internal call is routed through
+    # the proxy. When the proxy is down or can't serve loopback, the call
+    # dies with "All connection attempts failed" even though the backend
+    # is up (agents then misread it and fall back to local tools). Internal
+    # traffic must never depend on the user's proxy.
+    async with httpx.AsyncClient(timeout=timeout, trust_env=False) as client:
         if method == 'GET':
             resp = await client.get(url, headers=headers, cookies=cookies)
         elif method == 'POST':


### PR DESCRIPTION
## Problem

The vibe-seller MCP server calls its **own** backend over loopback (`http://127.0.0.1:<port>`) with `httpx`, which defaults to `trust_env=True` and so honours `HTTP_PROXY`/`ALL_PROXY`. On a machine running a proxy (e.g. clash) with an **empty `NO_PROXY`**, even the loopback call is routed through the proxy. When the proxy is down/unreachable, the call fails with `"All connection attempts failed"` although the backend is up.

Seen live: `vibe_seller_generate_image` returned `{"error":"All connection attempts failed"}` → the image confirm card never popped (the emit is inside the endpoint, which was never reached) → the agent misread it as "vision key not configured" and fell back to a local `rembg` script, bypassing the confirm gate.

## Fix

Create the loopback client with `trust_env=False`. It only ever talks to the local backend, so proxy/env must never apply — the call now works whether the proxy is up, down, or misconfigured. External callers (kie.ai, PyPI, supplier CDNs) are untouched and still use the proxy. One line + comment; the "internal calls go direct" contract is enforced in code, not left to the environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9p1mvGVPimwVG3WcQ7P26