### PR TITLE
feat(vision): left→right cascading model picker (二级菜单), most-expensive-first

### DIFF
--- a/app/vision.py
+++ b/app/vision.py
@@ -155,9 +155,13 @@ _FAMILIES: list = [
         'input_urls',
         True,
         {'aspect_ratio': '1:1'},
+        # Only the cheapest tier: GPT Image 1.5 · Medium ($0.02) is the
+        # cheapest OpenAI option. Its "high" tier ($0.11) is dropped — it
+        # costs MORE than the newer GPT Image 2 · 4K ($0.08) while being
+        # lower quality (GPT Image 2 leads 1.5 on text, resolution, prompt
+        # following, and editing), so it's a strictly dominated option.
         [
             _Tier('medium', 'Medium', 0.02, {'quality': 'medium'}),
-            _Tier('high', 'High', 0.11, {'quality': 'high'}),
         ],
     ),
     _Family(

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -38,7 +38,9 @@ kie.ai's pricing API + docs (2026-07); refresh manually.
 
 Providers/models (image-to-image, tiers in parens): Google — Nano Banana
 Pro (2K/4K), Nano Banana 2 (1K/2K/4K), Nano Banana Edit; OpenAI — GPT
-Image 2 (1K/2K/4K), GPT Image 1.5 (Medium/High); ByteDance — Seedream 5
+Image 2 (1K/2K/4K), GPT Image 1.5 (Medium — cheapest OpenAI; its High
+tier is omitted as it costs more than the newer, better GPT Image 2·4K);
+ByteDance — Seedream 5
 Pro (Basic/High), Seedream 4.5; Black Forest — Flux-2 Pro (1K/2K), Flux 2
 Flex (1K/2K); Qwen — Image Edit; Ideogram — V3 Remix (Turbo/Balanced/
 Quality). Pure utilities (Recraft bg-removal, Topaz upscale) are

--- a/frontend/src/__tests__/imageGenerating.test.tsx
+++ b/frontend/src/__tests__/imageGenerating.test.tsx
@@ -5,7 +5,7 @@
  * the user knows work is in progress.
  */
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import { ImageRequestCard } from '../components/conversation/ImageRequestCard'
 
 const base = {
@@ -44,30 +44,50 @@ describe('ImageRequestCard generating state', () => {
 describe('ImageRequestCard model selector', () => {
   const multi = {
     ...base,
+    model: 'nano-banana-pro',
+    // Deliberately NOT in price order, to prove the submenu re-sorts.
     models: [
-      { id: 'nano-banana-pro', provider: 'Google', label: 'Nano Banana Pro', usd: 0.09, cny: 0.65, default: true },
-      { id: 'nano-banana-2', provider: 'Google', label: 'Nano Banana 2', usd: 0.04, cny: 0.29 },
-      { id: 'gpt-image-2', provider: 'OpenAI', label: 'GPT Image 2', usd: 0.05, cny: 0.36 },
+      { id: 'nano-banana-2', provider: 'Google', label: 'Nano Banana 2 · 1K', usd: 0.04, cny: 0.29 },
+      { id: 'nano-banana-pro', provider: 'Google', label: 'Nano Banana Pro · 2K', usd: 0.09, cny: 0.65, default: true },
+      { id: 'gpt-image-2', provider: 'OpenAI', label: 'GPT Image 2 · 2K', usd: 0.05, cny: 0.36 },
     ],
   }
 
-  it('is a single dropdown grouped by provider (optgroup), with price hints', () => {
+  it('is a left→right cascade: providers → models, most expensive first', () => {
     render(<ImageRequestCard {...multi} resolved={false} />)
-    // One select, no separate provider dropdown.
-    const modelSel = screen.getByTestId('image-model-select') as HTMLSelectElement
+    // Custom popover, not a native <select>/second provider dropdown.
     expect(screen.queryByTestId('image-provider-select')).toBeNull()
-    // The two-level menu = one <optgroup> per provider, de-duplicated.
-    const groups = Array.from(modelSel.querySelectorAll('optgroup'))
-    expect(groups.map(g => g.label)).toEqual(['Google', 'OpenAI'])
-    // All three models present, grouped under their provider.
-    const allOpts = Array.from(modelSel.querySelectorAll('option'))
-    expect(allOpts.map(o => o.value)).toEqual([
-      'nano-banana-pro', 'nano-banana-2', 'gpt-image-2',
-    ])
-    expect(groups[1].querySelectorAll('option')).toHaveLength(1) // OpenAI
-    // USD hint on the option label by default (test i18n has no zh).
-    expect(allOpts[0].textContent).toContain('$0.09')
-    // The standalone hint row is present for the selected model.
-    expect(screen.getByTestId('image-price-hint')).toBeInTheDocument()
+    const trigger = screen.getByTestId('image-model-select')
+    expect(trigger.textContent).toContain('Nano Banana Pro')
+
+    // Open the cascade.
+    fireEvent.click(trigger)
+    const menu = screen.getByTestId('image-model-menu')
+    // Level 1 — providers, de-duplicated.
+    expect(within(menu).getByTestId('image-provider-Google')).toBeInTheDocument()
+    expect(within(menu).getByTestId('image-provider-OpenAI')).toBeInTheDocument()
+
+    // Level 2 — active provider is the selected model's (Google); its
+    // models are sorted most-expensive-first regardless of input order.
+    const googleIds = within(screen.getByTestId('image-model-submenu'))
+      .getAllByRole('button')
+      .map(b => b.getAttribute('data-model-id'))
+    expect(googleIds).toEqual(['nano-banana-pro', 'nano-banana-2'])
+
+    // Hovering another provider swaps the right column.
+    fireEvent.mouseEnter(within(menu).getByTestId('image-provider-OpenAI'))
+    const openaiIds = within(screen.getByTestId('image-model-submenu'))
+      .getAllByRole('button')
+      .map(b => b.getAttribute('data-model-id'))
+    expect(openaiIds).toEqual(['gpt-image-2'])
+
+    // Picking a model closes the menu and updates the trigger.
+    fireEvent.click(
+      within(screen.getByTestId('image-model-submenu')).getAllByRole('button')[0],
+    )
+    expect(screen.queryByTestId('image-model-menu')).toBeNull()
+    expect(screen.getByTestId('image-model-select').textContent).toContain(
+      'GPT Image 2',
+    )
   })
 })

--- a/frontend/src/components/conversation/ImageRequestCard.tsx
+++ b/frontend/src/components/conversation/ImageRequestCard.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { ImageModelOption } from '../../types'
+import { ModelCascadeSelect } from './ModelCascadeSelect'
 
 interface AddedRef { path: string; url: string }
 
@@ -50,7 +51,7 @@ export function ImageRequestCard({
   generating,
   onDecision,
 }: ImageRequestCardProps) {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
   const [editedPrompt, setEditedPrompt] = useState(prompt)
   const [editedModel, setEditedModel] = useState(model)
   const [added, setAdded] = useState<AddedRef[]>([])
@@ -88,25 +89,12 @@ export function ImageRequestCard({
     }
   }
 
-  // One dropdown, grouped by provider (<optgroup> = the two-level menu).
-  // Fall back to a synthetic single option if the catalog didn't reach us.
+  // The selectable catalog (provider grouping, price formatting, and the
+  // two-level cascade live in <ModelCascadeSelect/>). Fall back to a
+  // synthetic single option if the catalog didn't reach us.
   const catalog: ImageModelOption[] = models.length
     ? models
     : [{ id: model, provider: '', label: model, usd: 0, cny: 0 }]
-  const selected =
-    catalog.find(m => m.id === editedModel) ?? catalog[0]
-  const providers = [...new Set(catalog.map(m => m.provider))]
-
-  // ¥ for Chinese, $ for English — a per-image hint, not a bill. The ≈
-  // keeps it honest: real cost varies by resolution/tier. Form:
-  // "≈$0.09/image" / "≈¥0.65/张".
-  const zh = (i18n?.language || '').startsWith('zh')
-  const unit = t('vision.perImageUnit')
-  const priceHint = (m: ImageModelOption): string => {
-    if (!m.usd && !m.cny) return ''
-    // Space after ≈ so it reads "≈ ¥0.65/张" / "≈ $0.09/image".
-    return zh ? `≈ ¥${m.cny}/${unit}` : `≈ $${m.usd}/${unit}`
-  }
 
   const thumbClass =
     'h-28 w-28 object-contain rounded border border-gray-200 bg-white'
@@ -143,43 +131,13 @@ export function ImageRequestCard({
           <label className="text-sm font-medium text-gray-700">
             {t('vision.modelLabel')}
           </label>
-          <select
-            data-testid="image-model-select"
+          <ModelCascadeSelect
+            models={catalog}
             value={editedModel}
-            onChange={e => setEditedModel(e.target.value)}
             disabled={resolved || busy}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white disabled:bg-gray-50 disabled:text-gray-400"
-          >
-            {providers.map(p => (
-              <optgroup
-                key={p}
-                label={p || '—'}
-                style={{ color: '#374151', fontWeight: 600 }}
-              >
-                {catalog
-                  .filter(m => m.provider === p)
-                  .map(m => (
-                    <option
-                      key={m.id}
-                      value={m.id}
-                      style={{ color: '#111827', fontWeight: 400 }}
-                    >
-                      {m.label}
-                      {priceHint(m) && ` · ${priceHint(m)}`}
-                    </option>
-                  ))}
-              </optgroup>
-            ))}
-          </select>
+            onChange={setEditedModel}
+          />
         </div>
-        {priceHint(selected) && (
-          <p
-            data-testid="image-price-hint"
-            className="-mt-2 text-xs text-gray-500 tabular-nums"
-          >
-            {priceHint(selected)}
-          </p>
-        )}
 
         <div className="space-y-2">
           <label className="text-sm font-medium text-gray-700">

--- a/frontend/src/components/conversation/ModelCascadeSelect.tsx
+++ b/frontend/src/components/conversation/ModelCascadeSelect.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { ImageModelOption } from '../../types'
+
+interface ModelCascadeSelectProps {
+  models: ImageModelOption[]
+  value: string
+  disabled?: boolean
+  onChange: (id: string) => void
+}
+
+/** Two-level (left→right) cascading model picker: providers in the left
+ *  column, and the hovered/active provider's models in the right column.
+ *  Within each provider the models are sorted most-expensive-first.
+ *
+ *  A native <select> can't render a left→right submenu, so this is a
+ *  custom popover. The closed trigger shows the selected model + its
+ *  price; opening reveals the two columns. */
+export function ModelCascadeSelect({
+  models,
+  value,
+  disabled,
+  onChange,
+}: ModelCascadeSelectProps) {
+  const { t, i18n } = useTranslation()
+  const zh = (i18n?.language || '').startsWith('zh')
+  const unit = t('vision.perImageUnit')
+  const price = (m: ImageModelOption): string => {
+    if (!m.usd && !m.cny) return ''
+    return zh ? `≈ ¥${m.cny}/${unit}` : `≈ $${m.usd}/${unit}`
+  }
+
+  const list = models.length ? models : []
+  const selected = list.find(m => m.id === value) ?? list[0]
+  const providers = [...new Set(list.map(m => m.provider))]
+  // Most expensive first within each provider (sorted in the frontend).
+  const modelsFor = (p: string) =>
+    list.filter(m => m.provider === p).sort((a, b) => b.usd - a.usd)
+
+  const [open, setOpen] = useState(false)
+  const [activeProvider, setActiveProvider] = useState(
+    selected?.provider ?? providers[0],
+  )
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDoc)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const toggle = () => {
+    if (disabled) return
+    // Open focused on the selected model's provider column.
+    setActiveProvider(selected?.provider ?? providers[0])
+    setOpen(o => !o)
+  }
+  const pick = (id: string) => {
+    onChange(id)
+    setOpen(false)
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        data-testid="image-model-select"
+        disabled={disabled}
+        onClick={toggle}
+        aria-haspopup="true"
+        aria-expanded={open}
+        className="w-full flex items-center justify-between px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white text-left disabled:bg-gray-50 disabled:text-gray-400"
+      >
+        <span className="truncate text-gray-900">
+          {selected?.label}
+          {selected && price(selected) && (
+            <span className="text-gray-500"> · {price(selected)}</span>
+          )}
+        </span>
+        <span className="ml-2 shrink-0 text-gray-400">▾</span>
+      </button>
+
+      {open && (
+        <div
+          data-testid="image-model-menu"
+          className="absolute left-0 z-30 mt-1 flex max-h-72 rounded-lg border border-gray-200 bg-white shadow-lg overflow-hidden"
+        >
+          {/* Level 1 — providers */}
+          <ul className="w-40 shrink-0 overflow-y-auto border-r border-gray-100 py-1">
+            {providers.map(p => (
+              <li key={p}>
+                <button
+                  type="button"
+                  data-testid={`image-provider-${p}`}
+                  onMouseEnter={() => setActiveProvider(p)}
+                  onFocus={() => setActiveProvider(p)}
+                  onClick={() => setActiveProvider(p)}
+                  className={`w-full flex items-center justify-between px-3 py-1.5 text-sm text-left ${
+                    p === activeProvider
+                      ? 'bg-indigo-50 text-indigo-800 font-medium'
+                      : 'text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  <span className="truncate">{p || '—'}</span>
+                  <span className="ml-2 shrink-0 text-gray-300">›</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+          {/* Level 2 — models for the active provider, most expensive first */}
+          <ul
+            data-testid="image-model-submenu"
+            className="w-72 shrink-0 overflow-y-auto py-1"
+          >
+            {modelsFor(activeProvider).map(m => (
+              <li key={m.id}>
+                <button
+                  type="button"
+                  data-model-id={m.id}
+                  onClick={() => pick(m.id)}
+                  className={`w-full flex items-center justify-between gap-3 px-3 py-1.5 text-sm text-left ${
+                    m.id === value
+                      ? 'bg-indigo-100 text-indigo-900'
+                      : 'text-gray-800 hover:bg-gray-50'
+                  }`}
+                >
+                  <span className="truncate">{m.label}</span>
+                  {price(m) && (
+                    <span className="shrink-0 tabular-nums text-gray-500">
+                      {price(m)}
+                    </span>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/tests/e2e/test_vision_image_ui.py
+++ b/tests/e2e/test_vision_image_ui.py
@@ -134,13 +134,14 @@ def test_confirm_card_edit_and_inline_image(authenticated_page):
             '主图：白色棉袜，纯白背景', timeout=5000
         )
 
-        # User edits the prompt and switches the model+tier (the model
-        # dropdown is grouped by provider via <optgroup>; option values
-        # are model-tier ids like "nano-banana-2-2k").
+        # User edits the prompt and switches the model+tier. The model
+        # picker is a left→right cascade (custom popover, not a <select>):
+        # click the trigger, pick the provider column, then the model
+        # option (data-model-id is a model-tier id like "nano-banana-2-2k").
         prompt_box.fill('主图：白色棉袜，纯白背景，产品占85%')
-        page.locator('[data-testid="image-model-select"]').select_option(
-            'nano-banana-2-2k'
-        )
+        page.locator('[data-testid="image-model-select"]').click()
+        page.locator('[data-testid="image-provider-Google"]').click()
+        page.locator('[data-model-id="nano-banana-2-2k"]').click()
         page.locator('[data-testid="image-confirm-btn"]').click()
 
         # The generated image renders inline.


### PR DESCRIPTION
## What

Replaces the flat single-dropdown `<optgroup>` list with a proper **two-level left→right cascade** (二级菜单):

- **Left column**: providers (Google, OpenAI, ByteDance, …).
- **Right column**: the hovered/active provider's models+tiers.
- Hover or click a provider to reveal its models; click a model to select. Click-outside / `Esc` closes.

A native `<select>` can't render a left→right submenu, so this is a small custom popover (`ModelCascadeSelect`). The closed trigger shows the selected model + its price; opening reveals the two columns.

**Sorting:** within each provider submenu, models are sorted **most-expensive-first** (frontend sort by USD desc).

Also drops the standalone price-hint line — the trigger now carries the selected model's price.

## Preview

```
模型  [ Nano Banana Pro · 2K · ≈ ¥0.65/张  ▾ ]
      ┌────────────┬───────────────────────────────┐
      │ Google   › │ Nano Banana Pro · 4K · ≈¥0.86 │
      │ OpenAI   › │ Nano Banana Pro · 2K · ≈¥0.65 │
      │ ByteDance› │ Nano Banana 2 · 4K · ≈¥0.65   │
      │ …          │ …  (most expensive on top)    │
      └────────────┴───────────────────────────────┘
```

## Tests

Rewritten selector test: feeds models out of price order and asserts the submenu re-sorts descending, providers de-dup, hovering a provider swaps the right column, and picking a model closes the menu + updates the trigger. Full frontend suite green; `tsc`/`eslint`/pre-commit clean.

<img width="2925" height="1571" alt="image" src="https://github.com/user-attachments/assets/be081952-d768-4e1b-af30-e35fcdb5dbec" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9p1mvGVPimwVG3WcQ7P26