### PR TITLE
feat(tasks): consistent follow-up gating (interrupt confirm/question gates) + fresh retry

### DIFF
--- a/app/ai/claude_backend_manager.py
+++ b/app/ai/claude_backend_manager.py
@@ -9,6 +9,7 @@ from app.ai.profiles import DEFAULT_PROFILE_ID
 from app.ai.stop_gates import recorded_skills
 from app.database import async_session
 from app.env_options import Options
+from app.events.bus import event_bus
 from app.models.task import Task
 from app.workspace.manager import workspace_manager
 from app.workspace.skills_sync import skills_sync
@@ -251,6 +252,33 @@ class ClaudeCodeBackend(AIAgentBackend):
         for data in session._pending_questions.values():
             return data
         return None
+
+    async def interrupt_pending_question(self, task_id: str) -> str | None:
+        """Interrupt a pending AskUserQuestion when the user sends a chat
+        follow-up instead of answering the card. Unblocks the parked hook
+        with a note (NOT the user's message, and NOT recorded as the
+        answers) so the tool returns and the agent then reads the user's
+        message — delivered separately as its own turn. Emits
+        ``task_question_interrupted`` so the UI retires the card as "you
+        replied instead", not "answered". Returns the request_id or None.
+
+        This mirrors the image confirm-gate interrupt: a gate that is
+        merely waiting on the user must yield to a follow-up, never
+        swallow it as a formal answer."""
+        pending = self.get_pending_questions(task_id)
+        if not pending:
+            return None
+        request_id = pending.get('request_id')
+        note = (
+            '[用户没有直接回答上面的问题，而是发送了一条新消息。请阅读用户接下来'
+            '的消息并据此继续，不要把这段当作对上面问题的正式回答。]'
+        )
+        await self.submit_answer(task_id, request_id, {'_free_text': note})
+        await event_bus.emit(
+            'task_question_interrupted',
+            {'task_id': task_id, 'request_id': request_id},
+        )
+        return request_id
 
     async def stop(self, task_id: str) -> bool:
         session = self._sessions.get(task_id)

--- a/app/routers/tasks_conversation.py
+++ b/app/routers/tasks_conversation.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app import vision
 from app.ai.claude_backend_manager import agent_manager
 from app.ai.compaction import build_history_prompt, dump_history_file
 from app.ai.profiles import DEFAULT_PROFILE_ID
@@ -213,6 +214,15 @@ async def send_task_message(
             'profile_switched': is_profile_switch,
             'woken': True,
         }
+
+    # A follow-up sent while the agent is PARKED on the image confirm card
+    # (shown, not yet generating) must interrupt the gate so it reaches the
+    # agent now instead of buffering behind the blocked generate tool. Only
+    # fires during the interruptible wait — once generating, there is no
+    # pending confirm. (A pending AskUserQuestion is handled client-side:
+    # the composer routes the message through the free-text answer channel.)
+    if not is_profile_switch:
+        await vision.interrupt_pending_confirm(task_id)
 
     # Check if agent is running and handle profile switch or send message
     if agent_manager.is_running(task_id):

--- a/app/routers/tasks_conversation.py
+++ b/app/routers/tasks_conversation.py
@@ -48,7 +48,7 @@ from app.task_states import (
     TaskStatus,
     assert_transition,
 )
-from app.workspace.manager import workspace_manager
+from app.workspace.manager import reset_task_runtime_state, workspace_manager
 
 logger = logging.getLogger(__name__)
 
@@ -215,14 +215,14 @@ async def send_task_message(
             'woken': True,
         }
 
-    # A follow-up sent while the agent is PARKED on the image confirm card
-    # (shown, not yet generating) must interrupt the gate so it reaches the
-    # agent now instead of buffering behind the blocked generate tool. Only
-    # fires during the interruptible wait — once generating, there is no
-    # pending confirm. (A pending AskUserQuestion is handled client-side:
-    # the composer routes the message through the free-text answer channel.)
+    # A follow-up while the agent is PARKED awaiting the user — a
+    # shown-but-not-generating confirm card, or a pending AskUserQuestion
+    # — INTERRUPTS the gate so the message reaches the agent now instead
+    # of buffering behind the blocked tool (neither fires once real work
+    # resumes). The message is delivered below as the agent's next turn.
     if not is_profile_switch:
         await vision.interrupt_pending_confirm(task_id)
+        await agent_manager.interrupt_pending_question(task_id)
 
     # Check if agent is running and handle profile switch or send message
     if agent_manager.is_running(task_id):
@@ -678,6 +678,11 @@ async def retry_task(
     )
     await db.execute(delete(TaskLog).where(TaskLog.task_id == task_id))
 
+    # Retry = a truly fresh start: wipe on-disk runtime state (workspace +
+    # Claude Code's per-task Task/todo store + project transcripts) so a
+    # prior run's todos/refs can't leak into the new session. See helper.
+    reset_task_runtime_state(task_id)
+
     store = None
     if task.store_id:
         store = await db.get(Store, task.store_id)
@@ -694,15 +699,9 @@ async def retry_task(
     task.todos = None
     task.wait_condition = None
     task.session_id = None
-    # Clear run-scoped timestamps — without this, retrying a
-    # COMPLETED task (RETRIABLE includes COMPLETED) leaves the
-    # previous run's started_at + completed_at in the row during
-    # the window between dispatch and the new run's first state
-    # write, so the UI shows a misleading duration mid-retry.
-    # auto_run_task overwrites started_at unconditionally on the
-    # PENDING→RUNNING transition, but execute_planned_task's
-    # session-resume branch uses ``task.started_at or now()``
-    # which would preserve a stale value if we leave one here.
+    # Clear run-scoped timestamps so a retried COMPLETED task doesn't show
+    # the previous run's duration mid-retry (execute_planned_task's resume
+    # branch uses ``task.started_at or now()``, preserving a stale value).
     task.started_at = None
     task.completed_at = None
 

--- a/app/routers/vision.py
+++ b/app/routers/vision.py
@@ -171,6 +171,19 @@ async def generate_task_image(
                 'Do NOT retry it — the newer request is the live one.'
             ),
         }
+    if decision.get('action') == 'interrupted':
+        # The user sent a chat message instead of confirming the card.
+        # The message arrives as the next user turn; the agent should
+        # read it and act, not proceed with the un-confirmed proposal.
+        return {
+            'status': 'interrupted',
+            'message': (
+                'The user sent a message instead of confirming this '
+                'image — do NOT generate the proposed image. Read the '
+                "user's next message and act on it; re-propose an image "
+                'only if that still fits what they now want.'
+            ),
+        }
     if decision.get('action') != 'confirm':
         return {
             'status': 'cancelled',

--- a/app/vision.py
+++ b/app/vision.py
@@ -30,6 +30,7 @@ from pathlib import Path
 import httpx
 
 from app.config import VIBE_SELLER_DIR
+from app.events.bus import event_bus
 
 VISION_CONFIG_PATH = VIBE_SELLER_DIR / 'vision.json'
 
@@ -408,6 +409,26 @@ def discard_confirm(request_id: str, task_id: str | None = None) -> None:
     _pending_payload.pop(request_id, None)
     if task_id and _pending_by_task.get(task_id) == request_id:
         _pending_by_task.pop(task_id, None)
+
+
+async def interrupt_pending_confirm(task_id: str) -> bool:
+    """Retire a pending confirm card when the user replies instead of
+    confirming. Resolves the parked future as ``interrupted`` (so the
+    blocked ``generate`` tool returns at once, telling the agent to read
+    the user's message rather than generate the proposal) and emits
+    ``image_request_interrupted`` so the card shows a truthful, retired
+    footer — distinct from ``image_request_expired`` (replaced by a newer
+    request). No-op (returns False) if nothing is pending, i.e. the image
+    is already generating or there was never a card."""
+    pending = get_pending_request(task_id)
+    if not pending:
+        return False
+    resolve_confirm(pending['request_id'], {'action': 'interrupted'})
+    await event_bus.emit(
+        'image_request_interrupted',
+        {'task_id': task_id, 'request_id': pending['request_id']},
+    )
+    return True
 
 
 # ───────────────────────── kie.ai client ──────────────────────

--- a/app/workspace/manager.py
+++ b/app/workspace/manager.py
@@ -602,3 +602,31 @@ browser: {backend}
 
 # Singleton
 workspace_manager = WorkspaceManager()
+
+
+def reset_task_runtime_state(task_id: str) -> None:
+    """Wipe ALL on-disk state for a task so a retry starts truly fresh —
+    like a brand-new task. Clearing the DB rows is not enough: two stores
+    outlive it and leak prior-run context into the fresh session.
+
+    1. The task workspace ``tasks/{id}/`` (uploads, generated_images, the
+       copied .claude skills, symlinks) — rebuilt by prepare_task_workspace.
+    2. Claude Code's per-task Task/todo store. We pin a STABLE
+       ``CLAUDE_CODE_TASK_LIST_ID='vibe-<id8>'`` (claude_backend.py) so a
+       task's todos survive its own follow-ups/resumes — but that means a
+       retry inherits them too unless we delete the store here. Claude Code
+       keeps it at ``$CLAUDE_CONFIG_DIR|~/.claude / tasks/<task-list-id>/``.
+    3. Claude Code's project transcripts, keyed by the workspace CWD
+       (each ``/`` and ``.`` → ``-``), under ``.../projects/<cwd>/``.
+    """
+    task_dir = VIBE_SELLER_DIR / 'tasks' / task_id
+    shutil.rmtree(task_dir, ignore_errors=True)
+
+    claude_home = Path(
+        os.environ.get('CLAUDE_CONFIG_DIR') or (Path.home() / '.claude')
+    )
+    shutil.rmtree(
+        claude_home / 'tasks' / f'vibe-{task_id[:8]}', ignore_errors=True
+    )
+    cwd_key = str(task_dir).replace('/', '-').replace('.', '-')
+    shutil.rmtree(claude_home / 'projects' / cwd_key, ignore_errors=True)

--- a/docs/events.md
+++ b/docs/events.md
@@ -39,6 +39,12 @@ Each subscriber gets its own `asyncio.Queue`. Events are JSON-serialized with `t
 | `task_message` | `task_id`, `role`, `content` | `claude_backend.py` |
 | `task_todos` | `task_id`, `todos[]` | `claude_backend.py` |
 | `task_questions` | `task_id`, `request_id`, `questions[]` | `claude_backend.py` |
+| `task_question_interrupted` | `task_id`, `request_id` | `claude_backend_manager.py` |
+| `image_request` | `task_id`, `request_id`, `prompt`, `model`, `models[]`, `reference_images[]`, `output_name`, `kind` | `routers/vision.py` |
+| `image_generating` | `task_id`, `request_id`, `model`, `kind` | `routers/vision.py` |
+| `image_generated` | `task_id`, `request_id`, `path`, `url`, `prompt`, `model`, `kind` | `routers/vision.py` |
+| `image_request_expired` | `task_id`, `request_id` | `routers/vision.py` |
+| `image_request_interrupted` | `task_id`, `request_id` | `vision.py` |
 | `agent_done` | `task_id`, `return_code`, `mode?` | `claude_backend.py` |
 | `event_created` | `event_id`, `title`, `status` | `events.py`, `channels.py` |
 | `event_updated` | `event_id`, `status`, `old_status?` | `events.py` |
@@ -79,6 +85,27 @@ Emitted in addition to the standard `task_update` stream:
 - **`schedule_plan_timeout`** — `plan_reaper.py` failed a schedule stuck in `plan_status='planning'` whose planner Task was idle past the threshold.
 
 All four are emitted **after** the DB commit so consumers never observe an event for state that isn't yet persisted.
+
+### Image confirm-gate lifecycle
+
+The `vibe_seller_generate_image` MCP tool is confirm-gated: every call
+emits `image_request` and blocks until the user acts, so the model can
+never generate without confirmation. One task shows at most one live
+card at a time.
+
+- **`image_request`** — a card is proposed; the tool is parked on a
+  per-request future waiting for the user to confirm/edit/cancel.
+- **`image_generating`** → **`image_generated`** — the user confirmed;
+  the kie.ai call runs (can take a minute) then the saved image lands.
+- **`image_request_expired`** — a *newer* image request superseded this
+  one (agent retry / task retry). The old card is retired; the newer
+  request is the live one.
+- **`image_request_interrupted`** — the user sent a chat message instead
+  of confirming. The parked tool returns at once telling the agent to
+  read that message rather than generate the un-confirmed proposal. This
+  is distinct from `expired`: nothing replaced the card — the user
+  redirected. `task_question_interrupted` is the exact analogue for a
+  pending `AskUserQuestion` retired by a chat follow-up.
 
 ### Question Format
 

--- a/frontend/src/__tests__/chatComposerHint.test.tsx
+++ b/frontend/src/__tests__/chatComposerHint.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * The composer must set the right expectation for a follow-up:
+ *  - awaiting the user (confirm card / question) → "redirect" hint
+ *  - actively working → "queued" hint
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ChatComposer } from '../components/conversation/ChatComposer'
+
+const base = {
+  fileInputRef: { current: null },
+  uploading: false,
+  uploadFiles: vi.fn(),
+  attachments: [],
+  onRemoveAttachment: vi.fn(),
+  inputRef: { current: null },
+  input: 'it is one image, both are references',
+  setInput: vi.fn(),
+  hasContent: true,
+  canSend: true,
+  onSend: vi.fn(),
+  onStop: vi.fn(),
+  placeholder: '',
+}
+
+describe('ChatComposer follow-up hint', () => {
+  it('shows the REDIRECT hint (not queued) when awaiting the user', () => {
+    render(<ChatComposer {...base} isActive awaitingUser />)
+    expect(screen.getByTestId('chat-redirect-hint')).toBeInTheDocument()
+    expect(screen.queryByTestId('chat-queued-hint')).toBeNull()
+  })
+
+  it('shows the QUEUED hint when actively working (not awaiting user)', () => {
+    render(<ChatComposer {...base} isActive awaitingUser={false} />)
+    expect(screen.getByTestId('chat-queued-hint')).toBeInTheDocument()
+    expect(screen.queryByTestId('chat-redirect-hint')).toBeNull()
+  })
+})

--- a/frontend/src/__tests__/composerGate.test.ts
+++ b/frontend/src/__tests__/composerGate.test.ts
@@ -3,7 +3,6 @@ import type { ConversationItem } from '../types'
 import {
   hasPendingImageConfirm,
   isAwaitingUser,
-  composerSendKind,
 } from '../handlers/composerGate'
 
 const imgItem = (over: Record<string, unknown>): ConversationItem =>
@@ -36,11 +35,5 @@ describe('composerGate', () => {
     expect(isAwaitingUser([imgItem({})], false)).toBe(true) // confirm card
     expect(isAwaitingUser([imgItem({ generating: true })], false)).toBe(false)
     expect(isAwaitingUser([], false)).toBe(false)
-  })
-
-  it('routes a composer send to the free-text ANSWER only during a pending question', () => {
-    expect(composerSendKind(true, 'one image, both refs')).toBe('answer')
-    expect(composerSendKind(true, '   ')).toBe('message') // empty → not an answer
-    expect(composerSendKind(false, 'hi')).toBe('message') // no question → message
   })
 })

--- a/frontend/src/__tests__/composerGate.test.ts
+++ b/frontend/src/__tests__/composerGate.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import type { ConversationItem } from '../types'
+import {
+  hasPendingImageConfirm,
+  isAwaitingUser,
+  composerSendKind,
+} from '../handlers/composerGate'
+
+const imgItem = (over: Record<string, unknown>): ConversationItem =>
+  ({
+    id: 'i1',
+    type: 'image_request',
+    imageRequest: {
+      requestId: 'r1',
+      prompt: 'p',
+      model: 'm',
+      models: [],
+      referenceImages: [],
+      ...over,
+    },
+  }) as unknown as ConversationItem
+
+describe('composerGate', () => {
+  it('a shown, un-acted image confirm card counts as pending', () => {
+    expect(hasPendingImageConfirm([imgItem({})])).toBe(true)
+  })
+
+  it('a generating / resolved / expired card is NOT pending', () => {
+    expect(hasPendingImageConfirm([imgItem({ generating: true })])).toBe(false)
+    expect(hasPendingImageConfirm([imgItem({ resolved: true })])).toBe(false)
+    expect(hasPendingImageConfirm([imgItem({ expired: true })])).toBe(false)
+  })
+
+  it('awaitingUser is true for a pending question OR a live confirm card', () => {
+    expect(isAwaitingUser([], true)).toBe(true) // pending question
+    expect(isAwaitingUser([imgItem({})], false)).toBe(true) // confirm card
+    expect(isAwaitingUser([imgItem({ generating: true })], false)).toBe(false)
+    expect(isAwaitingUser([], false)).toBe(false)
+  })
+
+  it('routes a composer send to the free-text ANSWER only during a pending question', () => {
+    expect(composerSendKind(true, 'one image, both refs')).toBe('answer')
+    expect(composerSendKind(true, '   ')).toBe('message') // empty → not an answer
+    expect(composerSendKind(false, 'hi')).toBe('message') // no question → message
+  })
+})

--- a/frontend/src/__tests__/imageGenerating.test.tsx
+++ b/frontend/src/__tests__/imageGenerating.test.tsx
@@ -39,6 +39,17 @@ describe('ImageRequestCard generating state', () => {
     expect(screen.getByTestId('image-confirm-btn')).toBeInTheDocument()
     expect(screen.queryByTestId('image-card-generating')).toBeNull()
   })
+
+  it('shows a truthful "you replied instead" footer when interrupted', () => {
+    render(<ImageRequestCard {...base} resolved interrupted generating={false} />)
+    const footer = screen.getByTestId('image-card-footer')
+    // The interrupted key (t returns the key in these tests), NOT the
+    // misleading "expired/replaced by a newer request" copy.
+    expect(footer.textContent).toContain('vision.interrupted')
+    expect(footer.textContent).not.toContain('vision.expired')
+    // Non-actionable: no confirm/cancel buttons remain.
+    expect(screen.queryByTestId('image-confirm-btn')).toBeNull()
+  })
 })
 
 describe('ImageRequestCard model selector', () => {

--- a/frontend/src/components/conversation/ChatComposer.tsx
+++ b/frontend/src/components/conversation/ChatComposer.tsx
@@ -16,6 +16,10 @@ interface ChatComposerProps {
   hasContent: boolean
   canSend: boolean
   isActive: boolean
+  /** The agent is parked awaiting the user (image confirm card shown but
+   *  not generating, or a question pending) — a follow-up REDIRECTS it
+   *  now instead of queueing behind a running step. */
+  awaitingUser?: boolean
   onSend: () => void
   onStop: () => void
   placeholder: string
@@ -27,8 +31,8 @@ interface ChatComposerProps {
  *  and only reach the agent when the user sends. */
 export function ChatComposer({
   fileInputRef, uploading, uploadFiles, attachments, onRemoveAttachment,
-  inputRef, input, setInput, hasContent, canSend, isActive, onSend, onStop,
-  placeholder,
+  inputRef, input, setInput, hasContent, canSend, isActive, awaitingUser,
+  onSend, onStop, placeholder,
 }: ChatComposerProps) {
   const { t } = useTranslation()
   return (
@@ -36,10 +40,16 @@ export function ChatComposer({
       {/* Staged attachment chips (thumbnails, not paths) */}
       <AttachmentChips attachments={attachments} onRemove={onRemoveAttachment} />
 
-      {/* While the agent is working, a follow-up is queued and delivered
-       *  when the current step finishes (it can't interrupt a running
-       *  tool such as image generation) — set that expectation. */}
-      {isActive && hasContent && (
+      {/* Two distinct expectations:
+       *  - awaiting the user (confirm card / question) → the message
+       *    REDIRECTS the agent right now.
+       *  - actively working → the message queues until the current step
+       *    (e.g. image generation) finishes. */}
+      {awaitingUser && hasContent ? (
+        <div className="text-[11px] text-indigo-500" data-testid="chat-redirect-hint">
+          {t('tasks.redirectWhileWaiting')}
+        </div>
+      ) : isActive && hasContent && (
         <div className="text-[11px] text-gray-400" data-testid="chat-queued-hint">
           {t('tasks.queuedWhileWorking')}
         </div>

--- a/frontend/src/components/conversation/ConversationStream.tsx
+++ b/frontend/src/components/conversation/ConversationStream.tsx
@@ -423,6 +423,7 @@ export function ConversationStream({
                 kind={item.imageRequest!.kind}
                 resolved={item.imageRequest!.resolved}
                 expired={item.imageRequest!.expired}
+                interrupted={item.imageRequest!.interrupted}
                 generating={item.imageRequest!.generating}
                 onDecision={onImageDecision || (() => {})}
               />

--- a/frontend/src/components/conversation/ConversationStream.tsx
+++ b/frontend/src/components/conversation/ConversationStream.tsx
@@ -64,23 +64,27 @@ function parseTaskStart(
   }
 }
 
-/** Collapsed view for questions that have already been answered. */
-function AnsweredQuestions({ questions }: { questions: { header?: string; question: string }[] }) {
+/** Collapsed view for a question that's no longer pending — either
+ *  answered, or interrupted (the user sent a chat follow-up instead of
+ *  answering the card). */
+function AnsweredQuestions({ questions, interrupted }: { questions: { header?: string; question: string }[]; interrupted?: boolean }) {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
   const summary = questions.map(q => q.header || q.question.slice(0, 40)).join(', ')
 
   return (
-    <div className="border-l-2 border-amber-200 pl-2 py-1">
+    <div className={`border-l-2 pl-2 py-1 ${interrupted ? 'border-gray-200' : 'border-amber-200'}`}>
       <button
-        className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-amber-600 w-full text-left"
+        className={`flex items-center gap-1.5 text-xs text-gray-400 w-full text-left ${interrupted ? 'hover:text-gray-600' : 'hover:text-amber-600'}`}
         onClick={() => setExpanded(e => !e)}
       >
         <span className={`text-[10px] transition-transform ${expanded ? 'rotate-90' : ''}`}>
           ▶
         </span>
-        <span className="text-amber-500">
-          {t('tasks.answeredQuestions', 'Questions answered')}
+        <span className={interrupted ? 'text-gray-400' : 'text-amber-500'}>
+          {interrupted
+            ? t('tasks.interruptedQuestions', 'You replied instead — not answered')
+            : t('tasks.answeredQuestions', 'Questions answered')}
         </span>
         {!expanded && (
           <span className="text-gray-300 truncate">
@@ -406,6 +410,7 @@ export function ConversationStream({
             return (
               <AnsweredQuestions
                 key={item.id}
+                interrupted={item.questionInterrupted}
                 questions={item.questions!.questions}
               />
             )

--- a/frontend/src/components/conversation/ImageRequestCard.tsx
+++ b/frontend/src/components/conversation/ImageRequestCard.tsx
@@ -15,6 +15,7 @@ interface ImageRequestCardProps {
   kind?: string
   resolved?: boolean
   expired?: boolean
+  interrupted?: boolean
   generating?: boolean
   onDecision: (
     requestId: string,
@@ -48,6 +49,7 @@ export function ImageRequestCard({
   kind,
   resolved,
   expired,
+  interrupted,
   generating,
   onDecision,
 }: ImageRequestCardProps) {
@@ -226,7 +228,11 @@ export function ImageRequestCard({
             data-testid="image-card-footer"
             className="px-4 py-2 bg-gray-50 border-t border-gray-100 text-xs text-gray-400"
           >
-            {expired ? t('vision.expired') : t('vision.handled')}
+            {interrupted
+              ? t('vision.interrupted')
+              : expired
+                ? t('vision.expired')
+                : t('vision.handled')}
           </div>
         )
       )}

--- a/frontend/src/handlers/composerGate.ts
+++ b/frontend/src/handlers/composerGate.ts
@@ -1,0 +1,37 @@
+import type { ConversationItem } from '../types'
+
+/** A live image confirm card the user hasn't acted on yet: shown, and
+ *  NOT resolved / expired / generating. */
+export function hasPendingImageConfirm(items: ConversationItem[]): boolean {
+  return items.some(
+    it =>
+      it.type === 'image_request' &&
+      !!it.imageRequest &&
+      !it.imageRequest.resolved &&
+      !it.imageRequest.expired &&
+      !it.imageRequest.generating,
+  )
+}
+
+/** The agent is PARKED awaiting the user — a live confirm card, or a
+ *  pending question — as opposed to actively working. A follow-up here
+ *  redirects the agent immediately instead of queueing behind a step. */
+export function isAwaitingUser(
+  items: ConversationItem[],
+  hasPendingQuestion: boolean,
+): boolean {
+  return hasPendingQuestion || hasPendingImageConfirm(items)
+}
+
+/** Where a composer send should go: during a pending question the message
+ *  IS the answer, so route it through the free-text answer channel
+ *  (unblocks the parked agent instantly, like the question card's "type
+ *  freely"); otherwise send it as a normal chat message. The image
+ *  confirm gate is interrupted server-side by POST /messages, so it uses
+ *  the plain message path. */
+export function composerSendKind(
+  hasPendingQuestion: boolean,
+  text: string,
+): 'answer' | 'message' {
+  return hasPendingQuestion && text.trim().length > 0 ? 'answer' : 'message'
+}

--- a/frontend/src/handlers/composerGate.ts
+++ b/frontend/src/handlers/composerGate.ts
@@ -22,16 +22,3 @@ export function isAwaitingUser(
 ): boolean {
   return hasPendingQuestion || hasPendingImageConfirm(items)
 }
-
-/** Where a composer send should go: during a pending question the message
- *  IS the answer, so route it through the free-text answer channel
- *  (unblocks the parked agent instantly, like the question card's "type
- *  freely"); otherwise send it as a normal chat message. The image
- *  confirm gate is interrupted server-side by POST /messages, so it uses
- *  the plain message path. */
-export function composerSendKind(
-  hasPendingQuestion: boolean,
-  text: string,
-): 'answer' | 'message' {
-  return hasPendingQuestion && text.trim().length > 0 ? 'answer' : 'message'
-}

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -380,6 +380,19 @@ export function useSSE({
             return prev
           })
         }
+        // The user sent a chat follow-up instead of answering — retire
+        // the question card as "you replied instead" (not "answered"):
+        // drop the pending banner and mark the question item interrupted.
+        if (data.type === 'task_question_interrupted') {
+          if (selectedTaskIdRef.current === data.task_id) {
+            setPendingQuestions(prev =>
+              prev && prev.request_id === data.request_id ? null : prev)
+            setConversationItems(items => items.map(it =>
+              it.type === 'question' && it.questions?.request_id === data.request_id
+                ? { ...it, questionInterrupted: true }
+                : it))
+          }
+        }
         // Image generation: the agent's tool call is paused server-side
         // waiting for the user to review/edit the prompt+model. Append a
         // confirm card; when the generated image arrives, mark the card

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -413,6 +413,18 @@ export function useSSE({
                 : it))
           }
         }
+        // User sent a chat message instead of confirming — retire the
+        // card (non-actionable) with a truthful "you replied instead"
+        // footer; the image was NOT generated. Distinct from _expired
+        // (which means a newer request replaced it).
+        if (data.type === 'image_request_interrupted') {
+          if (selectedTaskIdRef.current === data.task_id) {
+            setConversationItems(items => items.map(it =>
+              it.type === 'image_request' && it.imageRequest?.requestId === data.request_id
+                ? { ...it, imageRequest: { ...it.imageRequest!, resolved: true, interrupted: true, generating: false } }
+                : it))
+          }
+        }
         // User confirmed; the (minutes-long) generation is now running.
         // Flip the card into a "generating…" state so the user sees real
         // progress instead of the generic "agent is working" spinner.

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -135,6 +135,7 @@
     "chatPlaceholder": "Type a message to the AI...",
     "send": "Send",
     "queuedWhileWorking": "The agent is working — your message will be sent when the current step finishes.",
+    "redirectWhileWaiting": "The agent is waiting for you — your message will redirect it right away.",
     "executionPlan": "Execution Plan",
     "agentChat": "Agent Session",
     "agentStarting": "Agent starting...",
@@ -820,6 +821,7 @@
     "uploading": "Uploading…",
     "dropHint": "Drag an image here or click to add a reference",
     "expired": "Expired — replaced by a newer request below",
+    "interrupted": "You replied instead — this image wasn't generated",
     "generating": "Generating image… this can take 1–2 minutes"
   }
 }

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -127,6 +127,7 @@
     "confirmRunHint": "Task will pause after planning for your confirmation before executing.",
     "submitAnswers": "Submit Answers",
     "answeredQuestions": "Questions answered",
+    "interruptedQuestions": "You replied instead — not answered",
     "other": "Other...",
     "typeAnswer": "Type your answer...",
     "dismissQuestions": "Type freely instead",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -135,6 +135,7 @@
     "chatPlaceholder": "输入消息给 AI...",
     "send": "发送",
     "queuedWhileWorking": "智能体正在工作——你的消息将在当前步骤完成后发送。",
+    "redirectWhileWaiting": "智能体正在等你——你的消息会立即调整它的下一步。",
     "executionPlan": "执行计划",
     "agentChat": "工作会话",
     "agentStarting": "AI 启动中...",
@@ -822,6 +823,7 @@
     "uploading": "上传中…",
     "dropHint": "拖拽图片到此处，或点击上传参考图",
     "expired": "已过期——已被下方更新的请求替代",
+    "interrupted": "你改为发送了消息——未生成此图",
     "generating": "正在生成图片…大约需要 1–2 分钟"
   }
 }

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -127,6 +127,7 @@
     "confirmRunHint": "任务将在规划后等待确认再执行，可随时停止。",
     "submitAnswers": "提交回答",
     "answeredQuestions": "已回答问题",
+    "interruptedQuestions": "你改为发送了消息（未作答）",
     "other": "其他...",
     "typeAnswer": "输入您的回答...",
     "dismissQuestions": "自由输入回复",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -161,6 +161,9 @@ export interface ConversationItem {
   plan?: PlanVersion
   message?: { role: string; content: string }
   questions?: { request_id: string; questions: { header?: string; question: string; options?: { label: string; description?: string }[] }[] }
+  // The user sent a chat follow-up instead of answering this question —
+  // the card is retired as "you replied instead", not "answered".
+  questionInterrupted?: boolean
   result?: string
   toolCall?: { tool: string; input?: Record<string, unknown> }
   thinking?: { content: string; isStreaming: boolean }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -174,6 +174,9 @@ export interface ConversationItem {
     kind?: string
     resolved?: boolean
     expired?: boolean
+    // The user sent a chat message instead of confirming — the card is
+    // retired (non-actionable) and the image was NOT generated.
+    interrupted?: boolean
     // Confirmed and the image is actively generating (kie.ai poll,
     // ~1-2 min). Drives the "generating…" state in ImageRequestCard.
     generating?: boolean

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -8,6 +8,7 @@ import { StatusBadge } from '../components/ui'
 import { ConversationStream } from '../components/conversation/ConversationStream'
 import { useChatUploads } from '../hooks/useChatUploads'
 import { ChatComposer } from '../components/conversation/ChatComposer'
+import { composerSendKind, isAwaitingUser } from '../handlers/composerGate'
 import { ScheduleList } from '../components/ScheduleList'
 import { ScheduleDetailView } from '../components/ScheduleDetailView'
 import { EditScheduleModal } from '../components/EditScheduleModal'
@@ -201,6 +202,22 @@ export function TasksView({
   const isActive = taskCfg?.isActive ?? false
   // A message may be text-only, attachment-only, or both.
   const hasText = chatInput.trim().length > 0 || chatAttachments.length > 0
+
+  // The agent is parked awaiting the user (live confirm card, or a
+  // pending question) → a follow-up REDIRECTS it rather than queueing.
+  const awaitingUser = isAwaitingUser(conversationItems, !!pendingQuestions)
+
+  // During a pending question a composer message IS the answer — route it
+  // through the free-text answer channel; otherwise send normally (the
+  // image confirm gate is interrupted server-side by POST /messages).
+  const onComposerSend = () => {
+    if (composerSendKind(!!pendingQuestions, chatInput) === 'answer') {
+      submitAllAnswers({ _free_text: chatInput.trim() })
+      setChatInput('')
+      return
+    }
+    sendChatMessage()
+  }
 
   // Placeholder changes by state
   const getPlaceholder = () => {
@@ -718,7 +735,8 @@ export function TasksView({
                 uploadFiles={uploadChatFiles} attachments={chatAttachments}
                 onRemoveAttachment={removeAttachment} inputRef={chatInputRef}
                 input={chatInput} setInput={setChatInput} hasContent={hasText}
-                canSend={canSend} isActive={isActive} onSend={sendChatMessage}
+                canSend={canSend} isActive={isActive} awaitingUser={awaitingUser}
+                onSend={onComposerSend}
                 onStop={stopAgent} placeholder={getPlaceholder()}
               />
               </div>

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -8,7 +8,7 @@ import { StatusBadge } from '../components/ui'
 import { ConversationStream } from '../components/conversation/ConversationStream'
 import { useChatUploads } from '../hooks/useChatUploads'
 import { ChatComposer } from '../components/conversation/ChatComposer'
-import { composerSendKind, isAwaitingUser } from '../handlers/composerGate'
+import { isAwaitingUser } from '../handlers/composerGate'
 import { ScheduleList } from '../components/ScheduleList'
 import { ScheduleDetailView } from '../components/ScheduleDetailView'
 import { EditScheduleModal } from '../components/EditScheduleModal'
@@ -205,19 +205,11 @@ export function TasksView({
 
   // The agent is parked awaiting the user (live confirm card, or a
   // pending question) → a follow-up REDIRECTS it rather than queueing.
+  // Both gates are interrupted server-side by POST /messages, so the
+  // composer always sends normally: a follow-up is a chat message (shown
+  // as a bubble), NOT a formal answer to the question card. Answering the
+  // card is still done via the card itself (options / "type freely").
   const awaitingUser = isAwaitingUser(conversationItems, !!pendingQuestions)
-
-  // During a pending question a composer message IS the answer — route it
-  // through the free-text answer channel; otherwise send normally (the
-  // image confirm gate is interrupted server-side by POST /messages).
-  const onComposerSend = () => {
-    if (composerSendKind(!!pendingQuestions, chatInput) === 'answer') {
-      submitAllAnswers({ _free_text: chatInput.trim() })
-      setChatInput('')
-      return
-    }
-    sendChatMessage()
-  }
 
   // Placeholder changes by state
   const getPlaceholder = () => {
@@ -736,7 +728,7 @@ export function TasksView({
                 onRemoveAttachment={removeAttachment} inputRef={chatInputRef}
                 input={chatInput} setInput={setChatInput} hasContent={hasText}
                 canSend={canSend} isActive={isActive} awaitingUser={awaitingUser}
-                onSend={onComposerSend}
+                onSend={sendChatMessage}
                 onStop={stopAgent} placeholder={getPlaceholder()}
               />
               </div>

--- a/tests/unit/test_followup_gate.py
+++ b/tests/unit/test_followup_gate.py
@@ -1,0 +1,83 @@
+"""Unit tests for follow-up gate consistency:
+
+- ``reset_task_runtime_state`` wipes ALL on-disk state so a retry is a
+  true fresh start (workspace + Claude Code's per-task Task/todo store +
+  project transcripts) — the fix for stale todos/refs leaking across a
+  retried task via the stable CLAUDE_CODE_TASK_LIST_ID.
+- ``interrupt_pending_question`` retires a pending AskUserQuestion with a
+  NOTE (not the user's message, not recorded as answers) + emits
+  ``task_question_interrupted`` — so a composer follow-up interrupts the
+  card instead of being force-submitted as its answer.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from app.ai.claude_backend_manager import agent_manager
+from app.events.bus import event_bus
+from app.workspace import manager as mgr
+
+pytestmark = pytest.mark.unit
+
+
+def test_reset_task_runtime_state_wipes_everything(tmp_path, monkeypatch):
+    vibe = tmp_path / 'vibe'
+    claude = tmp_path / 'claude'
+    monkeypatch.setattr(mgr, 'VIBE_SELLER_DIR', vibe)
+    monkeypatch.setenv('CLAUDE_CONFIG_DIR', str(claude))
+
+    tid = 'abcd1234-0000-0000-0000-000000000000'
+    ws = vibe / 'tasks' / tid
+    (ws / 'uploads').mkdir(parents=True)
+    (ws / 'uploads' / 'ref.jpg').write_text('img')
+    store = claude / 'tasks' / f'vibe-{tid[:8]}'
+    store.mkdir(parents=True)
+    (store / '1.json').write_text('{"subject": "为产品图1生成白底主图"}')
+    cwd_key = str(ws).replace('/', '-').replace('.', '-')
+    proj = claude / 'projects' / cwd_key
+    proj.mkdir(parents=True)
+    (proj / 'session.jsonl').write_text('stale transcript')
+
+    mgr.reset_task_runtime_state(tid)
+
+    assert not ws.exists(), 'workspace (uploads etc.) must be wiped'
+    assert not store.exists(), 'Claude Code Task/todo store must be wiped'
+    assert not proj.exists(), 'Claude Code project transcripts must be wiped'
+
+
+async def test_interrupt_pending_question_no_session_is_noop():
+    assert await agent_manager.interrupt_pending_question('missing') is None
+
+
+async def test_interrupt_pending_question_notes_and_emits(monkeypatch):
+    class _FakeSession:
+        def __init__(self):
+            self.running = True
+            self._pending_questions = {
+                'req-1': {'request_id': 'req-1', 'questions': []}
+            }
+            self.submitted = None
+
+        async def submit_answer(self, request_id, answers):
+            self.submitted = (request_id, answers)
+
+    sess = _FakeSession()
+    monkeypatch.setitem(agent_manager._sessions, 'task-q', sess)
+    queue = event_bus.subscribe()
+    try:
+        rid = await agent_manager.interrupt_pending_question('task-q')
+        assert rid == 'req-1'
+        # Unblocked with a free-text NOTE (a sentinel telling the agent
+        # the user messaged) — NOT the user's message, NOT real answers.
+        assert sess.submitted[0] == 'req-1'
+        assert '_free_text' in sess.submitted[1]
+
+        raw = await asyncio.wait_for(queue.get(), 2)
+        ev = json.loads(raw)
+        assert ev['type'] == 'task_question_interrupted'
+        assert ev['request_id'] == 'req-1'
+    finally:
+        event_bus.unsubscribe(queue)
+        agent_manager._sessions.pop('task-q', None)

--- a/tests/workflow/fake_agent.py
+++ b/tests/workflow/fake_agent.py
@@ -736,6 +736,11 @@ class FakeAgent(AIAgentBackend):
         await session.reject_plan(feedback)
         return True
 
+    async def interrupt_pending_question(self, task_id: str) -> str | None:
+        # No AskUserQuestion is pending in the fake; the gate-interrupt
+        # call in send_task_message is a no-op here.
+        return None
+
     def is_running(self, task_id: str) -> bool:
         return self._running.get(task_id, False)
 

--- a/tests/workflow/test_wf_vision_image.py
+++ b/tests/workflow/test_wf_vision_image.py
@@ -9,6 +9,7 @@ Exercises the real API + event bus (kie.ai stubbed via VISION_FAKE):
 """
 
 import asyncio
+from datetime import UTC, datetime
 import json
 import shutil
 import uuid
@@ -17,6 +18,7 @@ import pytest
 
 from app import vision
 from app.events.bus import event_bus
+from app.models.task import Task
 from app.workspace.manager import VIBE_SELLER_DIR
 
 pytestmark = pytest.mark.workflow
@@ -196,6 +198,78 @@ async def test_pending_image_request_recoverable(admin_client, monkeypatch):
         await asyncio.wait_for(gen, timeout=10)
         p2 = (await admin_client.get(f'/api/tasks/{tid}/image/pending')).json()
         assert p2 == {'pending': False}
+    finally:
+        event_bus.unsubscribe(queue)
+        shutil.rmtree(task_dir, ignore_errors=True)
+
+
+async def test_followup_interrupts_pending_confirm(
+    admin_client, install_fake_agent, override_async_session, monkeypatch
+):
+    """A follow-up sent while the confirm card is shown (NOT generating)
+    INTERRUPTS the gate: the parked generate returns ``interrupted`` (no
+    image made) and the card is retired via ``image_request_interrupted``,
+    instead of buffering behind the blocked tool call."""
+    monkeypatch.setenv('VISION_FAKE', '1')
+    tid = str(uuid.uuid4())
+    task_dir = _TASKS_DIR / tid
+    now = datetime.now(UTC).isoformat()
+    async with override_async_session() as db:
+        db.add(
+            Task(
+                id=tid,
+                title='white bg main',
+                created_by='system',
+                status='running',
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        await db.commit()
+    # So POST /messages takes the live send_message path (no real spawn).
+    install_fake_agent._running[tid] = True
+
+    queue = event_bus.subscribe()
+    try:
+        gen = asyncio.create_task(
+            admin_client.post(
+                f'/api/tasks/{tid}/image/generate',
+                json={
+                    'prompt': '主图：纯白背景',
+                    'model': 'nano-banana-pro-2k',
+                    'output_name': 'main.png',
+                    'kind': 'main',
+                },
+            )
+        )
+        req = await _drain_until(queue, 'image_request')
+
+        # User sends a chat message instead of confirming the card.
+        m = await admin_client.post(
+            f'/api/tasks/{tid}/messages',
+            json={'content': '其实只有一张图，两张都是参考图'},
+        )
+        assert m.status_code == 200
+
+        # The parked generate returns interrupted — nothing was generated.
+        resp = await asyncio.wait_for(gen, timeout=10)
+        assert resp.json()['status'] == 'interrupted'
+        assert not (task_dir / 'generated_images').exists()
+
+        # The card is retired with the truthful interrupted event (NOT the
+        # "replaced by a newer request" expired event).
+        ev = await _drain_until(queue, 'image_request_interrupted')
+        assert ev['request_id'] == req['request_id']
+
+        # And the follow-up was delivered to the agent, not dropped.
+        assert any(
+            c.task_id == tid and c.action == 'send_message'
+            for c in install_fake_agent.calls
+        )
+
+        # Once interrupted, the card is no longer recoverable as pending.
+        p = (await admin_client.get(f'/api/tasks/{tid}/image/pending')).json()
+        assert p == {'pending': False}
     finally:
         event_bus.unsubscribe(queue)
         shutil.rmtree(task_dir, ignore_errors=True)


### PR DESCRIPTION
Makes a chat follow-up behave consistently whether the agent is actively working or just **parked waiting on the user**, and makes **retry** a true fresh start. Found + fixed via live testing on izz-mac.

## The core problem

The composer's "is the agent working / queue my message" state was derived **purely from `task.status` (`running`)**. But an image **confirm card** (agent parked, doing nothing) and a pending **AskUserQuestion** both run under `running` too — so a follow-up was treated as "agent busy", buffered on stdin behind the blocked tool, and did nothing until the user acted on the card. There was no way to tell "waiting on you" from "actively working".

## One rule

**Gate open (awaiting the user) ⇒ the follow-up INTERRUPTS the gate and reaches the agent now. Actively working ⇒ queue (buffer), as before.**

- **Image confirm gate** — `POST /messages` calls `vision.interrupt_pending_confirm` when a confirm card is pending (shown, not generating): resolves the parked future as `interrupted` (the `generate` tool returns *"user replied instead of confirming — read their message"*) and emits `image_request_interrupted`. Once generation is actually running there's no pending confirm, so mid-generation follow-ups still queue.
- **Question gate** — `POST /messages` calls `agent_manager.interrupt_pending_question`: unblocks the parked hook with a **note** (*"user sent a message instead of answering — read it; do NOT treat as answers"*), emits `task_question_interrupted`. The user's message is then delivered as a normal chat bubble. It is **not** force-submitted as the answer (that earlier approach mis-recorded a redirect as "已回答" and poisoned the agent with a non-answer). Answering the card is still done via the card itself (options / "type freely").
- **Truthful card states** — an interrupted confirm card shows *"you replied instead — this image wasn't generated"*; an interrupted question card shows *"you replied instead — not answered"* — distinct from "expired"/"answered". Cards stay in the transcript as history (don't vanish).
- **Composer hint** — `awaitingUser` shows *"your message will redirect it right away"* instead of *"queued while working"*.

## Retry = truly fresh (was leaking prior-run state)

We pin a **stable** `CLAUDE_CODE_TASK_LIST_ID=vibe-<id8>` so a task's Claude Code Task/todo list survives its own follow-ups/resumes — but **retry inherited it too**: a retried task's fresh session read the prior run's todos (e.g. reference-image IDs) via `TaskGet`/`TaskList`, and the workspace (uploads) also survived. `retry_task` now calls `workspace.reset_task_runtime_state`, wiping the **task workspace + Claude Code's task store (`~/.claude/tasks/vibe-<id8>/`) + project transcripts** — a retry is now byte-for-byte like a brand-new task. (Claude Code is fine; the stable id was ours to reset.)

## Tests
- **Backend**: `reset_task_runtime_state` wipes all three stores; `interrupt_pending_question` notes+emits (no-op when nothing pending); confirm-gate interrupt workflow (follow-up → `interrupted`, nothing generated, event emitted, message delivered).
- **Frontend**: `composerGate` (awaiting-user detection, generating/resolved/expired exclusions), interrupted image-card footer, redirect-vs-queued composer hint.
- Full suites green; `ruff`/`tsc`/`eslint`/800-line-limit/pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9p1mvGVPimwVG3WcQ7P26