### PR TITLE
fix(tasks): fresh session on follow-up when prior run orphaned a background task

### DIFF
--- a/app/routers/tasks_conversation.py
+++ b/app/routers/tasks_conversation.py
@@ -48,7 +48,11 @@ from app.task_states import (
     TaskStatus,
     assert_transition,
 )
-from app.workspace.manager import reset_task_runtime_state, workspace_manager
+from app.workspace.manager import (
+    reset_task_runtime_state,
+    session_has_orphaned_bg_task,
+    workspace_manager,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -67,12 +71,10 @@ def _follow_up_auto_approve(task: Task) -> bool:
     ``task_runner_auto.py``.
 
     Follow-up flows bypass ``auto_run_task`` and call
-    ``agent_manager.run()`` directly, so they must compute the same
-    gate locally. Without this, a plan-mode task with
-    ``schedule_id`` set (e.g. a plan-only planner whose first session
-    crashed and the user is nudging via follow-up) would leave
-    ``auto_approve_plan=False``, the agent would save its plan and
-    then wait forever for an approval that never arrives.
+    ``agent_manager.run()`` directly, so must compute the same gate
+    locally. Without this, a plan-mode task with ``schedule_id`` set
+    would leave ``auto_approve_plan=False`` and wait forever for an
+    approval that never arrives.
     """
     return bool(task.schedule_id) or not task.plan_mode
 
@@ -118,10 +120,9 @@ async def send_task_message(
     current_profile_id = task.ai_profile_id or DEFAULT_PROFILE_ID
     is_profile_switch = requested_profile_id != current_profile_id
 
-    # Promote staged chat attachments into the task workspace. This is the
-    # ONE moment an attachment becomes visible to the agent: staging kept
-    # it outside the agent's cwd until the user pressed Send. From here we
-    # keep TWO content strings:
+    # Promote staged chat attachments into the task workspace — the ONE
+    # moment an attachment becomes visible to the agent. From here we keep
+    # TWO content strings:
     #   display_content — stored + shown in the transcript; images become
     #                     markdown so the user sees a thumbnail, not a path.
     #   agent_content   — delivered to the agent; absolute paths it Reads
@@ -241,13 +242,11 @@ async def send_task_message(
                 # The task-level verdict is TURN-SCOPED: a delivered
                 # follow-up opens a new turn, so the prior turn's
                 # result/error must not survive it (the finished-task
-                # spawn path below clears the same fields). Without
-                # this, a turn-1 ``set_task_result``/``set_task_error``
-                # sticks: ``_save_result``'s preserve-existing rule
-                # then refuses the new turn's streamed result and the
-                # UI shows the stale verdict next to the new turn's
-                # answer. Gate redrives do NOT pass through here, so
-                # a converging turn keeps its accepted result.
+                # spawn path below clears the same fields). Without this
+                # a turn-1 verdict sticks: ``_save_result``'s
+                # preserve-existing rule refuses the new turn's streamed
+                # result and the UI shows the stale one. Gate redrives
+                # don't pass here, so a converging turn keeps its result.
                 task.result = None
                 task.error = None
                 task.error_category = None
@@ -267,14 +266,11 @@ async def send_task_message(
     is_plan_feedback = task.status == TaskStatus.PLANNED
     has_resumable_session = bool(task.session_id) and not is_profile_switch
     # Context-rot guard: past a certain transcript size, a resumed
-    # session carries more failed-attempt residue than signal — stale
-    # file paths, superseded conclusions, and old batch state dominate
-    # the context and the agent re-verifies dead artifacts (observed
-    # live: a reviewer "verified" a prior turn's report because its
-    # path was still in context). Beyond the threshold, start a FRESH
-    # CLI session seeded with the compact history summary the
-    # non-resumable branch below already builds (history file + recent
-    # messages + plan). The task workspace (files on disk) is unchanged.
+    # session carries more failed-attempt residue than signal (stale
+    # paths, superseded conclusions) and re-verifies dead artifacts.
+    # Beyond the threshold, start a FRESH session seeded with the compact
+    # history summary the non-resumable branch below builds. Files on
+    # disk are unchanged.
     if has_resumable_session:
         n_msgs = await db.scalar(
             select(func.count())
@@ -291,25 +287,35 @@ async def send_task_message(
                 n_msgs,
                 FRESH_SESSION_MSG_LIMIT,
             )
+    # Orphaned-background-task guard: if the prior run left a background
+    # shell running, `--resume` makes the CLI inject a reconciliation
+    # notification that collides with this follow-up and aborts the
+    # turn's tool calls — a confirm-gated generate_image then dies before
+    # its gate and the follow-up silently no-ops. Fresh session instead.
+    if has_resumable_session and session_has_orphaned_bg_task(
+        task_id, task.session_id
+    ):
+        has_resumable_session = False
+        logger.info(
+            'Task %s prior session left an orphaned background task — '
+            'starting a fresh session instead of resuming, to avoid the '
+            'resume-time reconciliation notification aborting the turn',
+            task_id,
+        )
 
-    # Plan approval is a ONE-WAY exit from plan mode (like Claude Code:
-    # an approved ExitPlanMode leaves the session in normal mode for
-    # good). ``started_at`` is stamped at approval and only reset by a
-    # full task retry (which also clears the plan and resets status to
-    # PENDING), so a task is still "planning" only if it hasn't started
-    # executing AND is in a pre-execution status. Past that a follow-up
-    # behaves like one on a non-plan task — resume and keep executing,
-    # never re-plan. (Bug: approved plan tasks sit in DESIGNING/COMPLETED
-    # between turns and used to re-plan every turn.) ``is_plan_only``
-    # schedule tasks only ever plan; PLANNED plan-feedback routes above.
-    # FAILED is included ONLY together with ``started_at is None``: a
-    # plan-mode task that failed BEFORE any plan was approved died in
-    # the planning phase, so a follow-up must resume PLANNING — without
-    # this it fell through to auto mode and executed the review-first
-    # task unreviewed under bypassPermissions. A COMPLETED task with no
-    # ``started_at`` (the plan-skip path: agent delivered a result
-    # without ExitPlanMode) stays auto — its work is already done and
-    # accepted as-is by the plan-skip contract.
+    # Plan approval is a ONE-WAY exit from plan mode: ``started_at`` is
+    # stamped at approval and only reset by a full retry, so a task is
+    # "planning" only if it hasn't started executing AND is pre-execution.
+    # Past that a follow-up resumes and keeps executing, never re-plans
+    # (Bug: approved plan tasks sat in DESIGNING/COMPLETED and re-planned
+    # every turn). ``is_plan_only`` schedule tasks only ever plan; PLANNED
+    # plan-feedback routes above. FAILED counts ONLY with ``started_at is
+    # None`` — a plan-mode task that failed BEFORE plan approval died in
+    # planning, so a follow-up must resume PLANNING (else it fell through
+    # to auto and ran a review-first task unreviewed under bypass). A
+    # COMPLETED task with no ``started_at`` (plan-skip: result without
+    # ExitPlanMode) stays auto — its work is done, per the plan-skip
+    # contract.
     plan_phase_active = task.plan_mode and (
         task.is_plan_only
         or (
@@ -524,20 +530,13 @@ async def send_task_message(
         return {**accepted, 'profile_switched': is_profile_switch}
     else:
         await refresh_token_if_needed()
-        # Mode selection for follow-ups on tasks NOT in WAITING /
-        # COMPLETED / FAILED. The remaining states are PENDING /
-        # QUEUED / DESIGNING / PLANNED / RUNNING.
-        #
+        # Mode selection for follow-ups NOT in WAITING/COMPLETED/FAILED
+        # (i.e. PENDING/QUEUED/DESIGNING/PLANNED/RUNNING).
         # Still in the plan phase (``plan_phase_active``) → keep
         # plan_then_execute so the resumed session stays in plan mode
-        # (otherwise ExitPlanMode returns "You are not in plan mode").
-        # Covers PENDING/QUEUED before the agent starts, DESIGNING after
-        # a crash/interrupt, and is_plan_only tasks.
-        #
-        # Non-plan task → auto. Plan-mode task past its plan phase
-        # (approved: RUNNING, or DESIGNING with started_at set) →
-        # execute: bypassPermissions, continues with context, no
-        # re-plan — exactly like a non-plan follow-up.
+        # (else ExitPlanMode errors "not in plan mode"). Non-plan task →
+        # auto. Plan-mode task past its plan phase → execute (bypass,
+        # continues with context, no re-plan) — like a non-plan follow-up.
         if plan_phase_active:
             follow_up_mode = 'plan_then_execute'
         elif not task.plan_mode:
@@ -657,9 +656,8 @@ async def retry_task(
     """Retry a retriable task (FAILED / PENDING / COMPLETED).
 
     Default: clear plan + restart from PENDING (re-plan if plan mode).
-    Scheduled plan-mode tasks re-seed from the owning Schedule's
-    frozen plan (``plan_status='ready'``) and go straight to PLANNED
-    → execute, matching the cron fire path.
+    Scheduled plan-mode tasks re-seed from the owning Schedule's frozen
+    plan (``plan_status='ready'``) and go straight to PLANNED → execute.
     """
     task = await db.get(Task, task_id)
     if not task:
@@ -741,13 +739,11 @@ async def retry_task(
     # If this child was retried, revert parent to WAITING
     await reopen_parent_if_child_active(task, db)
     # Retry is a DESTRUCTIVE fresh restart, so WIPE the per-task
-    # workspace (best-effort). Leftover run data — above all the review
-    # dumps under tasks/<id>/reviews/ — must not survive into the new
-    # run: a prior run's files let the agent "resume" stale data or bless
-    # them via a DoD-reviewer subagent instead of re-collecting, which is
-    # exactly the freshness hole this closes. Incremental resume that
-    # WANTS to keep banked progress (ad-audit reports/TSVs) goes through
-    # Continue (POST /messages), which never wipes — see
+    # workspace (best-effort). Leftover run data (above all review dumps
+    # under tasks/<id>/reviews/) must not survive: it lets the agent
+    # "resume" stale data instead of re-collecting — the freshness hole
+    # this closes. Incremental resume that keeps banked progress goes
+    # through Continue (POST /messages), which never wipes — see
     # test_wf_continue_vs_retry.
     try:
         await workspace_manager.prepare_task_workspace(task_id, clean=True)

--- a/app/workspace/manager.py
+++ b/app/workspace/manager.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 import os
 from pathlib import Path
+import re
 import shutil
 import time
 
@@ -630,3 +631,62 @@ def reset_task_runtime_state(task_id: str) -> None:
     )
     cwd_key = str(task_dir).replace('/', '-').replace('.', '-')
     shutil.rmtree(claude_home / 'projects' / cwd_key, ignore_errors=True)
+
+
+# A background shell command's start marker in the transcript. Claude
+# Code auto-backgrounds any Bash that exceeds its blocking budget (a slow
+# ``find`` over a big tree is the classic case) and stamps it with an id.
+_BG_START_RE = re.compile(
+    r'backgroundTaskId"\s*:\s*"([\w-]+)"'
+    r'|(?:moved to the background|running in background'
+    r'|backgrounded by user) with ID: ([\w-]+)'
+)
+# A completed/stopped background task carries its id inside a
+# ``<task-notification>`` block; an orphan (killed by teardown) never does.
+_TASK_NOTIFY_ID_RE = re.compile(r'<task-id>([\w-]+)</task-id>')
+
+
+def _session_transcript_path(task_id: str, session_id: str) -> Path:
+    """Where Claude Code stores this session's transcript.
+
+    Keyed by the workspace CWD (each ``/`` and ``.`` → ``-``), matching
+    ``reset_task_runtime_state``.
+    """
+    task_dir = VIBE_SELLER_DIR / 'tasks' / task_id
+    claude_home = Path(
+        os.environ.get('CLAUDE_CONFIG_DIR') or (Path.home() / '.claude')
+    )
+    cwd_key = str(task_dir).replace('/', '-').replace('.', '-')
+    return claude_home / 'projects' / cwd_key / f'{session_id}.jsonl'
+
+
+def session_has_orphaned_bg_task(task_id: str, session_id: str | None) -> bool:
+    """True if the prior session left a background shell command running.
+
+    Resuming such a session with ``claude --resume`` makes Claude Code
+    inject a background-task reconciliation ``<task-notification>`` into
+    the input queue. When that lands in the same instant as a user
+    follow-up (the resume prompt), the CLI aborts the turn's tool calls
+    (``CANCEL_MESSAGE``) — so e.g. a confirm-gated ``generate_image``
+    dies *before* reaching its gate and the follow-up silently does
+    nothing. The caller uses this to start a FRESH session (seeded with
+    compacted history) instead of resuming, so no reconciliation fires.
+
+    An orphan = a background-start id in the transcript with no matching
+    ``<task-notification>`` (a cleanly-finished task always has one; a
+    task killed by our process-group teardown never does). Best-effort:
+    any read/parse failure returns False (resume as normal).
+    """
+    if not session_id:
+        return False
+    path = _session_transcript_path(task_id, session_id)
+    try:
+        text = path.read_text(encoding='utf-8', errors='ignore')
+    except OSError:
+        return False
+    started = {a or b for a, b in _BG_START_RE.findall(text)}
+    started.discard('')
+    if not started:
+        return False
+    notified = set(_TASK_NOTIFY_ID_RE.findall(text))
+    return bool(started - notified)

--- a/tests/unit/test_followup_gate.py
+++ b/tests/unit/test_followup_gate.py
@@ -8,6 +8,10 @@
   NOTE (not the user's message, not recorded as answers) + emits
   ``task_question_interrupted`` — so a composer follow-up interrupts the
   card instead of being force-submitted as its answer.
+- ``session_has_orphaned_bg_task`` detects a prior run that left a
+  background shell running, so the follow-up spawns a FRESH session
+  instead of ``--resume`` (a resume would inject a reconciliation
+  notification that collides with the follow-up and aborts the turn).
 """
 
 import asyncio
@@ -45,6 +49,61 @@ def test_reset_task_runtime_state_wipes_everything(tmp_path, monkeypatch):
     assert not ws.exists(), 'workspace (uploads etc.) must be wiped'
     assert not store.exists(), 'Claude Code Task/todo store must be wiped'
     assert not proj.exists(), 'Claude Code project transcripts must be wiped'
+
+
+def _write_transcript(
+    tmp_path, monkeypatch, task_id: str, session_id: str, body: str
+) -> None:
+    """Write a fake Claude Code transcript at the path the detector reads."""
+    vibe = tmp_path / 'vibe'
+    claude = tmp_path / 'claude'
+    monkeypatch.setattr(mgr, 'VIBE_SELLER_DIR', vibe)
+    monkeypatch.setenv('CLAUDE_CONFIG_DIR', str(claude))
+    ws = vibe / 'tasks' / task_id
+    cwd_key = str(ws).replace('/', '-').replace('.', '-')
+    proj = claude / 'projects' / cwd_key
+    proj.mkdir(parents=True)
+    (proj / f'{session_id}.jsonl').write_text(body, encoding='utf-8')
+
+
+_BG_START = (
+    '{"type":"user","message":{"content":[{"type":"tool_result",'
+    '"content":"Command running in background with ID: bgtask-x1"}]},'
+    '"tool_use_result":{"backgroundTaskId":"bgtask-x1"}}\n'
+)
+_BG_DONE = (
+    '{"type":"user","message":{"content":[{"type":"text","text":'
+    '"<task-notification>\\n<task-id>bgtask-x1</task-id>\\n'
+    '<status>completed</status>\\n</task-notification>"}]}}\n'
+)
+
+
+def test_orphan_bg_task_no_session_is_false():
+    assert mgr.session_has_orphaned_bg_task('t', None) is False
+
+
+def test_orphan_bg_task_missing_transcript_is_false(tmp_path, monkeypatch):
+    monkeypatch.setattr(mgr, 'VIBE_SELLER_DIR', tmp_path / 'vibe')
+    monkeypatch.setenv('CLAUDE_CONFIG_DIR', str(tmp_path / 'claude'))
+    assert mgr.session_has_orphaned_bg_task('t', 'no-such-session') is False
+
+
+def test_orphan_bg_task_started_without_completion_is_true(
+    tmp_path, monkeypatch
+):
+    _write_transcript(tmp_path, monkeypatch, 't', 's1', _BG_START)
+    assert mgr.session_has_orphaned_bg_task('t', 's1') is True
+
+
+def test_orphan_bg_task_completed_is_false(tmp_path, monkeypatch):
+    _write_transcript(tmp_path, monkeypatch, 't', 's1', _BG_START + _BG_DONE)
+    assert mgr.session_has_orphaned_bg_task('t', 's1') is False
+
+
+def test_orphan_bg_task_none_started_is_false(tmp_path, monkeypatch):
+    body = '{"type":"assistant","message":{"content":"hi"}}\n'
+    _write_transcript(tmp_path, monkeypatch, 't', 's1', body)
+    assert mgr.session_has_orphaned_bg_task('t', 's1') is False
 
 
 async def test_interrupt_pending_question_no_session_is_noop():


### PR DESCRIPTION
Diagnosed live on izz-mac (task `bad67c58`) via `/debug-task`: an image **revise** follow-up made the agent try `generate_image` three times, each silently cancelled — no confirm card, no image — and the task ended with a plan instead.

## Root cause

1. Early in the run the agent ran a slow shell command (a broad `find` for the uploaded reference images). Claude Code **auto-backgrounds** any command that exceeds its blocking budget, stamping it with an id.
2. When the run finished (COMPLETED), our teardown killed the process group (`os.killpg`). The backgrounded command died **with no completion record**.
3. The follow-up resumed the session (`claude --resume`). On resume, Claude Code scanned the transcript, found the orphaned background task, and injected a reconciliation `<task-notification>` into the input queue **in the same instant** as the follow-up.
4. The two concurrent inputs aborted the turn. When `generate_image` went to execute, the CLI's `abortController` was already set, so it returned `CANCEL_MESSAGE` ("The user doesn't want to take this action…") **before the permission check or our confirm gate ran** — hence no `image_request`, no card, and (because the abort sticks) all 3 retries cancelled.

The confirm gate itself was never the problem: `generate_image` is unconditionally confirm-gated. The tool was just killed before reaching it.

## Fix

`session_has_orphaned_bg_task(task_id, session_id)` (in `app/workspace/manager.py`) scans the prior session's transcript for a background-start id (`backgroundTaskId` / "running in background with ID: …") that has **no matching `<task-notification>`** — a cleanly-finished task always has one; a task killed by teardown never does.

When a follow-up would `--resume` such a session, `send_task_message` instead starts a **fresh session seeded with the compacted history** it already builds (same mechanism as the existing context-rot guard). No resume ⇒ no reconciliation notification ⇒ no collision. A fresh session mints a new session id, so the orphan is left behind in the old transcript and never re-resumed.

- Precise, not broad: a background task that completed cleanly still resumes normally.
- Best-effort: any transcript read/parse error falls back to resuming as before.

## Tests

`tests/unit/test_followup_gate.py`: no session → False; missing transcript → False; started-without-completion → True; completed → False; none-started → False.

## Docs

New SSE event `image_request_interrupted` etc. were documented in `docs/events.md` under #113; this PR adds no new events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9p1mvGVPimwVG3WcQ7P26
