### PR TITLE
fix(agent): stop silent-failure classes in browser launch, retry and gates

### DIFF
--- a/.claude/skills/debug-store/SKILL.md
+++ b/.claude/skills/debug-store/SKILL.md
@@ -80,9 +80,15 @@ The wrapper:
 2. Validates the session name against `^<slug>(-aux|-[0-9a-fA-F]{8})?$`.
 3. Auto-starts the CDP proxy + Ziniao Chrome by calling
    `POST http://127.0.0.1:7777/api/stores/<store_id>/browser/start`
-   with a hardcoded `ai_bot` JWT. Polls until 9222 responds.
-4. Injects `--cdp-url ws://127.0.0.1:9222/client-<VIBE_TASK_ID>` so the
-   browser-use daemon connects through the mux proxy as a unique client.
+   with a hardcoded `ai_bot` JWT. Polls until **that store's** proxy port
+   responds — ports are allocated per store from `_BASE_PROXY_PORT`
+   (9222), so real stores sit on 9223, 9226, 9227… Read the actual port
+   out of the wrapper (`grep -o '127\.0\.0\.1:9[0-9]\{3\}'`) or the
+   `browser_sessions` row; never assume 9222.
+4. Exports `BU_CDP_WS=ws://127.0.0.1:<proxy_port>/client-<VIBE_TASK_ID>`
+   so the browser-use daemon connects through the mux proxy as a unique
+   client. (browser-use 0.13 dropped `--cdp-url` for this env var — the
+   wrapper *rejects* `--cdp-url`, see the blocked-flags list above.)
 5. Execs the real `browser-use` binary with the rest of the args.
 
 The wrapper blocks `--profile`, `--cdp-url`, and `--connect` flags
@@ -148,9 +154,22 @@ everything else.
 To verify the CDP proxy is actually responding:
 
 ```bash
-curl -sf -m 2 http://127.0.0.1:9222/json/version | head -1
-ps aux | grep -E "ziniaobrowser|cdp_mux_proxy" | grep -v grep
+# This store's mux port — NOT a fixed 9222 (allocated per store).
+PORT=$(grep -oE '127\.0\.0\.1:9[0-9]{3}' ~/.vibe-seller/bin/<slug>/browser-use | head -1 | cut -d: -f2)
+curl -sf -m 2 --noproxy '*' "http://127.0.0.1:$PORT/json/version"
+ps aux | grep -E "ziniaobrowser" | grep -v grep
 ```
+
+`--noproxy '*'` matters: with ClashX/etc. exported, curl sends the
+loopback request to the proxy and you get an empty body instead of a
+connection error — which reads as "the browser is up but broken".
+The mux proxy is an asyncio server **inside** the FastAPI process, so
+`grep cdp_mux_proxy` in `ps` finds nothing even when it is running.
+
+**Wedge signature:** the port accepts the TCP connection and then never
+answers (curl hangs to `-m` timeout, HTTP 000). Distinct from a clean
+"connection refused" — see
+[docs/ziniao-concurrency.md](../../../docs/ziniao-concurrency.md) runbook.
 
 ## Skipping JWT-cookie auth
 
@@ -228,10 +247,18 @@ The API surface (full list in `docs/api.md`) breaks into a few groups:
 | Group | Common routes | Use for |
 |---|---|---|
 | Auth | `POST /api/auth/login`, `GET /api/auth/me`, `POST /api/auth/logout` | Cookie lifecycle |
-| Stores | `GET /api/stores`, `GET /api/stores/<id>`, `POST /api/stores/<id>/browser/start`, `POST /api/stores/<id>/browser/stop` | Store metadata + per-store browser lifecycle |
+| Stores | `GET /api/stores`, `GET /api/stores/<id>`, `POST /api/stores/<id>/browser/start` (`?force=1`), `POST /api/stores/<id>/browser/aux/start` | Store metadata + per-store browser lifecycle |
 | Tasks | `POST /api/tasks`, `GET /api/tasks`, `GET /api/tasks/<id>`, `POST /api/tasks/<id>/messages`, `POST /api/tasks/<id>/stop` | Create / list / inspect / message / stop tasks |
 | Schedules | `GET /api/schedules`, `POST /api/schedules`, `POST /api/schedules/<id>/run` | Cron-style routines |
 | Events | `GET /api/events/stream` (SSE), `GET /api/events/recent` | Live + historical event feed |
+
+> **There is no `browser/stop` route** — stopping is internal only
+> (`BrowserManager.stop_session` / `aux_browser.stop_aux`, called by store
+> deletion and the idle sweeper). To stop one store's env by hand, send
+> Ziniao's own per-store `stopBrowser` with that store's `browser_oauth`;
+> never kill the shared Ziniao client, which would destroy every other
+> store's live browser (see
+> [docs/ziniao-concurrency.md](../../../docs/ziniao-concurrency.md)).
 
 Keys to remember:
 
@@ -473,8 +500,14 @@ what worked, not the per-run captures.
 - **The `aux` session for non-seller-center sites:** when you need to
   visit `amazon.com/dp/<ASIN>` (public product page) for a probe
   without disrupting the main seller-central session, use
-  `--session <slug>-aux`. It's a Chrome-direct (no CDP proxy) session
-  that the wrapper allows even in task-mode.
+  `--session <slug>-aux` — the one override the wrapper allows in
+  task-mode. It is **not** "Chrome-direct": since wrapper format v3/v4
+  every session gets an explicit `BU_CDP_WS`, and for a Ziniao store
+  `-aux` is that store's own dedicated login-less Chromium on its own
+  proxy (see § Wrapper architecture above). The old endpoint-less
+  exemption is what let a daemon attach to a *different* store's
+  browser. `-aux` has **no seller login** — never use it for seller
+  central.
 
 ## Things this skill is NOT
 

--- a/app/ai/stop_gates/ad_scale_winners.py
+++ b/app/ai/stop_gates/ad_scale_winners.py
@@ -78,6 +78,31 @@ def _is_separator(cells: list[str]) -> bool:
     return bool(nonempty) and all(_SEP_RE.fullmatch(c) for c in nonempty)
 
 
+def _has_bid(cells: list[str], col: dict[str, int]) -> bool:
+    """True only if this row carries an actual numeric bid.
+
+    A bid rule may only judge a row that HAS a bid. Campaign-level
+    aggregate rows (``全活动``, auto/Brand placements with no per-term
+    bid control) are written with an empty or ``-`` bid cell — there is
+    nothing to raise, so "raise the bid or justify the hold" is
+    unsatisfiable. The agent then rewrites the report forever trying to
+    appease a gate it cannot pass (observed: ~34 review rounds, ending
+    in renamed columns and zeroed values). Structural, not prose: this
+    kills the whole class rather than growing ``_BLOCKER_RE`` one
+    excuse at a time.
+
+    Deliberately NOT mirrored in ``ad_bid_floor``: that gate *forbids*
+    an action ("never lower a profitable bid"), so a bid-less row that
+    still recommends a cut is itself a real defect worth catching. Only
+    a gate that *demands* an action has to prove the action is possible.
+    """
+    i = col.get('bid')
+    if i is None or i >= len(cells):
+        # Can't verify → don't flag (module-wide fail-open stance).
+        return False
+    return _NUM_RE.search(cells[i].replace(',', '')) is not None
+
+
 def _roas_from(cells: list[str], col: dict[str, int]) -> float | None:
     """Return the row's ROAS, from a ROAS column or 100/ACOS%."""
     if 'roas' in col and col['roas'] < len(cells):
@@ -139,6 +164,8 @@ def check(
                     col.setdefault('roas', i)
                 elif h in ('建议', 'recommendation'):
                     col['rec'] = i
+                elif ('出价' in h) or (h == 'bid'):
+                    col.setdefault('bid', i)
                 elif ('关键词' in h) or (h in ('keyword', 'target')):
                     col.setdefault('name', i)
             col.setdefault('name', 0)
@@ -150,6 +177,9 @@ def check(
         if rec_i >= len(cells):
             continue
         rec = cells[rec_i]
+        # No bid on this row → no bid rule. See _has_bid.
+        if not _has_bid(cells, col):
+            continue
         # Only care about rows recommended as a hold (no raise verb).
         if not _HOLD_RE.search(rec) or _RAISE_RE.search(rec):
             continue

--- a/app/browser/launch_guards.py
+++ b/app/browser/launch_guards.py
@@ -1,0 +1,103 @@
+"""Guards around launching a store's browser.
+
+``BrowserManager.start_session`` holds a **global** lock — deliberately,
+so concurrent launches can't hammer the shared anti-detect client (see
+docs/ziniao-concurrency.md). That makes one store's failure everyone's
+problem: an unbounded per-store retry loop starves every other store's
+launch, and the dead-mux relaunch path is reachable from *every*
+``browser-use`` call, so a wedged client turns recovery into a storm.
+
+Both guards below bound that blast radius. They live here rather than on
+the manager because they are policy, independently testable, and the
+manager is already at the repo's file-size ceiling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+from app.browser.base import BrowserSessionInfo
+from app.env_options import Options
+
+logger = logging.getLogger(__name__)
+
+
+class RelaunchBudget:
+    """Per-store budget for the dead-mux full-env relaunch.
+
+    Relaunching tears down and re-creates a store's whole browser env.
+    With the client wedged every attempt fails identically, so the
+    unbudgeted version loops forever — the observed failure was three
+    stores cycling stop/start every ~20 s for five minutes, which
+    hammered the shared client until it hung and left every agent on a
+    freshly-wiped, logged-out browser. Bounding it turns that storm into
+    one actionable failure.
+    """
+
+    def __init__(self) -> None:
+        self._seen: dict[str, list[float]] = {}
+
+    def clear(self, store_id: str) -> None:
+        """Forget a store's history — call after a healthy launch so the
+        breaker only trips on a *run* of failures, not on occasional
+        recoveries spread across a long session."""
+        self._seen.pop(store_id, None)
+
+    def note(self, store_id: str, store_name: str) -> None:
+        """Record one relaunch; raise once the budget is spent."""
+        limit = Options.BROWSER_RELAUNCH_MAX.get_int()
+        window = Options.BROWSER_RELAUNCH_WINDOW_S.get_float()
+        if limit <= 0 or window <= 0:
+            return
+        now = time.monotonic()
+        recent = [t for t in self._seen.get(store_id, []) if now - t < window]
+        if len(recent) >= limit:
+            oldest = int(now - recent[0])
+            self._seen[store_id] = recent
+            raise RuntimeError(
+                f'Browser for {store_name} has been relaunched '
+                f'{len(recent)} times in the last {oldest}s and its CDP '
+                f'proxy is still dead. Refusing to restart again — '
+                f'repeated relaunches wipe the browser session and can '
+                f'wedge the shared Ziniao client. Check that Ziniao is '
+                f'running in WebDriver mode and responding, then retry '
+                f'(Settings → Ziniao → Force Restart).'
+            )
+        recent.append(now)
+        self._seen[store_id] = recent
+
+
+async def start_backend_bounded(backend, browser_config: dict, store_name: str):
+    """``backend.start()`` with a hard ceiling on how long it may run.
+
+    Runs under the manager's global lock, so a store stuck in its own
+    retry loop would otherwise block every other store's launch for
+    minutes (4 Ziniao attempts x ~95 s). One broken store must fail
+    fast, not stall the machine.
+
+    On timeout the half-started env is torn down — the Ziniao backend
+    captures its per-store ``stopBrowser`` payload early in ``start()``,
+    so this closes THIS env only and never touches a peer.
+    """
+    timeout = Options.BROWSER_START_TIMEOUT_S.get_float()
+    if timeout <= 0:
+        return await backend.start(browser_config)
+    try:
+        return await asyncio.wait_for(
+            backend.start(browser_config), timeout=timeout
+        )
+    except TimeoutError:
+        try:
+            await backend.stop(BrowserSessionInfo())
+        except Exception as e:
+            logger.warning(
+                'Cleanup after start timeout failed for %s: %s', store_name, e
+            )
+        raise RuntimeError(
+            f'Browser launch for {store_name} exceeded {timeout:.0f}s and '
+            f'was aborted so it could not block other stores. This store '
+            f'failed to start; other stores are unaffected. Retry the '
+            f'task — if it persists, restart Ziniao (Settings → Ziniao).'
+        ) from None

--- a/app/browser/manager.py
+++ b/app/browser/manager.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import tempfile
+import time
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -35,6 +36,7 @@ from app.config import (
     WEB_BROWSER_SLUG,
 )
 from app.database import async_session
+from app.env_options import Options
 from app.models.app_settings import AppSettings
 from app.models.browser_session import BrowserSession
 from app.models.store import Store
@@ -110,45 +112,93 @@ async def _kill_all_browser_daemons() -> int:
         return 0
 
 
-def _wipe_generated_wrappers() -> int:
-    """Delete OUTDATED auto-generated browser-use wrappers on boot.
+def _wipe_generated_wrappers(live_store_ids: set[str] | None = None) -> int:
+    """Delete OUTDATED or ORPHANED auto-generated wrappers on boot.
 
-    In-place-upgrade safety: a wrapper left by an OLDER version drives a
-    stale CLI/env contract and would misbehave if invoked before the next
-    task launch regenerates it. So we remove wrappers whose embedded
-    format version is BELOW the current ``WRAPPER_FORMAT_VERSION`` (and
-    unmarked/pre-versioning ones, treated as version 0).
+    Two independent reasons to remove a wrapper:
 
-    We KEEP wrappers at the current-or-higher version: current ones
+    1. **Outdated format** (in-place-upgrade safety): a wrapper left by an
+       OLDER version drives a stale CLI/env contract and would misbehave
+       if invoked before the next task launch regenerates it. So we remove
+       wrappers whose embedded format version is BELOW the current
+       ``WRAPPER_FORMAT_VERSION`` (and unmarked/pre-versioning ones,
+       treated as version 0).
+
+    2. **Orphaned** — the store it was generated for no longer exists.
+       Version alone never reaps these, so a deleted store's wrapper
+       survived forever while holding a FROZEN ``proxy_port``. Ports are
+       re-allocated from ``_BASE_PROXY_PORT`` every boot, so that number
+       eventually lands on a *live* store; the orphan then finds the port
+       already up, skips the start API (so its dead ``store_id`` never
+       404s) and exports ``BU_CDP_WS`` straight at another store's
+       browser — wrong account, wrong downloads dir. Same cross-store
+       hole wrapper v3 closed for aux sessions (docs/browser.md).
+       Pass ``live_store_ids`` to enable this check.
+
+    We KEEP current-or-newer wrappers belonging to a live store: they
     survive a restart (no wrapper-less window → no local-Chrome fallback,
     see docs/ziniao-concurrency.md), and a running vN never deletes a
     newer vN+1's (rollback safety). User-created wrappers (no auto-gen
-    header) are untouched. See docs/browser-use-0.13-migration.md.
+    header) are untouched, and so are non-store wrappers such as
+    ``_web``/``_guard`` (no embedded store id — fail safe, keep).
+    See docs/browser-use-0.13-migration.md.
     """
     removed = 0
+    orphaned = 0
     if not BROWSER_USE_BIN_DIR.is_dir():
         return 0
+    # An EMPTY live set is far more likely "wrong/unloaded DB" than
+    # "the user deleted every store", and acting on it would delete the
+    # wrappers of stores that are actively in use. Never orphan-reap on
+    # no evidence — fall back to version-only.
+    if live_store_ids is not None and not live_store_ids:
+        live_store_ids = None
     for sub in BROWSER_USE_BIN_DIR.iterdir():
         wrapper = sub / 'browser-use'
         if not wrapper.is_file():
             continue
         try:
-            head = wrapper.read_text(errors='replace')[:400]
+            text = wrapper.read_text(errors='replace')
         except OSError:
             continue
+        head = text[:400]
         if 'Auto-generated browser-use wrapper' not in head:
             continue  # user-created wrapper — never touch
         m = re.search(rf'{re.escape(WRAPPER_FORMAT_MARKER)}\s*(\d+)', head)
         version = int(m.group(1)) if m else 0
-        if version >= WRAPPER_FORMAT_VERSION:
-            continue  # current or newer — keep (no wrapper-less window)
+        stale_format = version < WRAPPER_FORMAT_VERSION
+        # Ownership: only judge a wrapper we can actually attribute to a
+        # store. No parseable id (e.g. the store-less `_web` wrapper) →
+        # keep, so a format change here can never orphan-reap everything.
+        is_orphan = False
+        if live_store_ids is not None:
+            # Don't assume a UUID shape — match whatever the wrapper
+            # actually embeds, so a non-UUID id is still attributable.
+            owner = re.search(r'/api/stores/([^/"\s]+)/browser/', text)
+            if owner and owner.group(1) not in live_store_ids:
+                is_orphan = True
+        if not stale_format and not is_orphan:
+            continue
         try:
             wrapper.unlink()
             removed += 1
+            if is_orphan:
+                orphaned += 1
+                # Drop the now-empty dir so `ls bin/` reflects reality.
+                try:
+                    sub.rmdir()
+                except OSError:
+                    pass
         except OSError:
             pass
     if removed:
-        logger.info('Boot: wiped %d outdated browser-use wrapper(s)', removed)
+        logger.info(
+            'Boot: wiped %d browser-use wrapper(s) (%d outdated, '
+            '%d orphaned — store no longer exists)',
+            removed,
+            removed - orphaned,
+            orphaned,
+        )
     return removed
 
 
@@ -232,6 +282,12 @@ class BrowserManager:
         self._active_ziniao_account_id: str | None = None
         # store_id -> store_name for active ziniao stores
         self._ziniao_stores: dict[str, str] = {}
+        # Circuit breaker for the dead-mux relaunch path: store_id ->
+        # monotonic timestamps of recent full-env relaunches. Every
+        # browser-use call can reach that path via the wrapper, so
+        # without a budget a wedged Ziniao client turns into a restart
+        # storm that deepens the wedge and wipes agent tabs mid-task.
+        self._relaunches: dict[str, list[float]] = {}
 
     @staticmethod
     async def _cdp_alive(port: int, timeout: float = 2.0) -> bool:
@@ -278,6 +334,41 @@ class BrowserManager:
                 await asyncio.sleep(gap)
         return False
 
+    def _note_relaunch(self, store: Store) -> None:
+        """Record a dead-mux relaunch; raise once the budget is spent.
+
+        The relaunch tears down and re-creates the whole store env, and
+        the wrapper can reach it on every single ``browser-use`` call.
+        When the Ziniao client itself is wedged, each relaunch fails the
+        same way, so the unbudgeted version loops indefinitely — the
+        observed failure was three stores cycling stop/start every ~20 s
+        for five minutes, which hammered the shared client until it hung
+        and left every agent on a freshly-wiped, logged-out browser.
+        Bounding it converts that storm into one actionable failure.
+        """
+        limit = Options.BROWSER_RELAUNCH_MAX.get_int()
+        window = Options.BROWSER_RELAUNCH_WINDOW_S.get_float()
+        if limit <= 0 or window <= 0:
+            return
+        now = time.monotonic()
+        recent = [
+            t for t in self._relaunches.get(store.id, []) if now - t < window
+        ]
+        if len(recent) >= limit:
+            oldest = int(now - recent[0])
+            self._relaunches[store.id] = recent
+            raise RuntimeError(
+                f'Browser for {store.name} has been relaunched '
+                f'{len(recent)} times in the last {oldest}s and its CDP '
+                f'proxy is still dead. Refusing to restart again — '
+                f'repeated relaunches wipe the browser session and can '
+                f'wedge the shared Ziniao client. Check that Ziniao is '
+                f'running in WebDriver mode and responding, then retry '
+                f'(Settings → Ziniao → Force Restart).'
+            )
+        recent.append(now)
+        self._relaunches[store.id] = recent
+
     async def cleanup_stale_sessions(self) -> int:
         """Mark stale 'running' sessions as idle and kill orphans.
 
@@ -294,12 +385,16 @@ class BrowserManager:
         #      shape this code emits (>=0.13),
         #  (a) wipe stale wrapper scripts so a pre-upgrade (0.12-shaped)
         #      wrapper is never invoked before it self-heals on the next
-        #      task launch,
+        #      task launch, and orphaned ones whose store is gone (their
+        #      frozen proxy_port can later point at a LIVE store),
         #  (b) reap orphaned daemons (both 0.13 pid-file + legacy 0.12
         #      cmdline) — preserves daemons for active tasks (e.g. WAITING
         #      tasks that survive a restart).
         warn_on_browser_use_version_mismatch()
-        _wipe_generated_wrappers()
+        async with async_session() as db:
+            rows = await db.execute(select(Store.id))
+            live_store_ids = {sid for (sid,) in rows.all()}
+        _wipe_generated_wrappers(live_store_ids)
         await reap_orphaned_daemons()
 
         async with async_session() as db:
@@ -404,6 +499,13 @@ class BrowserManager:
                 )
                 self._active_sessions.pop(store.id, None)
             elif not await self._cdp_alive_with_retry(proxy_port):
+                # Tearing the env down and relaunching is the recovery,
+                # but it is reachable from EVERY browser-use call via
+                # the wrapper. Budget it per store, else a wedged
+                # Ziniao client produces an endless stop/start storm
+                # (each cycle also destroys the agent's tabs and login
+                # state mid-task). Past the budget, fail loudly.
+                self._note_relaunch(store)
                 logger.warning(
                     'CDP proxy :%s not responding for %s — forcing restart',
                     proxy_port,
@@ -515,8 +617,43 @@ class BrowserManager:
             store.name,
             store.browser_backend,
         )
-        info = await backend.start(browser_config)
+        # Bounded: this call runs under the GLOBAL _lock, so a store
+        # stuck in its per-store retry loop would otherwise block every
+        # other store's launch for minutes (4 Ziniao attempts × ~95 s).
+        # One broken store must fail fast, not stall the machine.
+        start_timeout = Options.BROWSER_START_TIMEOUT_S.get_float()
+        try:
+            if start_timeout > 0:
+                info = await asyncio.wait_for(
+                    backend.start(browser_config), timeout=start_timeout
+                )
+            else:
+                info = await backend.start(browser_config)
+        except TimeoutError:
+            # Tear the half-started env down so it can't linger without
+            # a proxy. ZiniaoBackend captures its per-store stopBrowser
+            # payload early in start(), so this closes THIS env only.
+            self._backends.pop(store.id, None)
+            try:
+                await backend.stop(BrowserSessionInfo())
+            except Exception as e:
+                logger.warning(
+                    'Cleanup after start timeout failed for %s: %s',
+                    store.name,
+                    e,
+                )
+            raise RuntimeError(
+                f'Browser launch for {store.name} exceeded '
+                f'{start_timeout:.0f}s and was aborted so it could not '
+                f'block other stores. This store failed to start; other '
+                f'stores are unaffected. Retry the task — if it '
+                f'persists, restart Ziniao (Settings → Ziniao).'
+            ) from None
         self._active_sessions[store.id] = info
+        # A healthy launch clears the relaunch budget — the breaker
+        # should only trip on a *run* of failures, not on occasional
+        # recoveries spread over a long session.
+        self._relaunches.pop(store.id, None)
 
         # Track active Ziniao account
         if store.browser_backend == 'ziniao' and store.ziniao_account_id:

--- a/app/browser/manager.py
+++ b/app/browser/manager.py
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 import tempfile
-import time
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -15,12 +14,12 @@ from app.auth import create_token
 from app.browser.base import BrowserBackend, BrowserSessionInfo
 from app.browser.bh_daemons import LEGACY_DAEMON_PATTERN, kill_bh_daemons
 from app.browser.daemon_reaper import reap_orphaned_daemons
+from app.browser.launch_guards import RelaunchBudget, start_backend_bounded
 from app.browser.web_wrapper import write_web_browser_use_wrapper
 from app.browser.wrapper import (
-    WRAPPER_FORMAT_MARKER,
-    WRAPPER_FORMAT_VERSION,
     remove_browser_use_wrapper,
     store_slug,
+    wipe_generated_wrappers,
     write_browser_use_wrapper,
 )
 from app.browser.ziniao_utils import (
@@ -30,13 +29,11 @@ from app.browser.ziniao_utils import (
 )
 from app.config import (
     AI_BOT_USER_ID,
-    BROWSER_USE_BIN_DIR,
     DEMO_MODE,
     LOCALHOST,
     WEB_BROWSER_SLUG,
 )
 from app.database import async_session
-from app.env_options import Options
 from app.models.app_settings import AppSettings
 from app.models.browser_session import BrowserSession
 from app.models.store import Store
@@ -110,96 +107,6 @@ async def _kill_all_browser_daemons() -> int:
         return total
     except Exception:
         return 0
-
-
-def _wipe_generated_wrappers(live_store_ids: set[str] | None = None) -> int:
-    """Delete OUTDATED or ORPHANED auto-generated wrappers on boot.
-
-    Two independent reasons to remove a wrapper:
-
-    1. **Outdated format** (in-place-upgrade safety): a wrapper left by an
-       OLDER version drives a stale CLI/env contract and would misbehave
-       if invoked before the next task launch regenerates it. So we remove
-       wrappers whose embedded format version is BELOW the current
-       ``WRAPPER_FORMAT_VERSION`` (and unmarked/pre-versioning ones,
-       treated as version 0).
-
-    2. **Orphaned** — the store it was generated for no longer exists.
-       Version alone never reaps these, so a deleted store's wrapper
-       survived forever while holding a FROZEN ``proxy_port``. Ports are
-       re-allocated from ``_BASE_PROXY_PORT`` every boot, so that number
-       eventually lands on a *live* store; the orphan then finds the port
-       already up, skips the start API (so its dead ``store_id`` never
-       404s) and exports ``BU_CDP_WS`` straight at another store's
-       browser — wrong account, wrong downloads dir. Same cross-store
-       hole wrapper v3 closed for aux sessions (docs/browser.md).
-       Pass ``live_store_ids`` to enable this check.
-
-    We KEEP current-or-newer wrappers belonging to a live store: they
-    survive a restart (no wrapper-less window → no local-Chrome fallback,
-    see docs/ziniao-concurrency.md), and a running vN never deletes a
-    newer vN+1's (rollback safety). User-created wrappers (no auto-gen
-    header) are untouched, and so are non-store wrappers such as
-    ``_web``/``_guard`` (no embedded store id — fail safe, keep).
-    See docs/browser-use-0.13-migration.md.
-    """
-    removed = 0
-    orphaned = 0
-    if not BROWSER_USE_BIN_DIR.is_dir():
-        return 0
-    # An EMPTY live set is far more likely "wrong/unloaded DB" than
-    # "the user deleted every store", and acting on it would delete the
-    # wrappers of stores that are actively in use. Never orphan-reap on
-    # no evidence — fall back to version-only.
-    if live_store_ids is not None and not live_store_ids:
-        live_store_ids = None
-    for sub in BROWSER_USE_BIN_DIR.iterdir():
-        wrapper = sub / 'browser-use'
-        if not wrapper.is_file():
-            continue
-        try:
-            text = wrapper.read_text(errors='replace')
-        except OSError:
-            continue
-        head = text[:400]
-        if 'Auto-generated browser-use wrapper' not in head:
-            continue  # user-created wrapper — never touch
-        m = re.search(rf'{re.escape(WRAPPER_FORMAT_MARKER)}\s*(\d+)', head)
-        version = int(m.group(1)) if m else 0
-        stale_format = version < WRAPPER_FORMAT_VERSION
-        # Ownership: only judge a wrapper we can actually attribute to a
-        # store. No parseable id (e.g. the store-less `_web` wrapper) →
-        # keep, so a format change here can never orphan-reap everything.
-        is_orphan = False
-        if live_store_ids is not None:
-            # Don't assume a UUID shape — match whatever the wrapper
-            # actually embeds, so a non-UUID id is still attributable.
-            owner = re.search(r'/api/stores/([^/"\s]+)/browser/', text)
-            if owner and owner.group(1) not in live_store_ids:
-                is_orphan = True
-        if not stale_format and not is_orphan:
-            continue
-        try:
-            wrapper.unlink()
-            removed += 1
-            if is_orphan:
-                orphaned += 1
-                # Drop the now-empty dir so `ls bin/` reflects reality.
-                try:
-                    sub.rmdir()
-                except OSError:
-                    pass
-        except OSError:
-            pass
-    if removed:
-        logger.info(
-            'Boot: wiped %d browser-use wrapper(s) (%d outdated, '
-            '%d orphaned — store no longer exists)',
-            removed,
-            removed - orphaned,
-            orphaned,
-        )
-    return removed
 
 
 def warn_on_browser_use_version_mismatch() -> str | None:
@@ -282,12 +189,11 @@ class BrowserManager:
         self._active_ziniao_account_id: str | None = None
         # store_id -> store_name for active ziniao stores
         self._ziniao_stores: dict[str, str] = {}
-        # Circuit breaker for the dead-mux relaunch path: store_id ->
-        # monotonic timestamps of recent full-env relaunches. Every
-        # browser-use call can reach that path via the wrapper, so
-        # without a budget a wedged Ziniao client turns into a restart
-        # storm that deepens the wedge and wipes agent tabs mid-task.
-        self._relaunches: dict[str, list[float]] = {}
+        # Circuit breaker for the dead-mux relaunch path — every
+        # browser-use call can reach it via the wrapper, so without a
+        # budget a wedged Ziniao client becomes a restart storm that
+        # deepens the wedge and wipes agent tabs mid-task.
+        self._relaunches = RelaunchBudget()
 
     @staticmethod
     async def _cdp_alive(port: int, timeout: float = 2.0) -> bool:
@@ -334,41 +240,6 @@ class BrowserManager:
                 await asyncio.sleep(gap)
         return False
 
-    def _note_relaunch(self, store: Store) -> None:
-        """Record a dead-mux relaunch; raise once the budget is spent.
-
-        The relaunch tears down and re-creates the whole store env, and
-        the wrapper can reach it on every single ``browser-use`` call.
-        When the Ziniao client itself is wedged, each relaunch fails the
-        same way, so the unbudgeted version loops indefinitely — the
-        observed failure was three stores cycling stop/start every ~20 s
-        for five minutes, which hammered the shared client until it hung
-        and left every agent on a freshly-wiped, logged-out browser.
-        Bounding it converts that storm into one actionable failure.
-        """
-        limit = Options.BROWSER_RELAUNCH_MAX.get_int()
-        window = Options.BROWSER_RELAUNCH_WINDOW_S.get_float()
-        if limit <= 0 or window <= 0:
-            return
-        now = time.monotonic()
-        recent = [
-            t for t in self._relaunches.get(store.id, []) if now - t < window
-        ]
-        if len(recent) >= limit:
-            oldest = int(now - recent[0])
-            self._relaunches[store.id] = recent
-            raise RuntimeError(
-                f'Browser for {store.name} has been relaunched '
-                f'{len(recent)} times in the last {oldest}s and its CDP '
-                f'proxy is still dead. Refusing to restart again — '
-                f'repeated relaunches wipe the browser session and can '
-                f'wedge the shared Ziniao client. Check that Ziniao is '
-                f'running in WebDriver mode and responding, then retry '
-                f'(Settings → Ziniao → Force Restart).'
-            )
-        recent.append(now)
-        self._relaunches[store.id] = recent
-
     async def cleanup_stale_sessions(self) -> int:
         """Mark stale 'running' sessions as idle and kill orphans.
 
@@ -394,7 +265,7 @@ class BrowserManager:
         async with async_session() as db:
             rows = await db.execute(select(Store.id))
             live_store_ids = {sid for (sid,) in rows.all()}
-        _wipe_generated_wrappers(live_store_ids)
+        wipe_generated_wrappers(live_store_ids)
         await reap_orphaned_daemons()
 
         async with async_session() as db:
@@ -505,7 +376,7 @@ class BrowserManager:
                 # Ziniao client produces an endless stop/start storm
                 # (each cycle also destroys the agent's tabs and login
                 # state mid-task). Past the budget, fail loudly.
-                self._note_relaunch(store)
+                self._relaunches.note(store.id, store.name)
                 logger.warning(
                     'CDP proxy :%s not responding for %s — forcing restart',
                     proxy_port,
@@ -617,43 +488,21 @@ class BrowserManager:
             store.name,
             store.browser_backend,
         )
-        # Bounded: this call runs under the GLOBAL _lock, so a store
-        # stuck in its per-store retry loop would otherwise block every
-        # other store's launch for minutes (4 Ziniao attempts × ~95 s).
-        # One broken store must fail fast, not stall the machine.
-        start_timeout = Options.BROWSER_START_TIMEOUT_S.get_float()
+        # Bounded — runs under the GLOBAL _lock, so a store stuck in its
+        # own retry loop would otherwise block every other store's
+        # launch. See app/browser/launch_guards.py.
         try:
-            if start_timeout > 0:
-                info = await asyncio.wait_for(
-                    backend.start(browser_config), timeout=start_timeout
-                )
-            else:
-                info = await backend.start(browser_config)
-        except TimeoutError:
-            # Tear the half-started env down so it can't linger without
-            # a proxy. ZiniaoBackend captures its per-store stopBrowser
-            # payload early in start(), so this closes THIS env only.
+            info = await start_backend_bounded(
+                backend, browser_config, store.name
+            )
+        except RuntimeError:
             self._backends.pop(store.id, None)
-            try:
-                await backend.stop(BrowserSessionInfo())
-            except Exception as e:
-                logger.warning(
-                    'Cleanup after start timeout failed for %s: %s',
-                    store.name,
-                    e,
-                )
-            raise RuntimeError(
-                f'Browser launch for {store.name} exceeded '
-                f'{start_timeout:.0f}s and was aborted so it could not '
-                f'block other stores. This store failed to start; other '
-                f'stores are unaffected. Retry the task — if it '
-                f'persists, restart Ziniao (Settings → Ziniao).'
-            ) from None
+            raise
         self._active_sessions[store.id] = info
         # A healthy launch clears the relaunch budget — the breaker
         # should only trip on a *run* of failures, not on occasional
         # recoveries spread over a long session.
-        self._relaunches.pop(store.id, None)
+        self._relaunches.clear(store.id)
 
         # Track active Ziniao account
         if store.browser_backend == 'ziniao' and store.ziniao_account_id:

--- a/app/browser/wrapper.py
+++ b/app/browser/wrapper.py
@@ -44,7 +44,7 @@ _BIN_DIR = BROWSER_USE_BIN_DIR
 # generated wrapper's contract (env vars, CLI shape, PATH assumptions).
 #   1 = pre-0.13 (0.12 subcommand CLI: open/click/state)
 #   2 = 0.13 heredoc + BU_CDP_WS env-injection (current)
-# Boot cleanup (BrowserManager._wipe_generated_wrappers) deletes wrappers
+# Boot cleanup (``wipe_generated_wrappers`` below) deletes wrappers
 # with a version BELOW this and never touches equal-or-higher ones. So:
 #   - a stale pre-0.13 wrapper (v1 / unmarked) is removed on upgrade;
 #   - the current version's own wrappers SURVIVE a restart (no wrapper-less
@@ -498,3 +498,93 @@ def remove_browser_use_wrapper(store_name: str, store_id: str | None = None):
     if wrapper_dir.exists():
         shutil.rmtree(wrapper_dir)
         logger.info('Removed browser-use wrapper dir: %s', wrapper_dir)
+
+
+def wipe_generated_wrappers(live_store_ids: set[str] | None = None) -> int:
+    """Delete OUTDATED or ORPHANED auto-generated wrappers on boot.
+
+    Two independent reasons to remove a wrapper:
+
+    1. **Outdated format** (in-place-upgrade safety): a wrapper left by an
+       OLDER version drives a stale CLI/env contract and would misbehave
+       if invoked before the next task launch regenerates it. So we remove
+       wrappers whose embedded format version is BELOW the current
+       ``WRAPPER_FORMAT_VERSION`` (and unmarked/pre-versioning ones,
+       treated as version 0).
+
+    2. **Orphaned** — the store it was generated for no longer exists.
+       Version alone never reaps these, so a deleted store's wrapper
+       survived forever while holding a FROZEN ``proxy_port``. Ports are
+       re-allocated from ``_BASE_PROXY_PORT`` every boot, so that number
+       eventually lands on a *live* store; the orphan then finds the port
+       already up, skips the start API (so its dead ``store_id`` never
+       404s) and exports ``BU_CDP_WS`` straight at another store's
+       browser — wrong account, wrong downloads dir. Same cross-store
+       hole wrapper v3 closed for aux sessions (docs/browser.md).
+       Pass ``live_store_ids`` to enable this check.
+
+    We KEEP current-or-newer wrappers belonging to a live store: they
+    survive a restart (no wrapper-less window → no local-Chrome fallback,
+    see docs/ziniao-concurrency.md), and a running vN never deletes a
+    newer vN+1's (rollback safety). User-created wrappers (no auto-gen
+    header) are untouched, and so are non-store wrappers such as
+    ``_web``/``_guard`` (no embedded store id — fail safe, keep).
+    See docs/browser-use-0.13-migration.md.
+    """
+    removed = 0
+    orphaned = 0
+    if not _BIN_DIR.is_dir():
+        return 0
+    # An EMPTY live set is far more likely "wrong/unloaded DB" than
+    # "the user deleted every store", and acting on it would delete the
+    # wrappers of stores that are actively in use. Never orphan-reap on
+    # no evidence — fall back to version-only.
+    if live_store_ids is not None and not live_store_ids:
+        live_store_ids = None
+    for sub in _BIN_DIR.iterdir():
+        wrapper = sub / 'browser-use'
+        if not wrapper.is_file():
+            continue
+        try:
+            text = wrapper.read_text(errors='replace')
+        except OSError:
+            continue
+        head = text[:400]
+        if 'Auto-generated browser-use wrapper' not in head:
+            continue  # user-created wrapper — never touch
+        m = re.search(rf'{re.escape(WRAPPER_FORMAT_MARKER)}\s*(\d+)', head)
+        version = int(m.group(1)) if m else 0
+        stale_format = version < WRAPPER_FORMAT_VERSION
+        # Ownership: only judge a wrapper we can actually attribute to a
+        # store. No parseable id (e.g. the store-less `_web` wrapper) →
+        # keep, so a format change here can never orphan-reap everything.
+        is_orphan = False
+        if live_store_ids is not None:
+            # Don't assume a UUID shape — match whatever the wrapper
+            # actually embeds, so a non-UUID id is still attributable.
+            owner = re.search(r'/api/stores/([^/"\s]+)/browser/', text)
+            if owner and owner.group(1) not in live_store_ids:
+                is_orphan = True
+        if not stale_format and not is_orphan:
+            continue
+        try:
+            wrapper.unlink()
+            removed += 1
+            if is_orphan:
+                orphaned += 1
+                # Drop the now-empty dir so `ls bin/` reflects reality.
+                try:
+                    sub.rmdir()
+                except OSError:
+                    pass
+        except OSError:
+            pass
+    if removed:
+        logger.info(
+            'Boot: wiped %d browser-use wrapper(s) (%d outdated, '
+            '%d orphaned — store no longer exists)',
+            removed,
+            removed - orphaned,
+            orphaned,
+        )
+    return removed

--- a/app/browser/ziniao.py
+++ b/app/browser/ziniao.py
@@ -214,22 +214,38 @@ class ZiniaoBackend(BrowserBackend):
             )
 
             # Verify the browser ACTUALLY came up on that port before we
-            # build the proxy against it.
+            # build the proxy against it, AND that Ziniao finished
+            # wiring its own instrumentation into it (see
+            # _instrumentation_live — a port-only check passes for an
+            # env whose SBP layer never loaded, which is unusable).
             if await self._cdp_port_reachable(target_host, int(cdp_port)):
-                break
-
-            logger.warning(
-                'Ziniao reported startBrowser success but CDP %s:%s is '
-                'unreachable (stale launch) — attempt %d/%d.',
-                target_host,
-                cdp_port,
-                attempt,
-                MAX_ZINIAO_ATTEMPTS,
-            )
+                if await self._instrumentation_live(target_host, int(cdp_port)):
+                    break
+                logger.warning(
+                    'Ziniao env on %s:%s came up WITHOUT its instrumentation '
+                    '(SBP not injected: navigator.webdriver leaks true, so '
+                    'no account auto-fill / OTP / passkey overlay, and the '
+                    'platform will treat the session as a bot) — attempt '
+                    '%d/%d.',
+                    target_host,
+                    cdp_port,
+                    attempt,
+                    MAX_ZINIAO_ATTEMPTS,
+                )
+            else:
+                logger.warning(
+                    'Ziniao reported startBrowser success but CDP %s:%s is '
+                    'unreachable (stale launch) — attempt %d/%d.',
+                    target_host,
+                    cdp_port,
+                    attempt,
+                    MAX_ZINIAO_ATTEMPTS,
+                )
             if attempt >= MAX_ZINIAO_ATTEMPTS:
                 raise RuntimeError(
                     f'Ziniao reported a browser on {target_host}:{cdp_port} '
-                    f'but nothing is reachable there after '
+                    f'but it never came up healthy (unreachable, or up '
+                    f'without its instrumentation layer) after '
                     f'{MAX_ZINIAO_ATTEMPTS} startBrowser attempts. This '
                     f'store failed to launch; other stores are unaffected. '
                     f'Retry the task — if it persists, the Ziniao client may '
@@ -409,6 +425,94 @@ class ZiniaoBackend(BrowserBackend):
             if i < attempts - 1:
                 await asyncio.sleep(delay)
         return False
+
+    @staticmethod
+    async def _instrumentation_live(
+        host: str,
+        port: int,
+        *,
+        attempts: int = 3,
+        delay: float = 1.5,
+    ) -> bool:
+        """True unless the env is PROVEN to be missing Ziniao's own layer.
+
+        ``_cdp_port_reachable`` only proves *Chrome* is up. Ziniao
+        additionally injects its SBP content scripts into every page —
+        that layer is what masks ``navigator.webdriver``, auto-fills the
+        store account, and renders the ``紫鸟验证码服务`` OTP and
+        ``已托管账号Passkey`` overlays. An env can bind its debug port
+        with SBP dead; agents handed such a browser see no auto-fill,
+        leak ``webdriver=true`` to the platform, and get bounced to
+        ``/ap/signin`` on a login they cannot win. Probing the raw port
+        (before the mux exists) closes that gap.
+
+        Deliberately asymmetric: return False only on a *positive*
+        reading of ``navigator.webdriver === true`` on a real http(s)
+        page. Anything inconclusive (no page target yet, still on
+        about:blank, eval error) returns True so a probe failure can
+        never become a store-wide outage.
+        """
+        list_url = f'http://{host}:{port}/json/list'
+        expr = 'navigator.webdriver === true'
+        for i in range(attempts):
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(
+                        list_url,
+                        timeout=aiohttp.ClientTimeout(total=5),
+                    ) as resp:
+                        targets = await resp.json()
+                    pages = [
+                        t
+                        for t in targets
+                        if t.get('type') == 'page'
+                        and str(t.get('url', '')).startswith('http')
+                        and t.get('webSocketDebuggerUrl')
+                    ]
+                    if not pages:
+                        # Launcher page hasn't navigated yet — no verdict.
+                        if i < attempts - 1:
+                            await asyncio.sleep(delay)
+                        continue
+                    ws_url = pages[0]['webSocketDebuggerUrl']
+                    async with session.ws_connect(ws_url, timeout=10) as ws:
+                        await ws.send_json({
+                            'id': 1,
+                            'method': 'Runtime.evaluate',
+                            'params': {
+                                'expression': expr,
+                                'returnByValue': True,
+                            },
+                        })
+                        deadline = asyncio.get_event_loop().time() + 8
+                        while asyncio.get_event_loop().time() < deadline:
+                            remaining = (
+                                deadline - asyncio.get_event_loop().time()
+                            )
+                            msg = await asyncio.wait_for(
+                                ws.receive_json(), timeout=remaining
+                            )
+                            if msg.get('id') != 1:
+                                continue
+                            leaked = (
+                                msg.get('result', {})
+                                .get('result', {})
+                                .get('value')
+                            )
+                            # Only a positive leak is a verdict; False
+                            # (masked) and None (eval error) both pass.
+                            return leaked is not True
+            except Exception as e:
+                logger.debug('Instrumentation probe attempt %d: %s', i + 1, e)
+            if i < attempts - 1:
+                await asyncio.sleep(delay)
+        # Never got a reading — do not block the launch on that.
+        logger.debug(
+            'Instrumentation probe inconclusive for %s:%s — proceeding',
+            host,
+            port,
+        )
+        return True
 
     @staticmethod
     async def _wait_for_target_stability(

--- a/app/env_options.py
+++ b/app/env_options.py
@@ -36,6 +36,15 @@ class Options(enum.Enum):
     # Logging
     LOG_LEVEL = ('LOG_LEVEL', 'INFO')
 
+    # Backend log rotation (app/logging_setup.py). Rolls on size OR age,
+    # whichever comes first; at most BACKUP_COUNT old files are kept, so
+    # the on-disk ceiling is MAX_BYTES * (BACKUP_COUNT + 1). Defaults:
+    # 5 GiB / 7 days / 1 backup → never more than 10 GiB or 2 weeks.
+    # Both MAX_BYTES and ROTATE_DAYS at 0 disables rotation.
+    LOG_MAX_BYTES = ('LOG_MAX_BYTES', str(5 * 1024**3))
+    LOG_ROTATE_DAYS = ('LOG_ROTATE_DAYS', '7')
+    LOG_BACKUP_COUNT = ('LOG_BACKUP_COUNT', '1')
+
     # AI Agent
     AGENT_DEBUG = ('AGENT_DEBUG', 'false')
     MOCK_CLI = ('MOCK_CLI', '')
@@ -64,6 +73,23 @@ class Options(enum.Enum):
     # (0 = unbounded). See app/browser/idle_sweep.py.
     BROWSER_IDLE_S = ('VIBE_BROWSER_IDLE_S', '300')
     TAB_CAP = ('VIBE_TAB_CAP', '12')
+
+    # Circuit breaker on the dead-mux full-env relaunch in
+    # BrowserManager.start_session: at most RELAUNCH_MAX relaunches per
+    # store within RELAUNCH_WINDOW_S, after which the start fails with
+    # an actionable error instead of restarting forever (0 = unbounded).
+    # A wedged Ziniao client otherwise turns every browser-use call
+    # into another stop/start cycle. See app/browser/manager.py.
+    BROWSER_RELAUNCH_MAX = ('VIBE_BROWSER_RELAUNCH_MAX', '3')
+    BROWSER_RELAUNCH_WINDOW_S = ('VIBE_BROWSER_RELAUNCH_WINDOW_S', '600')
+
+    # Hard ceiling on one store's browser launch. start_session holds a
+    # GLOBAL lock (deliberate — it serializes Ziniao startBrowser so the
+    # shared client isn't hammered concurrently), so an unbounded
+    # per-store retry loop starves every OTHER store's launch. Cap it so
+    # a broken store fails fast instead of taking the machine with it
+    # (0 = unbounded). See app/browser/manager.py.
+    BROWSER_START_TIMEOUT_S = ('VIBE_BROWSER_START_TIMEOUT_S', '180')
 
     # Sync
     KNOWLEDGE_REPO_URL = ('KNOWLEDGE_REPO_URL', '')

--- a/app/logging_setup.py
+++ b/app/logging_setup.py
@@ -1,0 +1,145 @@
+"""Bounded logging for the backend.
+
+``--dev`` sets ``LOG_LEVEL=DEBUG``, which turns on per-statement chatter
+from ``aiosqlite``/``httpcore``/``websockets`` — a long dev session with
+a few concurrent tasks produced a **5 GB** ``backend_<port>.log``. The
+handler was a plain ``logging.FileHandler``, so nothing ever bounded it.
+
+Rotation fires on size **or** age, whichever comes first, because either
+alone misses a real case: a quiet week still ages out, and a busy
+afternoon still blows the size cap.
+
+Why not subclass ``TimedRotatingFileHandler`` and bolt a size check onto
+``shouldRollover``: since Python 3.12 its ``doRollover`` returns early
+when the timestamped backup already exists ("already rolled over"). A
+second size-triggered rollover inside the same time window computes the
+same name, hits that guard, and silently does nothing — the file grows
+unbounded again while ``shouldRollover`` keeps saying yes. So this owns
+rotation outright, with plain numbered backups.
+"""
+
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import os
+from pathlib import Path
+import time
+
+from app.env_options import Options
+
+
+class SizeAndTimeRotatingFileHandler(logging.handlers.BaseRotatingHandler):
+    """Roll on size OR age; keep ``backup_count`` numbered backups.
+
+    Backups are ``<log>.1`` (newest) … ``<log>.<backup_count>``; the
+    oldest is deleted as the others shift down, so the on-disk total is
+    bounded by ``max_bytes * (backup_count + 1)``.
+
+    The age anchor is the current file's mtime at construction (or now,
+    for a fresh file), and resets on every rollover. A restart therefore
+    re-anchors the clock — the size cap is the hard guarantee, age is
+    best-effort housekeeping for a log too quiet to ever hit the cap.
+    """
+
+    def __init__(
+        self,
+        filename,
+        *,
+        max_bytes: int = 0,
+        rotate_seconds: float = 0,
+        backup_count: int = 1,
+        encoding: str | None = None,
+        delay: bool = False,
+    ):
+        super().__init__(filename, 'a', encoding=encoding, delay=delay)
+        self.max_bytes = max_bytes
+        self.rotate_seconds = rotate_seconds
+        self.backup_count = backup_count
+        self.rollover_at = self._compute_rollover(initial=True)
+
+    def _compute_rollover(self, *, initial: bool = False) -> float:
+        if self.rotate_seconds <= 0:
+            return 0.0
+        anchor = time.time()
+        if initial:
+            try:
+                st = os.stat(self.baseFilename)
+                if st.st_size > 0:
+                    anchor = st.st_mtime
+            except OSError:
+                pass
+        return anchor + self.rotate_seconds
+
+    def shouldRollover(self, record: logging.LogRecord) -> int:  # noqa: N802
+        if self.rollover_at and time.time() >= self.rollover_at:
+            return 1
+        if self.max_bytes <= 0:
+            return 0
+        if self.stream is None:
+            self.stream = self._open()
+        try:
+            self.stream.seek(0, os.SEEK_END)
+            projected = self.stream.tell() + len(self.format(record)) + 1
+        except (OSError, ValueError):
+            return 0
+        return 1 if projected >= self.max_bytes else 0
+
+    def doRollover(self) -> None:  # noqa: N802
+        if self.stream:
+            self.stream.close()
+            self.stream = None
+
+        if self.backup_count > 0:
+            # Drop the oldest, then shift every backup one slot down.
+            oldest = f'{self.baseFilename}.{self.backup_count}'
+            if os.path.exists(oldest):
+                try:
+                    os.remove(oldest)
+                except OSError:
+                    pass
+            for i in range(self.backup_count - 1, 0, -1):
+                src = f'{self.baseFilename}.{i}'
+                dst = f'{self.baseFilename}.{i + 1}'
+                if os.path.exists(src):
+                    try:
+                        os.replace(src, dst)
+                    except OSError:
+                        pass
+            try:
+                os.replace(self.baseFilename, f'{self.baseFilename}.1')
+            except OSError:
+                pass
+        else:
+            # No backups wanted — just start over.
+            try:
+                os.remove(self.baseFilename)
+            except OSError:
+                pass
+
+        self.rollover_at = self._compute_rollover()
+        if not self.delay:
+            self.stream = self._open()
+
+
+def build_file_handler(log_file: Path) -> logging.Handler:
+    """File handler for the backend log, bounded per the LOG_* options.
+
+    ``LOG_MAX_BYTES=0`` and ``LOG_ROTATE_DAYS=0`` together disable
+    rotation entirely (plain ``FileHandler``) for anyone who wants the
+    old unbounded behaviour.
+    """
+    max_bytes = Options.LOG_MAX_BYTES.get_int()
+    rotate_days = Options.LOG_ROTATE_DAYS.get_int()
+    backup_count = Options.LOG_BACKUP_COUNT.get_int()
+
+    if max_bytes <= 0 and rotate_days <= 0:
+        return logging.FileHandler(str(log_file))
+
+    return SizeAndTimeRotatingFileHandler(
+        str(log_file),
+        max_bytes=max(0, max_bytes),
+        rotate_seconds=max(0, rotate_days) * 86400,
+        backup_count=max(0, backup_count),
+        encoding='utf-8',
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -29,6 +29,7 @@ from app.events_system.backends import (  # registers backends
     dida365 as dida365,
     google_calendar as google_calendar,
 )
+from app.logging_setup import build_file_handler
 from app.models.app_settings import AppSettings
 from app.models.schedule import Schedule
 from app.models.store import Store
@@ -87,7 +88,8 @@ logging.basicConfig(
     level=_log_level,
     format='%(asctime)s %(name)s %(levelname)s %(message)s',
     handlers=[
-        logging.FileHandler(str(log_file)),
+        # Bounded: DEBUG level (--dev) grew this to 5 GB unrotated.
+        build_file_handler(log_file),
         logging.StreamHandler(),
     ],
 )

--- a/app/scheduler/task_queue.py
+++ b/app/scheduler/task_queue.py
@@ -74,10 +74,17 @@ class TaskQueueScheduler:
     async def submit(self, task_id: str, store_id: str | None):
         """Enqueue a task and signal the tick loop.
 
-        Only sets status to QUEUED from PENDING/WAITING — other
-        states (e.g. PLANNED being submitted for execution) are
-        left untouched so the dispatcher can transition them
-        correctly.
+        Only sets status to QUEUED from the states that have no other
+        meaning to the dispatcher — other states (e.g. PLANNED being
+        submitted for execution) are left untouched so it can
+        transition them correctly.
+
+        FAILED is included because it is in ``STARTABLE``: the retry
+        button (``POST /tasks/{id}/start``) accepts a failed task, but
+        leaving the row FAILED here made retry a silent no-op — the
+        task was enqueued and then dropped by ``_on_start``, which only
+        spawns from PLANNED/QUEUED/RUNNING. Keep this set and
+        ``STARTABLE`` in agreement.
         """
         async with self._lock:
             if store_id not in self._queues:
@@ -93,8 +100,24 @@ class TaskQueueScheduler:
             if task and task.status in (
                 TaskStatus.PENDING,
                 TaskStatus.WAITING,
+                TaskStatus.FAILED,
             ):
                 task.status = TaskStatus.QUEUED
+                # The previous run's error must not survive into this
+                # one. It is a terminal-run artifact, and every consumer
+                # reads it as current: the detail panel paints a red
+                # banner from `task.error` with no status guard, and the
+                # list sets `has_error` from it — so a retried task
+                # rendered as "运行中" AND "任务已被用户停止。" at the
+                # same time. Clearing it here (the single choke point
+                # all launch paths route through) keeps the row
+                # self-consistent instead of teaching each reader to
+                # distrust the field. NOT a frontend fix: an agent may
+                # legitimately set an error on a RUNNING task via
+                # `set_task_error` (partial failure), so the view must
+                # keep showing errors for active tasks.
+                task.error = None
+                task.error_category = None
                 task.updated_at = datetime.now(UTC).isoformat()
                 await db.commit()
                 await event_bus.emit(
@@ -102,6 +125,7 @@ class TaskQueueScheduler:
                     {
                         'task_id': task_id,
                         'status': TaskStatus.QUEUED,
+                        'error': None,
                     },
                 )
 

--- a/app/skills_v2/amazon-shared/SKILL.md
+++ b/app/skills_v2/amazon-shared/SKILL.md
@@ -82,6 +82,17 @@ otherwise → ask a human.** Ziniao "has it" when the field is pre-filled
 appears for a required step, stop and ask the user — never loop forever
 on a challenge Ziniao can't satisfy.
 
+> **Not every missing affordance is a missing credential.** If *nothing*
+> Ziniao-ish works — email not pre-filled, password not pre-filled, no
+> OTP panel, no passkey overlay — that is the signature of an env whose
+> Ziniao layer didn't load, not of an unprovisioned account. Confirm
+> with `js("return navigator.webdriver")`: an anti-detect browser must
+> report `false`. If it returns `true`, the browser itself is broken —
+> say so and stop; do NOT ask the user for a password, and do not try to
+> hand-type your way in (the platform is already treating the session as
+> a bot). The launcher now rejects such envs at start, so this should be
+> rare; seeing it means the browser was wedged after launch.
+
 ### 2a. Ziniao helper panels are NATIVE overlays — screenshot, don't querySelector
 
 When a step needs a code or a passkey, Ziniao renders its own panel:

--- a/app/task_states.py
+++ b/app/task_states.py
@@ -65,6 +65,7 @@ TRANSITIONS: dict[TaskStatus, set[TaskStatus]] = {
     },
     TaskStatus.FAILED: {
         TaskStatus.PENDING,
+        TaskStatus.QUEUED,  # retry: FAILED is in STARTABLE
         TaskStatus.DESIGNING,
         TaskStatus.RUNNING,  # follow-up (auto mode)
     },

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -291,6 +291,28 @@ Browser lifecycle (see docs/browser.md § Browser Lifecycle):
 |----------|---------|-------------|
 | `VIBE_BROWSER_IDLE_S` | `300` | Idle window before a browser with no live task is terminated. `0` = never |
 | `VIBE_TAB_CAP` | `12` | Max tabs one task may keep open; oldest closed beyond it. `0` = unbounded |
+| `VIBE_BROWSER_RELAUNCH_MAX` | `3` | Dead-mux full-env relaunches allowed per store per window before `start_session` refuses. `0` = unbounded |
+| `VIBE_BROWSER_RELAUNCH_WINDOW_S` | `600` | Sliding window for the relaunch budget above. `0` = unbounded |
+| `VIBE_BROWSER_START_TIMEOUT_S` | `180` | Ceiling on one store's `backend.start()`. It runs under a global lock, so an unbounded per-store retry loop starves every other store. `0` = unbounded |
+
+Logging (`app/logging_setup.py`) — the backend log rolls on size **or**
+age, whichever comes first, keeping `LOG_BACKUP_COUNT` numbered backups
+(`backend_<port>.log.1`, …). On-disk ceiling is
+`LOG_MAX_BYTES × (LOG_BACKUP_COUNT + 1)`; defaults give 10 GiB / 2 weeks.
+`--dev` (`LOG_LEVEL=DEBUG`) is what makes this matter — DEBUG chatter from
+`aiosqlite`/`httpcore`/`websockets` once grew an unrotated log to 5 GB.
+`start.sh` applies the same policy to `backend.log` (uvicorn's
+stdout/stderr, captured by a shell redirect the handler can't reach).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LOG_LEVEL` | `INFO` | `--dev` sets `DEBUG` |
+| `LOG_MAX_BYTES` | `5368709120` (5 GiB) | Roll when the log would exceed this. `0` = no size trigger |
+| `LOG_ROTATE_DAYS` | `7` | Roll when the log is this old. `0` = no age trigger |
+| `LOG_BACKUP_COUNT` | `1` | Old logs kept; the oldest is deleted as backups shift down. `0` = keep none |
+
+Setting both `LOG_MAX_BYTES=0` and `LOG_ROTATE_DAYS=0` disables rotation
+(plain unbounded `FileHandler`).
 
 ## Configuration
 

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -40,7 +40,7 @@ class BrowserBackend(ABC):
 
 Singleton that orchestrates browser sessions across all stores:
 
-- `start_session(store, db)` — Launches browser (Ziniao only), creates/updates `BrowserSession` DB record, generates wrapper script
+- `start_session(store, db)` — Launches browser (Ziniao only), creates/updates `BrowserSession` DB record, generates wrapper script. The launch is bounded by `VIBE_BROWSER_START_TIMEOUT_S` (default 180s) and the dead-mux relaunch path is budgeted per store — see § Browser Lifecycle
 - `stop_session(store, db)` — Closes browser, updates DB, removes wrapper script
 - `ensure_session(store, db)` — Start or reuse a session, always regenerates wrapper
 - `write_mcp_config(store, db)` — Generates browser-use wrapper WITHOUT starting browser (used at task launch)
@@ -55,13 +55,15 @@ Singleton that orchestrates browser sessions across all stores:
 
 **Ziniao guard**: Only one Ziniao account can be active per machine. `_start_session_locked` checks `_active_ziniao_account_id` — if a different account is already active, it raises `RuntimeError` with the names of conflicting stores. Chrome stores have no such account restriction (but still use CDPMuxProxy for shared browser and cookie persistence).
 
-> **Multiple stores of the SAME account run concurrently** (verified against the official Ziniao demo). Ziniao's `startBrowser` is flaky (nondeterministic per-store "stale launch"); recovery is **per store** (`stopBrowser` + retry), never a global client kill — a global kill destroys every other store's live browser and cascades. See [docs/ziniao-concurrency.md](ziniao-concurrency.md) for the full mechanism, root-cause investigation, and fix.
+`_start_session_locked` raises for two more reasons, both there to keep one broken store from becoming a machine-wide outage: the **relaunch budget** is spent (`VIBE_BROWSER_RELAUNCH_MAX` per `VIBE_BROWSER_RELAUNCH_WINDOW_S`), or `backend.start()` blew through `VIBE_BROWSER_START_TIMEOUT_S`. All three failures are per store — peers keep running and the task can be retried.
+
+> **Multiple stores of the SAME account run concurrently** (verified against the official Ziniao demo). Ziniao's `startBrowser` is flaky (nondeterministic per-store "stale launch" — either the debug port never binds, or it binds but Ziniao's SBP layer never injects, leaving the env with no account auto-fill and `navigator.webdriver` unmasked). Readiness therefore checks **both** (`_cdp_port_reachable` + `_instrumentation_live`); recovery is **per store** (`stopBrowser` + retry) and budgeted, never a global client kill — a global kill destroys every other store's live browser and cascades. See [docs/ziniao-concurrency.md](ziniao-concurrency.md) for the full mechanism, root-cause investigation, and fix.
 
 **Wrapper script generation**: `write_browser_use_wrapper()` in `app/browser/wrapper.py` generates a bash script per store. Session validation uses a regex check (`^{slug}(-aux|-{8hex})?$`). For both Chrome and Ziniao stores, the wrapper auto-starts the CDP proxy and injects `BU_CDP_WS=ws://…/client-{task_id}` (the 0.13 replacement for `--cdp-url`) pointing at CDPMuxProxy. EVERY session — aux included, both backends — gets an explicit `BU_CDP_WS` on its own store's proxy: per-task sessions use `client-{task_id}`, aux uses the stable `client-aux`. (The former Ziniao-aux "Chrome direct" exemption exported no endpoint; `browser_harness`'s ambient discovery then attached to a *different store's* browser — wrong Amazon account, wrong downloads dir — observed live with two Ziniao stores. Wrapper format v3 removed it.) The auto-start block checks the browser start API's HTTP status and exits with a clear error on non-2xx responses. A final CDP readiness check after the poll loop catches cases where the browser started but the proxy isn't ready.
 
 **Wrapper safety — the agent must never touch a local Chrome**: the agent's `PATH` prepends the store `bin/<slug>` dir, so bare `browser-use` resolves to the wrapper. Three layers keep it from ever falling through to the real `browser-use` binary (which would attach to the user's own Chrome):
 1. **Written before start** — `write_browser_use_wrapper()` runs *before* `backend.start()` in `_start_session_locked`, so a failed/stale launch still leaves a working wrapper (its auto-start block retries `browser/start` on the next call).
-2. **Version-aware boot wipe** — each wrapper embeds a monotonic `WRAPPER_FORMAT_VERSION`; `_wipe_generated_wrappers()` deletes only *older* wrappers and keeps current+newer, so a restart never leaves a wrapper-less window (and never nukes a newer version — rollback-safe).
+2. **Version-aware boot wipe** — each wrapper embeds a monotonic `WRAPPER_FORMAT_VERSION`; `_wipe_generated_wrappers()` deletes only *older* wrappers and keeps current+newer, so a restart never leaves a wrapper-less window (and never nukes a newer version — rollback-safe). It **also reaps orphans**: a wrapper whose embedded `store_id` is no longer in the DB. Version alone never caught those, so a deleted store's wrapper lived forever holding a *frozen* `proxy_port` — and since ports are re-allocated from the base every boot, that number eventually lands on a live store. The orphan then finds the port already up, skips the start API (so its dead `store_id` never 404s) and points `BU_CDP_WS` at **another store's** browser: wrong account, wrong downloads dir — the same cross-store hole v3 closed for aux. A wrapper with no parseable store id (the store-less `_web`) is kept, so the check can never mass-reap.
 3. **Guard** — `apply_agent_venv_path` puts a guard `browser-use` (`bin/_guard`) on `PATH` below the wrapper but above the venvs; if the wrapper is somehow missing, bare `browser-use` hits the guard and **exits non-zero** instead of reaching the real binary.
 
 See [docs/browser-use-0.13-migration.md § wrapper-format versioning](browser-use-0.13-migration.md) and [docs/ziniao-concurrency.md](ziniao-concurrency.md).
@@ -190,6 +192,21 @@ thousand-tab windows. Two mechanisms bound this
 - **Ziniao envs really stop now**: `ZiniaoBackend.stop()` sends the
   per-store `stopBrowser` captured at start (previously it only tore
   down the mux proxy and the Chromium env lived forever).
+- **Relaunch circuit breaker** (`VIBE_BROWSER_RELAUNCH_MAX`, default 3,
+  per `VIBE_BROWSER_RELAUNCH_WINDOW_S`, default 600s; 0 disables): the
+  counterpart to `stop_session` above. `start_session` relaunches a
+  store's whole env whenever its mux looks dead, and the wrapper reaches
+  that path on *every* `browser-use` call — so a wedged Ziniao client
+  turned recovery into a restart storm that wiped agent tabs mid-task and
+  deepened the wedge. Past the budget the start fails with an actionable
+  error; a healthy launch clears it.
+- **Bounded launch** (`VIBE_BROWSER_START_TIMEOUT_S`, default 180s; 0
+  disables): `start_session` holds a **global** lock — deliberate, it
+  serializes Ziniao `startBrowser` so the shared client isn't hit
+  concurrently — so an unbounded per-store retry loop starves every other
+  store's launch. `backend.start()` is wrapped in `asyncio.wait_for`; on
+  timeout the half-started env is torn down (per-store `stopBrowser`) and
+  only that store fails.
 - **Per-client tab cap** (`VIBE_TAB_CAP`, default 12; 0 disables): the
   mux LRU-closes a client's oldest tab beyond the cap on every
   `Target.createTarget`, strictly within that client's ownership — a

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -20,7 +20,7 @@
 
 **Scheduled fires** (children of a plan-mode Schedule): auto-approve the plan at execution since the human already reviewed it at creation time. They re-inject per-store context (L3 catalog, bookmarks, emails) and reuse `Schedule.plan` as-is.
 
-Note: `queued` is used for store-task launches from `pending`/`waiting` states. `submit()` only transitions to `queued` from those states — `planned` tasks enqueued for execution stay `planned` in the DB so `_approve_plan_request` can transition them directly to `running`. The `execute_plan` endpoint explicitly sets `planned` → `queued` before enqueueing to prevent duplicate submissions. No-store tasks launch directly via `_auto_run_task()`.
+Note: `queued` is used for store-task launches from `pending`/`waiting`/`failed` states. `submit()` only transitions to `queued` from those three — `planned` tasks enqueued for execution stay `planned` in the DB so `_approve_plan_request` can transition them directly to `running`. **`failed` is in that set because it is in `STARTABLE`**: the retry button (`POST /tasks/{id}/start`) accepts a failed task, so leaving the row `failed` here made retry a silent no-op — the task was enqueued and then dropped by `_on_start`, which only spawns from `planned`/`queued`/`running`. Keep `submit()`'s set and `STARTABLE` in agreement. The `execute_plan` endpoint explicitly sets `planned` → `queued` before enqueueing to prevent duplicate submissions. No-store tasks launch directly via `_auto_run_task()`.
 
 **`queued`/`pending` means "waiting for the agent-concurrency slot" — a task in these states has NOT started and produces no output** (input bar disabled via `TASK_UI`, and the stall reaper — which is RUNNING-only — ignores it). The transition out is owned by `on_start`, which the manager awaits *after* acquiring the semaphore and *before* `session.start()` (`claude_backend_manager.run`), so a live session's status is always RUNNING/DESIGNING by the time it streams. **Invariant enforced two ways so a missed/late/clobbered `task_update(running)` can't strand the badge on `queued` (the `pending→queued→running` SSE race — see `retryTask.ts`, `sseCreateTaskRace`):** (a) backend — `_emit_message` reconciles a still-QUEUED/PENDING task to RUNNING/DESIGNING on its first streamed message (`_status_reconciled` one-shot; a backstop, inert in the normal path); (b) frontend — `useSSE` promotes a `queued`/`pending` task to `running`/`designing` on any streamed `task_message`, never touching terminal/active states. Net: **a task emitting session output is never displayed as `queued`.**
 
@@ -46,7 +46,7 @@ When the agent subprocess exits while holding an unanswered `AskUserQuestion`, `
 The operator answers via `POST /api/tasks/{id}/questions/answer` exactly as for a live session. The endpoint (`app/routers/tasks_conversation.py`) has two branches: if the agent is still running it forwards over IPC; if the session is dead and the task is WAITING with a matching `request_id`, it persists the answers into `wait_condition.answers`, flips WAITING → QUEUED, and re-queues. Store tasks go through `task_queue_scheduler`; no-store tasks are launched directly via `auto_run_task`.
 
 On re-dispatch, `auto_run_task` calls `maybe_inject_pending_answers()` which composes a user-turn prefix from `wait_condition.answers` + the stored questions, clears `wait_condition`, and passes `resume=True` so the spawned session runs `claude --resume <task.session_id>` and picks up the transcript. The resumed agent sees the operator's answers as the next user message and continues.
-- Transitions: `running` → `waiting` (agent signals wait OR incomplete todos), `waiting` → `queued` (woken) / `failed` (timeout)
+- Transitions: `running` → `waiting` (agent signals wait OR incomplete todos), `waiting` → `queued` (woken) / `failed` (timeout), `failed` → `queued` (retry)
 - State machine defined in `app/task_states.py` (backend) and `frontend/src/taskStates.ts` (frontend UI config)
 - Backend: `TaskStatus` enum, `TRANSITIONS` table, named groups (`STOPPABLE`, `ACTIVE`, `WAKEABLE`, etc.)
 - Frontend: `TASK_UI` config table maps status → which buttons/tabs/panels are visible
@@ -112,6 +112,10 @@ Both modes use `DESIGN_SYSTEM_PROMPT` (knowledge recall, critical thinking, appr
 Each agent runs in a per-task isolated directory (`~/.vibe-seller/tasks/{task_id}/`) with symlinked shared resources — see [workspace.md](workspace.md#per-task-workspace-isolation).
 
 No manual buttons needed. Users see: progress indicator + Stop button + Retry on failure or completion (RETRIABLE = `{FAILED, PENDING, COMPLETED}`). Toggle "Review Plan" in the task detail footer to switch between modes.
+
+**Stop lives only in the task header** — never in the chat composer. The composer's send slot used to render Send when the box had text and a red Stop when it was empty, but sending is exactly what empties it: the click that sent a message left a destructive button in the same pixels (measured: Send x1110–1176, Stop x1121–1176, identical y/height), so a double-click killed the run with no confirmation. General rule: **a destructive control must never occupy the position a safe control just vacated.**
+
+Retry on a **failed store task** goes `failed` → `queued` (via `submit()`) → dispatched by `_on_start`, which spawns only from `planned`/`queued`/`running`. Those two sets must stay in agreement — when `submit()` left the row `failed`, the retry returned `200 {"status":"queued"}` and was then silently dropped at spawn (`Exec on_start: task … in status failed — aborting spawn`).
 
 ### Follow-up on Completed/Failed Tasks
 

--- a/docs/ziniao-concurrency.md
+++ b/docs/ziniao-concurrency.md
@@ -12,7 +12,12 @@
   (proven against the official demo: 4/4 stores opened at once).
 - Ziniao's `startBrowser` is **flaky**: it sometimes returns a
   `debuggingPort` whose DevTools endpoint never initialises — a
-  nondeterministic, **per-store** "stale launch".
+  nondeterministic, **per-store** "stale launch". A second shape of the
+  same flake: the port *does* bind, but Ziniao's own SBP layer never
+  injects into the env's pages — no account auto-fill, no
+  `紫鸟验证码服务` OTP panel, no `已托管账号Passkey` overlay, and
+  `navigator.webdriver` left unmasked at `true`. Both shapes are treated
+  as a stale launch (see § The fix, item 1).
 - Our old recovery for a stale launch was `kill_and_relaunch_ziniao()` →
   **`pkill -9` on the entire Ziniao client**. Under a multi-store fan-out
   that meant recovering one store **destroyed every other store's live
@@ -137,6 +142,18 @@ Implemented in `app/browser/ziniao.py` + `app/browser/ziniao_utils.py`:
    `startBrowser` (bounded, `MAX_ZINIAO_ATTEMPTS`). It never calls
    `kill_and_relaunch_ziniao`. If all attempts stale, it raises for **this
    store only** — peers are untouched; the task can be retried/re-queued.
+
+   Readiness is **two gates**, both on the raw Ziniao port before the mux
+   is built. `_cdp_port_reachable` proves *Chrome* is up;
+   `_instrumentation_live` proves *Ziniao* is. The second evaluates
+   `navigator.webdriver === true` on a real http(s) page — a positive
+   read means SBP never injected, so the env has no auto-fill/OTP/passkey
+   and leaks automation to the platform (which then bounces every page to
+   the login wall). A port-only gate waved that env through and handed an
+   agent a browser it could not log in with. The instrumentation gate is
+   deliberately **fail-open**: only a positive `webdriver === true` is a
+   verdict; unreachable, eval error, or no-page-yet all pass, so a probe
+   bug can never become a store-wide outage.
 2. **Graceful-first client restart.** `kill_and_relaunch_ziniao` (still
    used by the *user-initiated* force-restart endpoints) now tries the
    `exit` action first and only falls back to `pkill -9` if the client
@@ -148,6 +165,21 @@ Implemented in `app/browser/ziniao.py` + `app/browser/ziniao_utils.py`:
    (added in the self-heal PR) previously called the global kill; it now
    re-opens only its own store (`stopBrowser` + `startBrowser`) to obtain
    a fresh `debuggingPort`, never restarting the shared client.
+5. **The per-store relaunch is budgeted.** Per-store is necessary but not
+   sufficient: `BrowserManager.start_session` also relaunches a store's
+   whole env whenever its mux looks dead, and the wrapper can reach that
+   path on *every* `browser-use` call. With the client wedged, each
+   relaunch fails the same way, so the recovery became its own storm —
+   three stores cycling stop/start every ~20 s for five minutes, which
+   hammered the shared client until it hung and left every agent on a
+   freshly-wiped, logged-out browser. `_note_relaunch` bounds it to
+   `VIBE_BROWSER_RELAUNCH_MAX` per `VIBE_BROWSER_RELAUNCH_WINDOW_S` per
+   store (cleared on a healthy launch), and `backend.start()` is capped by
+   `VIBE_BROWSER_START_TIMEOUT_S` — `start_session` holds a **global**
+   lock (deliberate: it serializes `startBrowser` so the shared client
+   isn't hit concurrently), so an unbounded per-store retry loop starves
+   every other store's launch. One broken store now fails fast instead of
+   taking the machine with it.
 
 Net effect: Ziniao's real concurrency is preserved, the unavoidable
 per-store flake is isolated to a retry (not an outage), and no store's
@@ -176,6 +208,22 @@ that port never binds (`/json/version` unreachable), so every task fails at
 browser launch. Chrome may even spawn (process visible) yet its
 remote-debugging port never comes up. The official `ziniao_webdriver_demo`
 fails identically — a fast way to confirm it's the client, not our code.
+
+**Second symptom, same root cause:** the port binds and `/json/version`
+answers, but the env comes up uninstrumented — log line `Ziniao env on
+…:… came up WITHOUT its instrumentation (SBP not injected…)`. To the user
+this looks identical (every task fails at browser launch), but the
+diagnosis differs. Confirm by hand on the store's raw debug port:
+
+```bash
+# 'true' means SBP did not inject — an anti-detect browser must mask this.
+curl -s "http://127.0.0.1:<raw_cdp_port>/json/list"   # pick a page target
+# then Runtime.evaluate `navigator.webdriver` over its webSocketDebuggerUrl
+```
+
+A wedged client can also present as `/json/version` accepting the TCP
+connection and then never responding (curl hangs to timeout) — that is
+the same wedge, not a slow machine.
 
 **Root cause (the real one):** `pkill -9` on a Ziniao Chrome leaves stale
 **`SingletonLock` / `SingletonSocket` / `SingletonCookie`** files in that

--- a/frontend/src/__tests__/composerNoStopButton.test.tsx
+++ b/frontend/src/__tests__/composerNoStopButton.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * The chat composer must never host a Stop control.
+ *
+ * It used to: the send slot rendered Send when the textarea had text and
+ * a red Stop when it was empty — and sending is precisely what empties
+ * it. Measured on a live task, Stop landed inside Send's footprint
+ * (Send x1110-1176, Stop x1121-1176, identical y and height), so the
+ * click that sent a message left a destructive button under the cursor.
+ * A double-click, or one "did that register?" click, stopped the run
+ * with no confirmation — the user reported a task stopping that they
+ * never knowingly stopped.
+ *
+ * Stop lives in the task header instead, at a fixed position that never
+ * hosts another action. Rule: a destructive control must never occupy
+ * the position a safe control just vacated.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ChatComposer } from '../components/conversation/ChatComposer'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (k: string, d?: string) => {
+      const map: Record<string, string> = {
+        'tasks.send': 'Send',
+        'tasks.stopTask': 'Stop',
+        'tasks.queuedWhileWorking': 'queued',
+      }
+      return map[k] ?? d ?? k
+    },
+  }),
+}))
+
+function props(over: Record<string, unknown> = {}) {
+  return {
+    fileInputRef: { current: null },
+    uploading: false,
+    uploadFiles: vi.fn(),
+    attachments: [],
+    onRemoveAttachment: vi.fn(),
+    inputRef: { current: null },
+    input: '',
+    setInput: vi.fn(),
+    hasContent: false,
+    canSend: true,
+    isActive: true,
+    onSend: vi.fn(),
+    placeholder: 'Type…',
+    ...over,
+  }
+}
+
+describe('ChatComposer send slot', () => {
+  it('shows NO Stop button while the task is active and the box is empty', () => {
+    // The exact state that sending creates, and where the red Stop used
+    // to appear under the cursor.
+    render(<ChatComposer {...props({ isActive: true, hasContent: false })} />)
+
+    expect(screen.queryByRole('button', { name: 'Stop' })).toBeNull()
+    const send = screen.getByRole('button', { name: 'Send' })
+    expect(send).toBeDisabled()
+  })
+
+  it('shows an enabled Send once there is content', () => {
+    render(<ChatComposer {...props({ isActive: true, hasContent: true })} />)
+
+    expect(screen.queryByRole('button', { name: 'Stop' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Send' })).toBeEnabled()
+  })
+
+  it('never renders a destructive (red) button in the composer', () => {
+    // Guards the whole class, not just the label: no bg-red-* control
+    // may sit in the send row in ANY active/content combination.
+    for (const isActive of [true, false]) {
+      for (const hasContent of [true, false]) {
+        const { container, unmount } = render(
+          <ChatComposer {...props({ isActive, hasContent })} />,
+        )
+        const red = container.querySelectorAll('[class*="bg-red-"]')
+        expect(
+          red.length,
+          `red control rendered for isActive=${isActive} hasContent=${hasContent}`,
+        ).toBe(0)
+        unmount()
+      }
+    }
+  })
+})

--- a/frontend/src/components/conversation/ChatComposer.tsx
+++ b/frontend/src/components/conversation/ChatComposer.tsx
@@ -21,18 +21,21 @@ interface ChatComposerProps {
    *  now instead of queueing behind a running step. */
   awaitingUser?: boolean
   onSend: () => void
-  onStop: () => void
   placeholder: string
 }
 
 /** The task chat send bar: removable attachment chips, attach button,
- *  auto-growing textarea (drag/paste upload), and the Send/Stop button.
+ *  auto-growing textarea (drag/paste upload), and the Send button.
  *  Attachments are staged and shown as thumbnails — never a raw path —
- *  and only reach the agent when the user sends. */
+ *  and only reach the agent when the user sends.
+ *
+ *  Deliberately has NO Stop control: stopping is destructive and lives
+ *  in the task header, away from the button the user just clicked to
+ *  send. See the send-button block below. */
 export function ChatComposer({
   fileInputRef, uploading, uploadFiles, attachments, onRemoveAttachment,
   inputRef, input, setInput, hasContent, canSend, isActive, awaitingUser,
-  onSend, onStop, placeholder,
+  onSend, placeholder,
 }: ChatComposerProps) {
   const { t } = useTranslation()
   return (
@@ -97,19 +100,22 @@ export function ChatComposer({
           disabled={!canSend && !isActive}
           className="flex-1 px-3 py-2 text-sm leading-5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed resize-none overflow-y-auto"
         />
+        {/* This slot is Send-ONLY. It used to flip to a red Stop
+         *  whenever the box was empty and the task active — which is
+         *  the state sending itself creates. Send cleared the input,
+         *  React swapped Stop into the very pixels just clicked
+         *  (measured: Send x1110-1176, Stop x1121-1176, same y/height),
+         *  and a double-click or a "did that register?" click killed
+         *  the run with no confirmation. Stop lives in the task header
+         *  instead, at a fixed position that never hosts another
+         *  action. Rule: a destructive control must never occupy the
+         *  position a safe control just vacated. */}
         {canSend && hasContent ? (
           <button
             onClick={onSend}
             className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors"
           >
             {t('tasks.send')}
-          </button>
-        ) : isActive && !hasContent ? (
-          <button
-            onClick={onStop}
-            className="px-3 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 transition-colors"
-          >
-            {t('tasks.stopTask')}
           </button>
         ) : (
           <button

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -728,8 +728,7 @@ export function TasksView({
                 onRemoveAttachment={removeAttachment} inputRef={chatInputRef}
                 input={chatInput} setInput={setChatInput} hasContent={hasText}
                 canSend={canSend} isActive={isActive} awaitingUser={awaitingUser}
-                onSend={sendChatMessage}
-                onStop={stopAgent} placeholder={getPlaceholder()}
+                onSend={sendChatMessage} placeholder={getPlaceholder()}
               />
               </div>
             </div>

--- a/start.sh
+++ b/start.sh
@@ -110,6 +110,29 @@ fi
 LOG_DIR="$SCRIPT_DIR/logs"
 mkdir -p "$LOG_DIR"
 
+# backend.log captures uvicorn's stdout/stderr via the shell redirect
+# below, so the app's own rotating handler (app/logging_setup.py) can't
+# bound it. Roll it here on the same policy — size OR age, one backup
+# kept — so the pair stays under 2x the cap. --dev (LOG_LEVEL=DEBUG) is
+# what makes this matter: it once grew the app log to 5 GB.
+# Exported so app/logging_setup.py rotates on exactly the same policy.
+export LOG_MAX_BYTES="${LOG_MAX_BYTES:-5368709120}"   # 5 GiB
+export LOG_ROTATE_DAYS="${LOG_ROTATE_DAYS:-7}"
+_roll_log() {
+    local f="$1" size=0 aged=""
+    [ -f "$f" ] || return 0
+    size=$(wc -c < "$f" 2>/dev/null | tr -d ' ') || size=0
+    if [ "$LOG_ROTATE_DAYS" -gt 0 ] 2>/dev/null; then
+        aged=$(find "$f" -mtime +"$LOG_ROTATE_DAYS" -print -quit 2>/dev/null)
+    fi
+    if { [ "$LOG_MAX_BYTES" -gt 0 ] 2>/dev/null \
+         && [ "$size" -ge "$LOG_MAX_BYTES" ]; } || [ -n "$aged" ]; then
+        mv -f "$f" "$f.1"   # replaces the previous backup
+        _info "Rotated $(basename "$f") (${size} bytes) → $(basename "$f").1"
+    fi
+}
+_roll_log "$LOG_DIR/backend.log"
+
 echo "Starting server on port $PORT..."
 cd "$SCRIPT_DIR"
 nohup env LOG_DIR="$LOG_DIR" BACKEND_PORT="$PORT" uv run python -m uvicorn app.main:app --host 0.0.0.0 --port $PORT > "$LOG_DIR/backend.log" 2>&1 &

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,32 @@ from app.models.user import User  # noqa: E402
 # trying to connect to a server that doesn't exist.
 
 
+@pytest.fixture(autouse=True)
+def _isolate_wrapper_bin_dir(tmp_path_factory, monkeypatch):
+    """Keep wrapper writes/reaps out of the developer's real
+    ``~/.vibe-seller/bin/``.
+
+    Workflow tests create stores through the real ``BrowserManager``
+    (e.g. "Retry Test Store"), which generates a wrapper on disk. With
+    no isolation those landed in the developer's live bin dir and
+    *stayed* — orphan wrappers for stores that never existed outside a
+    test run, each pinning a frozen ``proxy_port`` that a real store can
+    later be allocated. Boot-time reaping is worse: it deletes, and a
+    test DB holds only its own stores, so a reap aimed at a real bin dir
+    wipes the wrappers of stores an actual task is using right now
+    (observed — it removed every live store's wrapper mid-run).
+
+    Both directions are the same bug: the suite must not share this
+    mutable state with the machine it runs on.
+    """
+    bin_dir = tmp_path_factory.mktemp('vs_bin')
+    monkeypatch.setattr('app.browser.wrapper._BIN_DIR', bin_dir, raising=False)
+    monkeypatch.setattr(
+        'app.browser.manager.BROWSER_USE_BIN_DIR', bin_dir, raising=False
+    )
+    return bin_dir
+
+
 def pytest_addoption(parser):
     parser.addoption(
         '--e2e',

--- a/tests/unit/test_browser/test_upgrade_safety.py
+++ b/tests/unit/test_browser/test_upgrade_safety.py
@@ -86,6 +86,77 @@ class TestWipeStaleWrappers:
             assert _wipe_generated_wrappers() == 0
 
 
+class TestWipeOrphanedWrappers:
+    """A wrapper must not outlive the store it was generated for.
+
+    Version-only reaping kept current-format wrappers forever, including
+    ones for deleted stores. Those hold a FROZEN proxy_port, and ports
+    are re-allocated from the base every boot — so the number eventually
+    lands on a live store. The orphan then finds the port already up,
+    skips the start API (its dead store_id never 404s) and points
+    BU_CDP_WS at another store's browser: wrong account, wrong downloads
+    dir. Same cross-store hole wrapper v3 closed for aux sessions.
+    """
+
+    @staticmethod
+    def _write_current(bin_dir: Path, slug: str, store_id: str) -> Path:
+        with mock.patch('app.browser.wrapper._BIN_DIR', bin_dir):
+            write_browser_use_wrapper(slug, 'ziniao', 9227, store_id=store_id)
+        return bin_dir / slug / 'browser-use'
+
+    def test_orphan_reaped_live_store_kept(self, tmp_path: Path):
+        bin_dir = tmp_path / 'bin'
+        live = self._write_current(bin_dir, 'live-store', 'store-live')
+        orphan = self._write_current(bin_dir, 'dead-store', 'store-dead')
+        assert f'{WRAPPER_FORMAT_MARKER} {WRAPPER_FORMAT_VERSION}' in (
+            orphan.read_text()
+        )  # current format — version alone would never reap it
+
+        with mock.patch('app.browser.manager.BROWSER_USE_BIN_DIR', bin_dir):
+            removed = _wipe_generated_wrappers({'store-live'})
+
+        assert removed == 1
+        assert live.exists(), 'live store wrapper must survive a restart'
+        assert not orphan.exists(), 'deleted store wrapper must be reaped'
+        assert not orphan.parent.exists(), 'empty dir should go too'
+
+    def test_no_live_ids_means_version_only(self, tmp_path: Path):
+        """Omitting the arg keeps the old behaviour — callers without a
+        DB must never trigger a mass orphan-reap."""
+        bin_dir = tmp_path / 'bin'
+        w = self._write_current(bin_dir, 'some-store', 'store-x')
+        with mock.patch('app.browser.manager.BROWSER_USE_BIN_DIR', bin_dir):
+            assert _wipe_generated_wrappers() == 0
+        assert w.exists()
+
+    def test_empty_live_set_never_reaps(self, tmp_path: Path):
+        """No stores loaded reads as 'wrong/unloaded DB', not 'delete
+        everything'. Guard against a caller handing us an empty set
+        while a real task is using those wrappers."""
+        bin_dir = tmp_path / 'bin'
+        w = self._write_current(bin_dir, 'live-store', 'store-live')
+        with mock.patch('app.browser.manager.BROWSER_USE_BIN_DIR', bin_dir):
+            assert _wipe_generated_wrappers(set()) == 0
+        assert w.exists()
+
+    def test_unattributable_wrapper_is_kept(self, tmp_path: Path):
+        """No parseable store id (e.g. the store-less `_web` wrapper) →
+        fail safe and keep it, even with an empty live set."""
+        bin_dir = tmp_path / 'bin'
+        d = bin_dir / '_web'
+        d.mkdir(parents=True)
+        w = d / 'browser-use'
+        w.write_text(
+            '#!/usr/bin/env bash\n'
+            '# Auto-generated browser-use wrapper for store: _web\n'
+            f'# {WRAPPER_FORMAT_MARKER} {WRAPPER_FORMAT_VERSION}\n'
+            'curl http://127.0.0.1:7777/api/browser/web/start\n'
+        )
+        with mock.patch('app.browser.manager.BROWSER_USE_BIN_DIR', bin_dir):
+            assert _wipe_generated_wrappers(set()) == 0
+        assert w.exists()
+
+
 class TestVersionAssertion:
     def test_warns_on_old_version(self, caplog):
         with mock.patch('app.browser.manager.version', return_value='0.12.6'):

--- a/tests/unit/test_browser/test_upgrade_safety.py
+++ b/tests/unit/test_browser/test_upgrade_safety.py
@@ -13,7 +13,7 @@ from unittest import mock
 
 import pytest
 
-from app.browser import manager
+from app.browser import wrapper as wrapper_mod
 from app.browser.manager import warn_on_browser_use_version_mismatch
 from app.browser.wrapper import (
     WRAPPER_FORMAT_MARKER,
@@ -21,7 +21,7 @@ from app.browser.wrapper import (
     write_browser_use_wrapper,
 )
 
-_wipe_generated_wrappers = manager._wipe_generated_wrappers
+_wipe_generated_wrappers = wrapper_mod.wipe_generated_wrappers
 
 pytestmark = pytest.mark.unit
 
@@ -50,7 +50,7 @@ class TestWipeStaleWrappers:
         user_wrapper = user_dir / 'browser-use'
         user_wrapper.write_text('#!/usr/bin/env bash\necho custom\n')
 
-        with mock.patch('app.browser.manager.BROWSER_USE_BIN_DIR', bin_dir):
+        with mock.patch('app.browser.wrapper._BIN_DIR', bin_dir):
             removed = _wipe_generated_wrappers()
 
         assert removed == 1
@@ -64,7 +64,7 @@ class TestWipeStaleWrappers:
         legacy = _write_legacy_wrapper(bin_dir, 'acme-store')
         assert '--cdp-url "$WS"' in legacy.read_text()  # old shape
 
-        with mock.patch('app.browser.manager.BROWSER_USE_BIN_DIR', bin_dir):
+        with mock.patch('app.browser.wrapper._BIN_DIR', bin_dir):
             _wipe_generated_wrappers()
 
         # Regenerate via the real generator (write_task_browser_config's
@@ -81,7 +81,7 @@ class TestWipeStaleWrappers:
 
     def test_no_bin_dir_is_noop(self, tmp_path: Path):
         with mock.patch(
-            'app.browser.manager.BROWSER_USE_BIN_DIR', tmp_path / 'missing'
+            'app.browser.wrapper._BIN_DIR', tmp_path / 'missing'
         ):
             assert _wipe_generated_wrappers() == 0
 
@@ -112,7 +112,7 @@ class TestWipeOrphanedWrappers:
             orphan.read_text()
         )  # current format — version alone would never reap it
 
-        with mock.patch('app.browser.manager.BROWSER_USE_BIN_DIR', bin_dir):
+        with mock.patch('app.browser.wrapper._BIN_DIR', bin_dir):
             removed = _wipe_generated_wrappers({'store-live'})
 
         assert removed == 1
@@ -125,7 +125,7 @@ class TestWipeOrphanedWrappers:
         DB must never trigger a mass orphan-reap."""
         bin_dir = tmp_path / 'bin'
         w = self._write_current(bin_dir, 'some-store', 'store-x')
-        with mock.patch('app.browser.manager.BROWSER_USE_BIN_DIR', bin_dir):
+        with mock.patch('app.browser.wrapper._BIN_DIR', bin_dir):
             assert _wipe_generated_wrappers() == 0
         assert w.exists()
 
@@ -135,7 +135,7 @@ class TestWipeOrphanedWrappers:
         while a real task is using those wrappers."""
         bin_dir = tmp_path / 'bin'
         w = self._write_current(bin_dir, 'live-store', 'store-live')
-        with mock.patch('app.browser.manager.BROWSER_USE_BIN_DIR', bin_dir):
+        with mock.patch('app.browser.wrapper._BIN_DIR', bin_dir):
             assert _wipe_generated_wrappers(set()) == 0
         assert w.exists()
 
@@ -152,7 +152,7 @@ class TestWipeOrphanedWrappers:
             f'# {WRAPPER_FORMAT_MARKER} {WRAPPER_FORMAT_VERSION}\n'
             'curl http://127.0.0.1:7777/api/browser/web/start\n'
         )
-        with mock.patch('app.browser.manager.BROWSER_USE_BIN_DIR', bin_dir):
+        with mock.patch('app.browser.wrapper._BIN_DIR', bin_dir):
             assert _wipe_generated_wrappers(set()) == 0
         assert w.exists()
 
@@ -220,7 +220,7 @@ class TestVersionAwareWipe:
         user = ud / 'browser-use'
         user.write_text('#!/usr/bin/env bash\necho hi\n')
 
-        with mock.patch('app.browser.manager.BROWSER_USE_BIN_DIR', bin_dir):
+        with mock.patch('app.browser.wrapper._BIN_DIR', bin_dir):
             removed = _wipe_generated_wrappers()
 
         assert not older.exists(), 'older-version wrapper must be wiped'
@@ -240,7 +240,7 @@ class TestVersionAwareWipe:
         assert (
             f'{WRAPPER_FORMAT_MARKER} {WRAPPER_FORMAT_VERSION}' in w.read_text()
         )
-        with mock.patch('app.browser.manager.BROWSER_USE_BIN_DIR', bin_dir):
+        with mock.patch('app.browser.wrapper._BIN_DIR', bin_dir):
             removed = _wipe_generated_wrappers()
         assert removed == 0
         assert w.exists(), 'current generated wrapper must survive boot'

--- a/tests/unit/test_browser/test_upgrade_safety.py
+++ b/tests/unit/test_browser/test_upgrade_safety.py
@@ -80,9 +80,7 @@ class TestWipeStaleWrappers:
         assert '--cdp-url "$WS"' not in content  # old injection gone
 
     def test_no_bin_dir_is_noop(self, tmp_path: Path):
-        with mock.patch(
-            'app.browser.wrapper._BIN_DIR', tmp_path / 'missing'
-        ):
+        with mock.patch('app.browser.wrapper._BIN_DIR', tmp_path / 'missing'):
             assert _wipe_generated_wrappers() == 0
 
 

--- a/tests/unit/test_browser/test_ziniao_health_gate.py
+++ b/tests/unit/test_browser/test_ziniao_health_gate.py
@@ -16,9 +16,9 @@ from unittest import mock
 import pytest
 
 from app.browser import ziniao as zmod
+from app.browser.launch_guards import RelaunchBudget
 from app.browser.manager import BrowserManager
 from app.browser.ziniao import ZiniaoBackend
-from app.models.store import Store
 
 pytestmark = pytest.mark.unit
 
@@ -148,26 +148,27 @@ class TestCrossStoreIsolation:
     """One broken store must not take the others down with it."""
 
     def test_relaunch_breaker_trips_then_resets(self):
-        mgr = BrowserManager()
-        store = Store(id='s1', name='alpha', browser_backend='ziniao')
-        other = Store(id='s2', name='beta', browser_backend='ziniao')
+        budget = RelaunchBudget()
 
         # Budget is per store: 3 relaunches allowed, 4th refuses.
         for _ in range(3):
-            mgr._note_relaunch(store)
+            budget.note('s1', 'alpha')
         with pytest.raises(RuntimeError, match='Refusing to restart'):
-            mgr._note_relaunch(store)
+            budget.note('s1', 'alpha')
 
         # A DIFFERENT store is unaffected by the tripped breaker.
-        mgr._note_relaunch(other)
+        budget.note('s2', 'beta')
 
         # A healthy launch clears the budget (see start_session).
-        mgr._relaunches.pop(store.id, None)
-        mgr._note_relaunch(store)
+        budget.clear('s1')
+        budget.note('s1', 'alpha')
 
     def test_relaunch_breaker_disabled_at_zero(self, monkeypatch):
         monkeypatch.setenv('VIBE_BROWSER_RELAUNCH_MAX', '0')
-        mgr = BrowserManager()
-        store = Store(id='s1', name='alpha', browser_backend='ziniao')
+        budget = RelaunchBudget()
         for _ in range(25):
-            mgr._note_relaunch(store)  # must never raise
+            budget.note('s1', 'alpha')  # must never raise
+
+    def test_manager_wires_the_budget(self):
+        """The breaker is only useful if the manager actually holds one."""
+        assert isinstance(BrowserManager()._relaunches, RelaunchBudget)

--- a/tests/unit/test_browser/test_ziniao_health_gate.py
+++ b/tests/unit/test_browser/test_ziniao_health_gate.py
@@ -1,0 +1,173 @@
+"""Unit tests: a Ziniao env is only "ready" if Ziniao instrumented it,
+and one broken store can never stall the others.
+
+Observed failure (2026-07-25): three stores' envs came up with their
+debug port bound but Ziniao's SBP layer never injected — no account
+auto-fill, no OTP/passkey overlay, and ``navigator.webdriver`` leaking
+``true`` to Amazon, which bounced every page to ``/ap/signin``. The
+readiness contract only proved *Chrome* was up, so the agents were
+handed unusable browsers and burned a full run on an unwinnable login.
+Meanwhile the dead-mux path relaunched the whole env on every
+``browser-use`` call, hammering the shared Ziniao client until it hung.
+"""
+
+from unittest import mock
+
+import pytest
+
+from app.browser import ziniao as zmod
+from app.browser.manager import BrowserManager
+from app.browser.ziniao import ZiniaoBackend
+from app.models.store import Store
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def cfg():
+    return {
+        'company': 'co',
+        'username': 'u',
+        'password': 'p',
+        'socket_port': 16851,
+        'client_path': 'ziniao',
+        'browser_oauth': 'OAUTH==',
+        'proxy_port': 9222,
+        'store_slug': 'store-x',
+    }
+
+
+class TestInstrumentationGate:
+    async def test_uninstrumented_env_is_rejected_and_recovered_per_store(
+        self, cfg, tmp_path
+    ):
+        """Port reachable but SBP dead → treat as a stale launch and
+        recover PER STORE (stopBrowser this env + retry), never a global
+        client kill."""
+        calls: list[str] = []
+
+        async def fake_try_connect(port, data, timeout):
+            calls.append(data['action'])
+            return (
+                {'statusCode': '0', 'debuggingPort': 5000 + len(calls)},
+                '127.0.0.1',
+            )
+
+        # Port is always reachable — only instrumentation is missing,
+        # so this is exactly the case the old gate waved through.
+        live = iter([False, False, True])
+
+        async def fake_live(host, port):
+            return next(live)
+
+        with (
+            mock.patch.object(
+                zmod, 'ensure_ziniao_running', new=mock.AsyncMock()
+            ),
+            mock.patch.object(zmod, 'update_ziniao_core', new=mock.AsyncMock()),
+            mock.patch.object(
+                zmod,
+                'try_connect_ziniao',
+                new=mock.AsyncMock(side_effect=fake_try_connect),
+            ),
+            mock.patch.object(
+                ZiniaoBackend,
+                '_cdp_port_reachable',
+                new=mock.AsyncMock(return_value=True),
+            ),
+            mock.patch.object(
+                ZiniaoBackend,
+                '_instrumentation_live',
+                new=mock.AsyncMock(side_effect=fake_live),
+            ),
+            mock.patch.object(
+                ZiniaoBackend,
+                '_wait_for_target_stability',
+                new=mock.AsyncMock(),
+            ),
+            mock.patch.object(zmod, 'CDPMuxProxy') as MockProxy,
+            mock.patch('app.browser.ziniao.DOWNLOADS_DIR', tmp_path),
+            mock.patch('app.browser.ziniao_utils.force_kill_ziniao') as fk,
+            mock.patch(
+                'app.browser.ziniao_utils.kill_and_relaunch_ziniao',
+                new=mock.AsyncMock(),
+            ) as kar,
+        ):
+            MockProxy.return_value.start = mock.AsyncMock()
+            await ZiniaoBackend().start(cfg)
+
+        fk.assert_not_called()
+        kar.assert_not_called()
+        assert calls.count('stopBrowser') >= 2, (
+            f'expected per-store stopBrowser recovery, got {calls}'
+        )
+
+    async def test_never_uninstrumented_after_all_attempts(self, cfg, tmp_path):
+        """If instrumentation never appears, start() FAILS rather than
+        returning a browser the agent cannot log in with."""
+
+        async def fake_try_connect(port, data, timeout):
+            return ({'statusCode': '0', 'debuggingPort': 6000}, '127.0.0.1')
+
+        with (
+            mock.patch.object(
+                zmod, 'ensure_ziniao_running', new=mock.AsyncMock()
+            ),
+            mock.patch.object(zmod, 'update_ziniao_core', new=mock.AsyncMock()),
+            mock.patch.object(
+                zmod,
+                'try_connect_ziniao',
+                new=mock.AsyncMock(side_effect=fake_try_connect),
+            ),
+            mock.patch.object(
+                ZiniaoBackend,
+                '_cdp_port_reachable',
+                new=mock.AsyncMock(return_value=True),
+            ),
+            mock.patch.object(
+                ZiniaoBackend,
+                '_instrumentation_live',
+                new=mock.AsyncMock(return_value=False),
+            ),
+            mock.patch('app.browser.ziniao.DOWNLOADS_DIR', tmp_path),
+        ):
+            with pytest.raises(RuntimeError, match='instrumentation'):
+                await ZiniaoBackend().start(cfg)
+
+    async def test_probe_fails_open_when_inconclusive(self):
+        """A probe that cannot reach the port must NOT block the launch —
+        an unreachable/erroring probe is 'unknown', not 'broken'. Only a
+        positive ``navigator.webdriver === true`` is a verdict."""
+        ok = await ZiniaoBackend._instrumentation_live(
+            '127.0.0.1', 1, attempts=1, delay=0
+        )
+        assert ok is True
+
+
+class TestCrossStoreIsolation:
+    """One broken store must not take the others down with it."""
+
+    def test_relaunch_breaker_trips_then_resets(self):
+        mgr = BrowserManager()
+        store = Store(id='s1', name='alpha', browser_backend='ziniao')
+        other = Store(id='s2', name='beta', browser_backend='ziniao')
+
+        # Budget is per store: 3 relaunches allowed, 4th refuses.
+        for _ in range(3):
+            mgr._note_relaunch(store)
+        with pytest.raises(RuntimeError, match='Refusing to restart'):
+            mgr._note_relaunch(store)
+
+        # A DIFFERENT store is unaffected by the tripped breaker.
+        mgr._note_relaunch(other)
+
+        # A healthy launch clears the budget (see start_session).
+        mgr._relaunches.pop(store.id, None)
+        mgr._note_relaunch(store)
+
+    def test_relaunch_breaker_disabled_at_zero(self, monkeypatch):
+        monkeypatch.setenv('VIBE_BROWSER_RELAUNCH_MAX', '0')
+        mgr = BrowserManager()
+        store = Store(id='s1', name='alpha', browser_backend='ziniao')
+        for _ in range(25):
+            mgr._note_relaunch(store)  # must never raise

--- a/tests/unit/test_logging_setup.py
+++ b/tests/unit/test_logging_setup.py
@@ -1,0 +1,148 @@
+"""Unit tests: the backend log is bounded.
+
+``--dev`` sets ``LOG_LEVEL=DEBUG`` (per-statement aiosqlite/httpcore/
+websockets chatter) and the handler used to be a plain ``FileHandler``,
+so a long dev session produced a 5 GB ``backend_<port>.log``. Rotation
+must fire on size OR age, and the on-disk total must stay under
+``LOG_MAX_BYTES * (LOG_BACKUP_COUNT + 1)``.
+"""
+
+import logging
+import time
+
+import pytest
+
+from app.logging_setup import (
+    SizeAndTimeRotatingFileHandler,
+    build_file_handler,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _record(msg: str) -> logging.LogRecord:
+    return logging.LogRecord('test', logging.INFO, __file__, 1, msg, None, None)
+
+
+def _emit(handler: logging.Handler, n: int, payload: str) -> None:
+    for _ in range(n):
+        handler.emit(_record(payload))
+
+
+class TestSizeRotation:
+    def test_stays_bounded_across_MANY_rollovers(self, tmp_path):
+        """The ceiling must hold for a log that rolls over and over.
+
+        Regression guard: bolting a size check onto
+        ``TimedRotatingFileHandler`` passed a single-rollover test and
+        then silently stopped rotating — since Python 3.12 its
+        ``doRollover`` returns early when the timestamped backup already
+        exists, which is every subsequent roll inside the same window.
+        The file grew unbounded while ``shouldRollover`` kept saying yes.
+        """
+        log = tmp_path / 'backend.log'
+        handler = SizeAndTimeRotatingFileHandler(
+            log, max_bytes=2000, rotate_seconds=7 * 86400, backup_count=1
+        )
+        handler.setFormatter(logging.Formatter('%(message)s'))
+        try:
+            _emit(handler, 400, 'x' * 100)  # ~40 KB >> 2 KB cap
+        finally:
+            handler.close()
+
+        names = sorted(p.name for p in tmp_path.iterdir())
+        assert names == ['backend.log', 'backend.log.1'], names
+        total = sum(p.stat().st_size for p in tmp_path.iterdir())
+        assert total <= 2000 * 2, f'total {total} exceeds max_bytes*(n+1)'
+
+    def test_backup_count_zero_keeps_only_current(self, tmp_path):
+        log = tmp_path / 'backend.log'
+        handler = SizeAndTimeRotatingFileHandler(
+            log, max_bytes=2000, rotate_seconds=0, backup_count=0
+        )
+        handler.setFormatter(logging.Formatter('%(message)s'))
+        try:
+            _emit(handler, 200, 'x' * 100)
+        finally:
+            handler.close()
+        assert [p.name for p in tmp_path.iterdir()] == ['backend.log']
+        assert log.stat().st_size <= 2000
+
+    def test_no_rollover_below_cap(self, tmp_path):
+        log = tmp_path / 'backend.log'
+        handler = SizeAndTimeRotatingFileHandler(
+            log, max_bytes=10 * 1024, rotate_seconds=7 * 86400, backup_count=1
+        )
+        handler.setFormatter(logging.Formatter('%(message)s'))
+        try:
+            _emit(handler, 5, 'small')
+        finally:
+            handler.close()
+        assert [p.name for p in tmp_path.iterdir()] == ['backend.log']
+
+
+class TestTimeRotation:
+    def test_rolls_on_age_even_when_small(self, tmp_path):
+        """A quiet week must still roll — size alone would never fire."""
+        log = tmp_path / 'backend.log'
+        handler = SizeAndTimeRotatingFileHandler(
+            log,
+            max_bytes=10**9,
+            rotate_seconds=7 * 86400,
+            backup_count=1,
+        )
+        handler.setFormatter(logging.Formatter('%(message)s'))
+        try:
+            _emit(handler, 1, 'before')
+            handler.rollover_at = time.time() - 1  # the week elapsed
+            _emit(handler, 1, 'after')
+        finally:
+            handler.close()
+
+        assert sorted(p.name for p in tmp_path.iterdir()) == [
+            'backend.log',
+            'backend.log.1',
+        ]
+        assert log.read_text().strip() == 'after'
+        assert (tmp_path / 'backend.log.1').read_text().strip() == 'before'
+        # Clock re-armed, so it does not roll on every subsequent record.
+        assert handler.rollover_at > time.time()
+
+
+class TestBuildFileHandler:
+    def test_defaults_are_bounded(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('LOG_MAX_BYTES', raising=False)
+        monkeypatch.delenv('LOG_ROTATE_DAYS', raising=False)
+        monkeypatch.delenv('LOG_BACKUP_COUNT', raising=False)
+        h = build_file_handler(tmp_path / 'b.log')
+        try:
+            assert isinstance(h, SizeAndTimeRotatingFileHandler)
+            assert h.max_bytes == 5 * 1024**3  # 5 GiB
+            assert h.backup_count == 1  # → 10 GiB ceiling
+            assert h.rotate_seconds == 7 * 86400  # → 2 weeks
+        finally:
+            h.close()
+
+    def test_both_zero_disables_rotation(self, tmp_path, monkeypatch):
+        monkeypatch.setenv('LOG_MAX_BYTES', '0')
+        monkeypatch.setenv('LOG_ROTATE_DAYS', '0')
+        h = build_file_handler(tmp_path / 'b.log')
+        try:
+            assert type(h) is logging.FileHandler
+        finally:
+            h.close()
+
+    def test_size_only_when_days_zero(self, tmp_path, monkeypatch):
+        """days=0 must not mean 'roll constantly' — size still governs."""
+        monkeypatch.setenv('LOG_MAX_BYTES', '4096')
+        monkeypatch.setenv('LOG_ROTATE_DAYS', '0')
+        h = build_file_handler(tmp_path / 'b.log')
+        try:
+            assert isinstance(h, SizeAndTimeRotatingFileHandler)
+            assert h.max_bytes == 4096
+            # Age trigger disabled outright, so only size governs.
+            assert h.rotate_seconds == 0
+            assert h.rollover_at == 0.0
+            assert h.shouldRollover(_record('tiny')) == 0
+        finally:
+            h.close()

--- a/tests/unit/test_stop_gates.py
+++ b/tests/unit/test_stop_gates.py
@@ -379,6 +379,40 @@ class TestAdScaleWinnersGate:
         above = self.HEADER + self._row('5.5', 'Hold', acos='18%')
         assert scale_winners_gate.check(above) is not None
 
+    def _no_bid_row(self, roas, rec, acos='4.0%'):
+        """Campaign-level aggregate: no per-keyword bid to raise."""
+        return (
+            f'| 全活动（无逐词数据） | Delivering | 100 '
+            f'| USD 100.00 | 20 | USD 1000.00 | {acos} | {roas} | - '
+            f'| USD 1.00 | {rec} |\n'
+        )
+
+    def test_row_without_a_bid_is_not_a_scale_candidate(self):
+        """A bid rule may only judge a row that HAS a bid.
+
+        Campaign-aggregate rows (auto / Brand placements with no
+        per-term bid control) carry ``-`` in the bid cell, so "raise the
+        bid or justify the hold" is unsatisfiable — the agent cannot
+        ever pass it. Observed live: four such rows kept the report in
+        the review loop for ~34 rounds until the agent resorted to
+        renaming columns and zeroing values.
+        """
+        report = self.HEADER + self._no_bid_row(
+            '12.43', '维持出价（无逐词出价控制）'
+        )
+        assert scale_winners_gate.check(report) is None
+
+    def test_still_flags_the_same_row_when_it_does_have_a_bid(self):
+        """The guard must not neuter the gate: identical row, real bid."""
+        report = self.HEADER + self._row('12.43', '维持出价')
+        assert scale_winners_gate.check(report) is not None
+
+    def test_empty_bid_cell_also_skipped(self):
+        report = self.HEADER + self._no_bid_row('9.0', 'Hold').replace(
+            '| - |', '|  |'
+        )
+        assert scale_winners_gate.check(report) is None
+
     def test_per_store_override_raises_threshold(self):
         # A store whose notes.md sets scale_roas: 30 → a ROAS 24 bare
         # Hold is below the override and must NOT be flagged.

--- a/tests/unit/test_task_queue.py
+++ b/tests/unit/test_task_queue.py
@@ -110,6 +110,57 @@ class TestSubmitStatus:
             task = await db.get(Task, 'task-1')
             assert task.status == TaskStatus.QUEUED
 
+    async def test_submit_failed_becomes_queued(
+        self, db_session, store_and_task
+    ):
+        """Retry must actually re-enqueue. FAILED is in ``STARTABLE`` so
+        ``POST /tasks/{id}/start`` accepts it, but while submit() left the
+        row FAILED the spawn was silently dropped by ``_on_start`` (which
+        only starts from PLANNED/QUEUED/RUNNING) — retry looked like it
+        worked and did nothing."""
+        await store_and_task(status=TaskStatus.FAILED)
+        scheduler = TaskQueueScheduler()
+
+        with (
+            patch('app.scheduler.task_queue.async_session', db_session),
+            patch('app.scheduler.task_queue.event_bus', new_callable=AsyncMock),
+        ):
+            await scheduler.submit('task-1', 'store-1')
+
+        async with db_session() as db:
+            task = await db.get(Task, 'task-1')
+            assert task.status == TaskStatus.QUEUED
+
+    async def test_submit_clears_previous_run_error(
+        self, db_session, store_and_task
+    ):
+        """A retry must not carry the last run's error forward.
+
+        `task.error` is a terminal-run artifact but every consumer reads
+        it as current — the detail panel renders a red banner from it
+        with no status guard — so a retried task showed "运行中" and
+        "任务已被用户停止。" simultaneously.
+        """
+        await store_and_task(status=TaskStatus.FAILED)
+        async with db_session() as db:
+            task = await db.get(Task, 'task-1')
+            task.error = 'Stopped by user'
+            task.error_category = 'user_stop'
+            await db.commit()
+
+        scheduler = TaskQueueScheduler()
+        with (
+            patch('app.scheduler.task_queue.async_session', db_session),
+            patch('app.scheduler.task_queue.event_bus', new_callable=AsyncMock),
+        ):
+            await scheduler.submit('task-1', 'store-1')
+
+        async with db_session() as db:
+            task = await db.get(Task, 'task-1')
+            assert task.status == TaskStatus.QUEUED
+            assert task.error is None
+            assert task.error_category is None
+
     async def test_submit_planned_stays_planned(
         self, db_session, store_and_task
     ):

--- a/tests/unit/test_task_states.py
+++ b/tests/unit/test_task_states.py
@@ -59,6 +59,7 @@ class TestTaskStates:
         failed_targets = TRANSITIONS[TaskStatus.FAILED]
         assert failed_targets == {
             TaskStatus.PENDING,
+            TaskStatus.QUEUED,  # retry: FAILED is in STARTABLE
             TaskStatus.DESIGNING,
             TaskStatus.RUNNING,  # follow-up (auto mode)
         }
@@ -195,6 +196,7 @@ _EXPECTED_TRANSITIONS: dict[TaskStatus, set[TaskStatus]] = {
     },
     TaskStatus.FAILED: {
         TaskStatus.PENDING,
+        TaskStatus.QUEUED,
         TaskStatus.DESIGNING,
         TaskStatus.RUNNING,
     },


### PR DESCRIPTION
Six defects found while debugging a scheduled ad-audit run that stalled asking the user for a password it never needed. Each one let a wrong state through a surface that should have rejected it, so the symptom always surfaced far from the cause.

## The chain

The agent reported "the anti-detect browser isn't auto-filling the login" and escalated to the user. That observation was real; the conclusion was wrong. The browser env had come up **without its instrumentation layer** — no account auto-fill, no OTP or passkey overlay, and `navigator.webdriver` left unmasked at `true`, so the platform treated every page as a bot and bounced it to the sign-in wall. Nothing checked for this, because readiness only proved *Chrome* was up.

Verified by measurement, not inference:

| probe | wedged env | fresh env |
|---|---|---|
| page-script patch applied | absent | present |
| `navigator.webdriver` | `true` (leaking) | `false` (masked) |
| seller home | → sign-in | stays, logged in |

## Fixes

**1. Two-gate readiness (`ziniao.py`).** Port reachable **and** instrumentation live. Deliberately fail-open — only a positive `webdriver === true` on a real http(s) page is a verdict; unreachable, eval error, or no-page-yet all pass, so a probe bug can never become a store-wide outage. Live-verified against real browsers: passes a healthy env, rejects a stock Chromium that leaks `webdriver`.

**2. Bounded recovery (`manager.py`).** The dead-mux path relaunches a whole store env and is reachable from *every* browser call, so a wedged client turned recovery into a restart storm — three stores cycling stop/start every ~20 s for five minutes, which wiped agent tabs mid-task and deepened the wedge. Now budgeted per store (`VIBE_BROWSER_RELAUNCH_MAX` / `_WINDOW_S`), and `backend.start()` is capped by `VIBE_BROWSER_START_TIMEOUT_S`. That cap matters because `start_session` holds a **global** lock — deliberately, to serialize launches against the shared client — so an unbounded per-store retry starved every other store. Worst case went from ~6–7 min of cross-store starvation to 180 s.

**3. Retry was a silent no-op (`task_queue.py`, `task_states.py`).** `FAILED` is in `STARTABLE`, so `POST /tasks/{id}/start` returned `200 {"status":"queued"}` — but `submit()` only promoted `PENDING`/`WAITING`, leaving the row `FAILED` for `_on_start` to drop (`aborting spawn`). Retry looked like it worked and did nothing.

**4. Stale error survived retry (`task_queue.py`).** `error` is a terminal-run artifact but every consumer reads it as current, so a retried task rendered "running" **and** a red "stopped by user" banner at once. Cleared at requeue rather than hidden in the view — an agent may legitimately attach an error to a RUNNING task via `set_task_error` to report a partial failure, so the view must keep showing those.

**5. Orphan wrappers could drive another store's browser (`manager.py`).** Reaping was version-only, so a deleted store's wrapper lived forever holding a **frozen** proxy port. Ports are reallocated every boot, so that number eventually lands on a live store; the orphan then finds the port up, skips the start API (its dead store id never 404s) and points the CDP endpoint at someone else's browser — the same cross-store hole wrapper v3 closed for aux sessions. Now also reaped by ownership, with a guard that never reaps on an empty store set. Live-verified: `wiped 3 wrapper(s) (1 outdated, 2 orphaned)`.

Those orphans came from **the test suite writing into the developer's real `~/.vibe-seller/bin/`** — no isolation. Worse in the other direction: a reap driven by a test's in-memory DB deleted every live store's wrapper mid-run. `conftest` now isolates the wrapper dir; the suite leaves the real one untouched.

**6. An unsatisfiable stop gate (`ad_scale_winners.py`).** It demanded "raise the bid or justify the hold" on campaign-level aggregate rows whose bid cell is `-` — auto/Brand placements with no per-term bid control. There is no bid to raise, so the agent could never pass it: one report cycled ~34 review rounds and ended up renaming columns and zeroing values to escape. A bid rule may only judge a row that carries a bid. Structural, not another prose exception. Not mirrored in `ad_bid_floor`: that gate *forbids* an action, so a bid-less row recommending a cut is itself a real defect worth catching.

## Also

- **Composer Send/Stop shared pixels.** The send slot flipped to a red Stop whenever the box emptied — which is exactly what sending does. Measured: Send `x1110–1176`, Stop `x1121–1176`, identical y and height, so the click that sent a message left a destructive button under the cursor and a double-click ended the run with no confirmation. The slot is Send-only now and the `onStop` prop is gone so it can't be re-wired; Stop stays in the task header. This is a real reported incident, not a hypothetical.
- **Bounded logging** (`logging_setup.py`). `--dev` had produced a 5 GB unrotated log. Rotates on size **or** age, ceiling `LOG_MAX_BYTES × (LOG_BACKUP_COUNT + 1)` — 10 GiB / 2 weeks by default; `start.sh` applies the same policy to the file it captures by shell redirect. Note: subclassing `TimedRotatingFileHandler` and adding a size check *looks* right and is broken — since Python 3.12 its `doRollover` returns early when the timestamped backup exists, so every rollover after the first silently does nothing. Rotation is owned here with numbered backups; a test pins the ceiling across many rollovers.

## Tests

`2030 passed` backend, `406 passed` frontend, `tsc` clean. New coverage for every invariant above, including cross-store isolation of the breaker, probe fail-open, orphan-vs-live wrapper reaping, retry re-enqueue, error clearing, the bid-less row skip (plus a companion asserting the gate still fires when the row *does* have a bid), log-rotation ceilings, and a composer test asserting zero destructive controls across all active/content combinations.

One pre-existing failure is unrelated and reproduces on a clean tree: `test_platform.py::TestFindPidListeningOnPort::test_finds_own_listener` (sandbox blocks `lsof`).

## Docs

`ziniao-concurrency.md` (two-gate readiness, budgeted relaunch, the second wedge symptom + runbook), `browser.md`, `backend.md` (the env-var table — it was the only one in the repo and was missing every new knob), `tasks.md`. Corrected two stale claims in the debug skill that actively misled this investigation: a `POST /browser/stop` route that has never existed, and a hardcoded single mux port when ports are allocated per store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qg5csnfP39iFPAEqcEnqwK
