### PR TITLE
fix(profiles): mark MiniMax-M3 as multimodal per docs

### DIFF
--- a/app/ai/profiles.py
+++ b/app/ai/profiles.py
@@ -307,15 +307,21 @@ PROVIDER_MODELS = {
             'vision': True,
         },
     ],
-    # MiniMax: text-only. Live probe (red+blue x3) had M3 name red then
-    # reply "i cannot see images" / wrong color, and M2.x return empty —
-    # it accepts image blocks but does not reliably read them.
+    # MiniMax: M3 is multimodal; M2.x is text-only. M3 image+video
+    # input is documented at platform.minimaxi.com/docs/llms.txt
+    # ("Anthropic API compatibility supports type=image / type=video
+    # for MiniMax-M3; M2.x only supports text and tool-calling content
+    # blocks"). Doc-verified, not live-probed. An earlier live probe
+    # (red+blue x3 against M3) returned "cannot see images" / wrong
+    # color — that contradicts the doc and likely reflected an
+    # earlier model rollout; the user-facing badge now follows the
+    # doc so the agent stops degrading on browser screenshots.
     'minimax': [
         {
             'id': 'MiniMax-M3[1m]',
             'label': 'M3 (1M context)',
             'context': '1M',
-            'vision': False,
+            'vision': True,
         },
         {
             'id': 'MiniMax-M2.7',

--- a/tests/workflow/test_wf_profiles.py
+++ b/tests/workflow/test_wf_profiles.py
@@ -146,8 +146,14 @@ class TestProfileCrud:
         (64x64 red + blue, x3) actually found — NOT web search:
 
         - Qwen plus / flash / VL read both colors -> vision.
-        - qwen-max (400 on images), DeepSeek (empty), MiniMax (unreliable
-          / "cannot see images") -> text-only.
+        - qwen-max (400 on images), DeepSeek (empty), MiniMax M2.x
+          (no image support per docs) -> text-only.
+        - MiniMax M3 is multimodal per the MiniMax docs
+          (platform.minimaxi.com/docs/llms.txt — M3 accepts
+          type=image / type=video; M2.x is text+tool only). Doc-verified
+          because the earlier live probe conflicted with the doc; the
+          UI badge follows the doc so the agent doesn't degrade on
+          browser screenshots.
         - Kimi + GLM have no account key to probe, so vision is OMITTED
           (None) rather than guessed.
         """
@@ -165,7 +171,12 @@ class TestProfileCrud:
         # Live-verified text-only
         assert vis('qwen', 'qwen3.7-max') is False
         assert vis('deepseek', 'deepseek-v4-pro[1m]') is False
-        assert vis('minimax', 'MiniMax-M3[1m]') is False
+        # MiniMax: M3 is multimodal per docs; M2.x stays text-only
+        # (docs explicitly say M2.x only supports text+tool blocks).
+        assert vis('minimax', 'MiniMax-M3[1m]') is True
+        assert vis('minimax', 'MiniMax-M2.7') is False
+        assert vis('minimax', 'MiniMax-M2.5') is False
+        assert vis('minimax', 'MiniMax-M2.1') is False
         # GLM: text-only (confirmed — vision is the separate glm-4.5v /
         # glm-4v line, not these). Kimi K3: vision per Moonshot's official
         # vision guide + context7 (doc-verified, no key to live-probe).


### PR DESCRIPTION
## Summary

- Flip `MiniMax-M3[1m]` from `vision=False` to `vision=True` in `PROVIDER_MODELS['minimax']` (`app/ai/profiles.py`).
- Keep M2.7 / M2.5 / M2.1 at `vision=False` (the docs explicitly say M2.x is text+tool-only).
- Update the comment block on the `minimax` model list to cite the doc (platform.minimaxi.com/docs/llms.txt) and explain why the badge now follows the doc over the earlier live probe.
- Update `test_vision_labels_match_live_probe` to assert `M3 → True`, `M2.x → False`, and rewrite the docstring to match.

## Why

The MiniMax docs state:

> `MiniMax-M3` 支持通过 Anthropic 兼容内容块输入图片和视频；M2.7、M2.5、M2.1 和 M2 系列仅支持文本与工具调用相关内容块

…while our catalog had M3 marked text-only based on an old live probe that returned `"cannot see images"` / wrong color on a red+blue image. The user-facing config modal surfaces the badge as `纯文本` / `text-only` (see `frontend/src/i18n/locales/{en,zh}/translation.json` → `settings.textOnly`), which the agent reads when picking the default model — so the agent was effectively told M3 was text-only and would degrade on browser screenshots.

Doc-verified, not live-probed: the doc wins because the badge drives agent behavior on a model the agent already runs against, and the earlier probe contradicts the doc.

## Test

```
$ pytest -m workflow tests/workflow/test_wf_profiles.py
============= 18 passed in 4.23s =============
```

`ruff check` and `ruff format --check` both clean. Pre-commit hooks all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)