### PR TITLE
fix(skills): debug-store uses a stable debug account

### DIFF
--- a/.claude/skills/debug-store/SKILL.md
+++ b/.claude/skills/debug-store/SKILL.md
@@ -178,41 +178,50 @@ everything on a JWT cookie. From a Claude Code shell, you don't have
 that cookie. Two ways to work around without touching the user's
 admin password:
 
-### Option A — temp admin user, login via API, then deactivate
+### Option A — reusable `taskbot_debug` account, login via API, then deactivate
+
+**Always reuse the single `taskbot_debug` account.** Never mint a
+per-session `taskbot_tmp_$(date +%s)`-style user — that pattern
+accumulated 20+ dead admin accounts in the settings page before it was
+banned. The flow below is idempotent: it creates the account on first
+use, reactivates + rotates the password on every later use, and
+deactivates it when you're done.
 
 ```bash
 # 1. Generate password + bcrypt hash
 PW=$(python3 -c "import secrets;print('tmp_'+secrets.token_hex(8))")
 HASH=$(./.venv/bin/python3 -c "from app.password import hash_password;print(hash_password('$PW'))")  # run from repo root
 
-# 2. Insert temp user (admin role)
-TMP_UID="taskbot-$(uuidgen)"
-TMP_USERNAME="taskbot_tmp_$(date +%s)"
+# 2. Upsert the stable debug user (admin role, fixed id + username)
+DBG_UID="taskbot-debug"
 NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 sqlite3 ~/.vibe-seller/data/vibe_seller.db \
   "INSERT INTO users (id, username, email, password_hash, role, is_active,
                       plan_mode_default, debug_mode, default_profile_id,
                       created_at, updated_at)
-   VALUES ('$TMP_UID','$TMP_USERNAME',NULL,'$HASH','admin',1,1,0,'default',
-           '$NOW','$NOW');"
+   VALUES ('$DBG_UID','taskbot_debug',NULL,'$HASH','admin',1,1,0,'default',
+           '$NOW','$NOW')
+   ON CONFLICT(id) DO UPDATE SET
+     password_hash='$HASH', is_active=1, updated_at='$NOW';"
 
 # 3. Login → cookie
 curl -s -c /tmp/vs_cookie.txt -H 'Content-Type: application/json' \
   -X POST http://localhost:7777/api/auth/login \
-  -d "{\"identifier\":\"$TMP_USERNAME\",\"password\":\"$PW\"}"
+  -d "{\"identifier\":\"taskbot_debug\",\"password\":\"$PW\"}"
 
 # 4. Use the cookie for any API call
 curl -s -b /tmp/vs_cookie.txt http://localhost:7777/api/stores
 
-# 5. Cleanup — but only if no tasks reference the user (FK = restrict)
+# 5. Cleanup — MANDATORY before ending the session
 sqlite3 ~/.vibe-seller/data/vibe_seller.db \
-  "UPDATE users SET is_active=0 WHERE id='$TMP_UID';"
-# OR DELETE if no tasks were created with created_by=this user.
+  "UPDATE users SET is_active=0 WHERE id='$DBG_UID';"
 ```
 
-The `users.is_active=0` flag blocks future logins without violating the
-`tasks.created_by` FK. This is the safest cleanup if you created any
-tasks with the temp account.
+`is_active=0` blocks future logins without violating the
+`tasks.created_by` FK (FK = restrict, so the row can never be deleted
+once it owns tasks — which is fine: it's one stable row, not one per
+session). If you forget step 5 the account stays dormant with a
+throwaway password; the next session rotates it anyway.
 
 ### Option B — drive the wrapper directly (no API auth needed)
 

--- a/.claude/skills/debug-store/SKILL.md
+++ b/.claude/skills/debug-store/SKILL.md
@@ -180,12 +180,10 @@ admin password:
 
 ### Option A — reusable `taskbot_debug` account, login via API, then deactivate
 
-**Always reuse the single `taskbot_debug` account.** Never mint a
-per-session `taskbot_tmp_$(date +%s)`-style user — that pattern
-accumulated 20+ dead admin accounts in the settings page before it was
-banned. The flow below is idempotent: it creates the account on first
-use, reactivates + rotates the password on every later use, and
-deactivates it when you're done.
+Use the single stable `taskbot_debug` account for every debug session.
+The flow below is idempotent: it creates the account on first use,
+reactivates + rotates the password on every later use, and deactivates
+it when you're done.
 
 ```bash
 # 1. Generate password + bcrypt hash
@@ -212,16 +210,16 @@ curl -s -c /tmp/vs_cookie.txt -H 'Content-Type: application/json' \
 # 4. Use the cookie for any API call
 curl -s -b /tmp/vs_cookie.txt http://localhost:7777/api/stores
 
-# 5. Cleanup — MANDATORY before ending the session
+# 5. Cleanup before ending the session
 sqlite3 ~/.vibe-seller/data/vibe_seller.db \
   "UPDATE users SET is_active=0 WHERE id='$DBG_UID';"
 ```
 
-`is_active=0` blocks future logins without violating the
-`tasks.created_by` FK (FK = restrict, so the row can never be deleted
-once it owns tasks — which is fine: it's one stable row, not one per
-session). If you forget step 5 the account stays dormant with a
-throwaway password; the next session rotates it anyway.
+`is_active=0` blocks future logins for this account. The
+`tasks.created_by` column uses FK = restrict, so the row itself can
+never be deleted once it owns tasks — that's fine, it's one stable
+row across all sessions. If you forget step 5 the account stays
+dormant with a throwaway password; the next session rotates it.
 
 ### Option B — drive the wrapper directly (no API auth needed)
 

--- a/.claude/skills/debug-task/SKILL.md
+++ b/.claude/skills/debug-task/SKILL.md
@@ -63,6 +63,12 @@ powershell.exe -NoProfile -Command "Get-Process python,pythonw -ErrorAction Sile
 # → paths under C:\Users\<WinUser>\AppData\Local\Programs\VibeSeller\ confirm it
 ```
 
+**Need to call the HTTP API from this skill (not just read the DB)?**
+Get a session cookie via the JWT-auth workaround described in
+`debug-store/SKILL.md` § "Skipping JWT-cookie auth" — it uses a single
+stable `taskbot_debug` account, rotates the password per session, and
+deactivates on exit.
+
 **When the live server is native-Windows, everything relocates.** The
 real runtime data root is **`/mnt/c/Users/<WinUser>/.vibe-seller/`**
 (commonly `<WinUser>=Administrator`), NOT `~/.vibe-seller`. Re-point


### PR DESCRIPTION
## Summary

Update the JWT-auth workaround in the `debug-store` skill to use a
single stable `taskbot_debug` account (idempotent upsert: creates on
first use, rotates password + reactivates on every later use,
deactivates on exit) instead of minting a fresh per-session admin
user.

Add a one-line pointer from `debug-task` to the same account so any
future API recipe that needs a session cookie can reuse it.

## Why

`debug-store` previously inserted `taskbot_tmp_$(date +%s)`-style
admin rows directly into SQLite on every debug session, with cleanup
as an optional step. The `tasks.created_by` FK = restrict, so any
account that created tasks could not be deleted — only deactivated —
and the Settings → Users list grew monotonically.

The stable-account approach makes the worst case exactly one row:
- Idempotent `INSERT ... ON CONFLICT(id) DO UPDATE` keeps one row
  across all sessions; rotates the password and sets `is_active=1`
  on every use.
- The FK-restrict concern becomes moot (one stable row, not one per
  session).
- A forgotten cleanup self-heals on the next session's password
  rotation — the throwaway password is invalidated by the next
  upsert.

## Scope

Skill text only (`debug-store/SKILL.md`, `debug-task/SKILL.md`). No
runtime code or DB schema changes.

## Testing

- Verified the upsert + login + deactivate flow against a local
  dev DB (account created on first run, password rotated +
  reactivated on second, `is_active=0` after cleanup).
- Grepped the diff, commit message, and this PR body for real
  brand/SKU/ASIN/entity-id/metric shapes — none present; all
  identifiers are internal debug-account names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)