### PR TITLE
feat(profiles): opt-in sync of schedule pins on default-profile change

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -61,6 +61,8 @@ def _ensure_added_columns(conn) -> None:
         ('tasks', 'review_gaps', 'TEXT'),
         ('tasks', 'submission_count', 'INTEGER NOT NULL DEFAULT 0'),
         ('tasks', 'transcript_tail', 'TEXT'),
+        # User pref: re-pin owned schedules on default-profile change.
+        ('users', 'sync_profile_to_schedules', 'BOOLEAN NOT NULL DEFAULT 0'),
     ]
     for table, column, sqltype in added:
         cols = {

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -32,6 +32,12 @@ class User(Base):
     default_profile_id: Mapped[str] = mapped_column(
         String(50), nullable=False, default='default'
     )
+    # When on, changing the default profile also re-pins this user's
+    # schedules that carry a concrete ai_profile_id to the new default
+    # (rows left as 'default'/NULL already inherit and are untouched).
+    sync_profile_to_schedules: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
     created_at: Mapped[str] = mapped_column(
         String, default=lambda: datetime.now(UTC).isoformat()
     )

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -65,6 +65,7 @@ async def login(body: LoginRequest, db: AsyncSession = Depends(get_db)):
             'default_profile_id': user.default_profile_id,
             'debug_mode': user.debug_mode,
             'plan_mode_default': user.plan_mode_default,
+            'sync_profile_to_schedules': user.sync_profile_to_schedules,
         }
     )
     set_session_cookie(response, token)
@@ -213,6 +214,21 @@ async def update_profile(
             {
                 'key': 'plan_mode_default',
                 'to_value': bool(body.plan_mode_default),
+            },
+        )
+        changed = True
+
+    if (
+        body.sync_profile_to_schedules is not None
+        and body.sync_profile_to_schedules
+        != current_user.sync_profile_to_schedules
+    ):
+        current_user.sync_profile_to_schedules = body.sync_profile_to_schedules
+        telemetry.send(
+            TelemetryEvent.USER_PREF_CHANGED,
+            {
+                'key': 'sync_profile_to_schedules',
+                'to_value': bool(body.sync_profile_to_schedules),
             },
         )
         changed = True

--- a/app/routers/profiles.py
+++ b/app/routers/profiles.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import telemetry
@@ -11,9 +12,10 @@ from app.ai.external_config import (
     assert_profile_compatible,
 )
 from app.ai.profile_validation import validate_profile_env
-from app.ai.profiles import ProfileManager, profile_kind
+from app.ai.profiles import DEFAULT_PROFILE_ID, ProfileManager, profile_kind
 from app.auth import get_current_user
 from app.database import get_db
+from app.models.schedule import Schedule
 from app.models.user import User
 from app.telemetry_events import TelemetryEvent
 
@@ -121,12 +123,33 @@ async def set_default_profile(
         raise HTTPException(status_code=404, detail='User not found')
     user.default_profile_id = profile_id
     user.updated_at = datetime.now(UTC).isoformat()
+    schedules_synced = 0
+    if user.sync_profile_to_schedules:
+        # Opt-in pref: re-pin the user's schedules that carry a
+        # concrete ai_profile_id so they move to the new default too.
+        # Rows holding 'default'/NULL already inherit the live default
+        # via resolve_schedule_profile() and are deliberately
+        # untouched; other users' schedules are out of scope.
+        result = await db.execute(
+            update(Schedule)
+            .where(
+                Schedule.created_by == user.id,
+                Schedule.ai_profile_id.is_not(None),
+                Schedule.ai_profile_id != DEFAULT_PROFILE_ID,
+            )
+            .values(ai_profile_id=profile_id)
+        )
+        schedules_synced = result.rowcount
     await db.commit()
     telemetry.send(
         TelemetryEvent.AI_PROFILE_DEFAULT_SET,
         {'provider_kind': profile_kind(profile)},
     )
-    return {'ok': True, 'default_profile_id': profile_id}
+    return {
+        'ok': True,
+        'default_profile_id': profile_id,
+        'schedules_synced': schedules_synced,
+    }
 
 
 @router.post('/validate')

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -34,6 +34,7 @@ class UserResponse(BaseModel):
     plan_mode_default: bool
     debug_mode: bool
     default_profile_id: str
+    sync_profile_to_schedules: bool
     created_at: str
 
 
@@ -73,6 +74,7 @@ class ProfileUpdate(BaseModel):
     username: str | None = None
     email: EmailStr | None = None
     plan_mode_default: bool | None = None
+    sync_profile_to_schedules: bool | None = None
 
     @field_validator('username')
     @classmethod

--- a/docs/api.md
+++ b/docs/api.md
@@ -152,7 +152,7 @@ On create, if the request body omits `timezone` (or sends `null`), the router re
 | POST | `/api/profiles` | Create AI profile |
 | PUT | `/api/profiles/{id}` | Update AI profile |
 | DELETE | `/api/profiles/{id}` | Delete AI profile |
-| PATCH | `/api/profiles/{id}/set-default` | Set a profile as the user's default |
+| PATCH | `/api/profiles/{id}/set-default` | Set a profile as the user's default. Response: `{'ok', 'default_profile_id', 'schedules_synced'}` — `schedules_synced` counts the caller's pinned schedules re-pinned to the new default (only when the caller's `sync_profile_to_schedules` pref is on; see [subsystems.md § Schedule AI profile resolution](subsystems.md#schedule-ai-profile-resolution)) |
 | POST | `/api/profiles/validate` | Probe a profile's endpoint config (no persistence) |
 | GET | `/api/profiles/presets` | Provider presets + per-provider model options |
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -76,7 +76,7 @@ SQLAlchemy 2.0 ORM models. All extend `Base` from `app/database.py`.
 | Model | Table | Description |
 |-------|-------|-------------|
 | `AppSettings` | `app_settings` | Key-value app settings (`auth_required`, `admin_credentials_set`, `max_agent_concurrency`, `default_schedule_phase_mode`, `default_schedule_timezone`, `task_retention_days`, `google_workspace_enabled`) |
-| `User` | `users` | Team members with JWT auth. `username` (unique, required), `email` (unique, nullable, validated). Login by username or email. Admin seeds from env (`ADMIN_USERNAME`, `ADMIN_EMAIL`). |
+| `User` | `users` | Team members with JWT auth. `username` (unique, required), `email` (unique, nullable, validated). Login by username or email. Admin seeds from env (`ADMIN_USERNAME`, `ADMIN_EMAIL`). Per-user prefs: `plan_mode_default`, `debug_mode`, `default_profile_id`, `sync_profile_to_schedules` (re-pin owned schedules on default-profile change — see [subsystems.md § Schedule AI profile resolution](subsystems.md#schedule-ai-profile-resolution)). |
 | `Store` | `stores` | E-commerce stores with browser config |
 | `BrowserSession` | `browser_sessions` | Active browser sessions per store |
 | `Task` | `tasks` | Units of work created by users |

--- a/docs/subsystems.md
+++ b/docs/subsystems.md
@@ -27,6 +27,12 @@ Cross-store scheduling. Three recurring task patterns:
 - **Task archiving**: terminal tasks (completed/failed) >7 days hidden by default, toggle to show
 - **Timezone resolution**: every schedule stores an IANA `timezone` column. When a client omits `timezone` on create, the router resolves it in order: (1) explicit `body.timezone`, (2) `AppSettings['default_schedule_timezone']`, (3) `get_server_timezone()` in `app/scheduler/cron.py` (wraps `tzlocal.get_localzone_name()`, UTC on failure). `build_trigger()` feeds the stored string into `ZoneInfo` so APScheduler fires in that zone. PUT `/api/schedules/:id` re-registers the APScheduler job so timezone edits take effect immediately.
 
+## Schedule AI profile resolution
+
+Every schedule carries `Schedule.ai_profile_id` with two meanings: `'default'`/NULL = **inherit** (follow the owner's current `User.default_profile_id`), any concrete value = **explicit pin** (always that profile). `resolve_schedule_profile()` (`app/ai/profiles.py`) runs **live at every fire** — cron (`scheduler/cron.py`), all-stores fan-out (`scheduler/fanout.py`), and finalize (`scheduler/finalize_reaper.py`) — and the resolved id is stamped onto the fired `Task.ai_profile_id` as the run's receipt. Switching the default profile therefore moves every unpinned schedule on its next fire with no schedule edits; pinned schedules are immune by design.
+
+**Opt-in sync on default change**: the per-user pref `User.sync_profile_to_schedules` (default off, toggle in Settings → AI profiles) makes `PATCH /api/profiles/{id}/set-default` additionally re-pin the caller's own schedules that hold a *concrete* `ai_profile_id` to the new default (`UPDATE ... WHERE created_by = me AND ai_profile_id NOT IN (NULL, 'default')`). Inherit rows and other users' schedules are untouched; the endpoint response reports how many rows moved in `schedules_synced`.
+
 ## Plan-at-creation lifecycle
 
 Plan-mode schedules (`Schedule.plan_mode=True`) author their plan

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -598,6 +598,8 @@
     "noVariables": "No variables added yet",
     "envVars": "environment variables",
     "noProfiles": "No custom profiles yet. Create one to get started.",
+    "syncSchedulesTitle": "Sync schedules when default changes",
+    "syncSchedulesDesc": "When you switch the default profile, schedules pinned to a specific profile are moved to the new default too. Schedules already following the default are unaffected.",
     "confirmDelete": "Delete profile \"{name}\"? This cannot be undone.",
     "loadGlobalMcp": "Load global MCP servers",
     "loadGlobalMcpHint": "Include MCP servers from global Claude settings. Disable to reduce tool count and speed up third-party APIs.",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -600,6 +600,8 @@
     "noVariables": "暂未添加变量",
     "envVars": "个环境变量",
     "noProfiles": "暂无自定义配置文件。创建一个开始使用。",
+    "syncSchedulesTitle": "更改默认配置时同步定时任务",
+    "syncSchedulesDesc": "切换默认 AI 配置时，也一并切换定时任务的 AI 配置。",
     "confirmDelete": "确定要删除配置文件 \"{name}\" 吗？此操作无法撤销。",
     "loadGlobalMcp": "加载全局 MCP 服务器",
     "loadGlobalMcpHint": "包含全局 Claude 设置中的 MCP 服务器。关闭可减少工具数量，加速第三方 API 调用。",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -116,7 +116,7 @@ export interface Profile {
 }
 export interface AuthUser {
   id: string; username: string; email: string | null; role: string; is_active: boolean;
-  avatar_url: string | null; plan_mode_default: boolean; debug_mode: boolean; default_profile_id: string; created_at: string;
+  avatar_url: string | null; plan_mode_default: boolean; debug_mode: boolean; default_profile_id: string; sync_profile_to_schedules: boolean; created_at: string;
 }
 export interface EventItem {
   id: string; channel_message_id: string | null; channel_type: string | null;

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -244,6 +244,31 @@ export function SettingsView({
             {profiles.length === 0 && (
               <p className="text-sm text-gray-500 text-center py-4">{t('profiles.noProfiles')}</p>
             )}
+
+            {/* Sync pinned schedules on default change */}
+            <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg gap-3 mt-3">
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium">{t('profiles.syncSchedulesTitle')}</p>
+                <p className="text-xs text-gray-500">{t('profiles.syncSchedulesDesc')}</p>
+              </div>
+              <label className="inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="sr-only peer"
+                  checked={currentUser?.sync_profile_to_schedules ?? false}
+                  onChange={async e => {
+                    const newVal = e.target.checked
+                    try {
+                      await api.patch('/api/auth/me/profile', { sync_profile_to_schedules: newVal })
+                      setCurrentUser(prev => prev ? { ...prev, sync_profile_to_schedules: newVal } : prev)
+                    } catch { /* ignore */ }
+                  }}
+                />
+                <span className="w-10 h-5 bg-gray-300 rounded-full relative transition-colors peer-checked:bg-indigo-600">
+                  <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${currentUser?.sync_profile_to_schedules ? 'translate-x-5' : ''}`}></span>
+                </span>
+              </label>
+            </div>
           </div>
 
           <VisionPanel isAdmin={currentUser?.role === 'admin'} />

--- a/tests/unit/test_finalize_reaper_unit.py
+++ b/tests/unit/test_finalize_reaper_unit.py
@@ -61,12 +61,15 @@ def test_ensure_added_columns_is_idempotent(tmp_path):
     # Simulate a pre-feature DB: tables without the new columns.
     con.execute('CREATE TABLE schedules (id TEXT PRIMARY KEY)')
     con.execute('CREATE TABLE tasks (id TEXT PRIMARY KEY)')
+    con.execute('CREATE TABLE users (id TEXT PRIMARY KEY)')
     con.commit()
     shim = _ConnShim(con)
 
     _ensure_added_columns(shim)  # first run adds columns
     _ensure_added_columns(shim)  # second run must be a no-op (no error)
 
+    user_cols = {r[1] for r in con.execute('PRAGMA table_info(users)')}
+    assert 'sync_profile_to_schedules' in user_cols
     sched_cols = {r[1] for r in con.execute('PRAGMA table_info(schedules)')}
     task_cols = {r[1] for r in con.execute('PRAGMA table_info(tasks)')}
     assert 'finalize_description' in sched_cols

--- a/tests/workflow/test_contracts.py
+++ b/tests/workflow/test_contracts.py
@@ -106,6 +106,7 @@ AUTH_USER_KEYS = {
     'avatar_url',
     'plan_mode_default',
     'default_profile_id',
+    'sync_profile_to_schedules',
     'created_at',
 }
 

--- a/tests/workflow/test_wf_profile_sync_schedules.py
+++ b/tests/workflow/test_wf_profile_sync_schedules.py
@@ -1,0 +1,174 @@
+"""Workflow tests: sync_profile_to_schedules pref on set-default.
+
+The opt-in user pref ``sync_profile_to_schedules`` (default off)
+controls whether ``PATCH /api/profiles/{id}/set-default`` also re-pins
+the user's schedules that carry a concrete ``ai_profile_id`` to the
+new default. Rows holding ``'default'``/NULL already inherit the live
+default via ``resolve_schedule_profile()`` and must stay untouched;
+other users' schedules are never in scope.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from app.models.schedule import Schedule
+from app.models.schedule_constants import PhaseMode
+from app.models.user import User
+from app.password import hash_password
+
+pytestmark = pytest.mark.workflow
+
+
+async def _make_schedule(db, created_by, ai_profile_id):
+    sched = Schedule(
+        id=str(uuid.uuid4()),
+        title=f'sched-{uuid.uuid4().hex[:8]}',
+        description='d',
+        schedule_type='minutes',
+        schedule_time='00:00',
+        interval_value=5,
+        plan_mode=False,
+        phase_mode=PhaseMode.SINGLE.value,
+        ai_profile_id=ai_profile_id,
+        created_by=created_by,
+    )
+    db.add(sched)
+    await db.commit()
+    await db.refresh(sched)
+    return sched
+
+
+async def _get_schedule(db, sched_id):
+    return await db.get(Schedule, sched_id)
+
+
+class TestSyncPrefRoundtrip:
+    async def test_pref_defaults_off(self, admin_client):
+        me = await admin_client.get('/api/auth/me')
+        assert me.json()['sync_profile_to_schedules'] is False
+
+    async def test_pref_toggle_roundtrip(self, admin_client):
+        r = await admin_client.patch(
+            '/api/auth/me/profile',
+            json={'sync_profile_to_schedules': True},
+        )
+        assert r.status_code == 200
+        me = await admin_client.get('/api/auth/me')
+        assert me.json()['sync_profile_to_schedules'] is True
+
+        await admin_client.patch(
+            '/api/auth/me/profile',
+            json={'sync_profile_to_schedules': False},
+        )
+        me = await admin_client.get('/api/auth/me')
+        assert me.json()['sync_profile_to_schedules'] is False
+
+
+class TestSetDefaultSync:
+    async def test_toggle_off_leaves_pinned_schedules(
+        self, admin_client, admin_user, override_async_session
+    ):
+        """Default (off): set-default must not touch any schedule."""
+        async with override_async_session() as db:
+            pinned = await _make_schedule(db, admin_user.id, 'prof-old')
+            inherit = await _make_schedule(db, admin_user.id, 'default')
+
+        await admin_client.post(
+            '/api/profiles',
+            json={'id': 'prof-new', 'name': 'New', 'env': {}},
+        )
+        r = await admin_client.patch('/api/profiles/prof-new/set-default')
+        assert r.status_code == 200
+        assert r.json()['default_profile_id'] == 'prof-new'
+        assert r.json()['schedules_synced'] == 0
+
+        async with override_async_session() as db:
+            assert (
+                await _get_schedule(db, pinned.id)
+            ).ai_profile_id == 'prof-old'
+            assert (
+                await _get_schedule(db, inherit.id)
+            ).ai_profile_id == 'default'
+
+    async def test_toggle_on_repins_only_concrete_pins(
+        self, admin_client, admin_user, override_async_session
+    ):
+        """On: concrete pins move; 'default'/NULL inherit rows stay."""
+        await admin_client.patch(
+            '/api/auth/me/profile',
+            json={'sync_profile_to_schedules': True},
+        )
+        async with override_async_session() as db:
+            pinned = await _make_schedule(db, admin_user.id, 'prof-old')
+            inherit_default = await _make_schedule(
+                db, admin_user.id, 'default'
+            )
+            # Legacy NULL row: the ORM column default forces 'default'
+            # on insert, so simulate a pre-default DB with raw SQL.
+            inherit_null = await _make_schedule(db, admin_user.id, 'x')
+            await db.execute(
+                text(
+                    'UPDATE schedules SET ai_profile_id = NULL'
+                    ' WHERE id = :sid'
+                ),
+                {'sid': inherit_null.id},
+            )
+            await db.commit()
+
+        await admin_client.post(
+            '/api/profiles',
+            json={'id': 'prof-new', 'name': 'New', 'env': {}},
+        )
+        r = await admin_client.patch('/api/profiles/prof-new/set-default')
+        assert r.status_code == 200
+        assert r.json()['schedules_synced'] == 1
+
+        async with override_async_session() as db:
+            assert (
+                await _get_schedule(db, pinned.id)
+            ).ai_profile_id == 'prof-new'
+            assert (
+                await _get_schedule(db, inherit_default.id)
+            ).ai_profile_id == 'default'
+            assert (
+                await _get_schedule(db, inherit_null.id)
+            ).ai_profile_id is None
+
+    async def test_toggle_on_never_touches_other_users(
+        self, admin_client, admin_user, override_async_session
+    ):
+        """Sync is scoped to created_by = current user."""
+        await admin_client.patch(
+            '/api/auth/me/profile',
+            json={'sync_profile_to_schedules': True},
+        )
+        async with override_async_session() as db:
+            other = User(
+                id=str(uuid.uuid4()),
+                username='other',
+                password_hash=hash_password('other123'),
+                role='member',
+                is_active=True,
+            )
+            db.add(other)
+            await db.commit()
+            mine = await _make_schedule(db, admin_user.id, 'prof-old')
+            theirs = await _make_schedule(db, other.id, 'prof-old')
+
+        await admin_client.post(
+            '/api/profiles',
+            json={'id': 'prof-new', 'name': 'New', 'env': {}},
+        )
+        r = await admin_client.patch('/api/profiles/prof-new/set-default')
+        assert r.status_code == 200
+        assert r.json()['schedules_synced'] == 1
+
+        async with override_async_session() as db:
+            assert (
+                await _get_schedule(db, mine.id)
+            ).ai_profile_id == 'prof-new'
+            assert (
+                await _get_schedule(db, theirs.id)
+            ).ai_profile_id == 'prof-old'

--- a/tests/workflow/test_wf_profile_sync_schedules.py
+++ b/tests/workflow/test_wf_profile_sync_schedules.py
@@ -102,16 +102,13 @@ class TestSetDefaultSync:
         )
         async with override_async_session() as db:
             pinned = await _make_schedule(db, admin_user.id, 'prof-old')
-            inherit_default = await _make_schedule(
-                db, admin_user.id, 'default'
-            )
+            inherit_default = await _make_schedule(db, admin_user.id, 'default')
             # Legacy NULL row: the ORM column default forces 'default'
             # on insert, so simulate a pre-default DB with raw SQL.
             inherit_null = await _make_schedule(db, admin_user.id, 'x')
             await db.execute(
                 text(
-                    'UPDATE schedules SET ai_profile_id = NULL'
-                    ' WHERE id = :sid'
+                    'UPDATE schedules SET ai_profile_id = NULL WHERE id = :sid'
                 ),
                 {'sid': inherit_null.id},
             )


### PR DESCRIPTION
## Problem

Schedules resolve their AI profile **live at every fire** via `resolve_schedule_profile()`: `'default'`/NULL means *inherit the owner's current default*, any concrete value is an *explicit pin*. Switching the default profile therefore only moves unpinned schedules — schedules carrying a concrete `ai_profile_id` (e.g. written by an older client that snapshotted the then-default at creation) stay on the old provider forever, and there is no UI to move them.

## What this adds

A per-user preference **`sync_profile_to_schedules`** (default **off**), exposed as a toggle in Settings → AI profiles:

> **更改默认配置时同步定时任务** — 切换默认 AI 配置时，也一并切换定时任务的 AI 配置。

When on, `PATCH /api/profiles/{id}/set-default` additionally re-pins the **current user's own** schedules that hold a concrete `ai_profile_id` to the new default:

- `'default'` / NULL rows already inherit the live default — deliberately untouched
- other users' schedules are never in scope (`created_by` filter)
- response gains `schedules_synced` so callers can see the blast radius

## Changes

| Layer | File | Change |
|---|---|---|
| Model | `app/models/user.py` | `sync_profile_to_schedules` bool, default false |
| Migration | `app/database.py` | PRAGMA-guarded `ALTER TABLE users ADD COLUMN` |
| Schemas | `app/schemas/user.py` | field on `UserResponse` + `ProfileUpdate` |
| API | `app/routers/auth.py` | pref in login response + `/me/profile` handler |
| API | `app/routers/profiles.py` | scoped schedule re-pin in `set_default_profile` |
| UI | `SettingsView.tsx`, `types.ts`, EN/ZH locales | toggle row in the AI profiles card |

## Tests

- **New** `tests/workflow/test_wf_profile_sync_schedules.py` (5 tests): pref defaults off / roundtrip via `/me/profile`; toggle off leaves pinned schedules untouched; toggle on re-pins only concrete values (`'default'` and legacy-NULL rows stay); other users' schedules never touched
- `test_contracts.py` — `AUTH_USER_KEYS` += new field
- `tests/unit/test_finalize_reaper_unit.py` — simulated pre-feature DB gains a `users` table (the new migration entry would otherwise `ALTER` a nonexistent table); also asserts the column lands

Full `unit or workflow` suite: 2080 passed (only pre-existing environmental `test_platform.py::test_finds_own_listener` failure, reproduces on clean `main`). Frontend: `tsc --noEmit` clean, 406/406 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)