### PR TITLE
feat(skills): noon per-SKU fee + ad-spend exports (FBN Reports, Ad Manager)

### DIFF
--- a/app/skills_v2/MANIFEST.txt
+++ b/app/skills_v2/MANIFEST.txt
@@ -42,6 +42,7 @@ noon-shared/SKILL.md
 noon-shared/references/dod-review-loop.md
 noon-listing/SKILL.md
 noon-fbn/SKILL.md
+noon-fbn/references/fee-reports.md
 noon-exports/SKILL.md
 noon-ads/SKILL.md
 noon-ads/references/ads-creation.md

--- a/app/skills_v2/noon-ads/SKILL.md
+++ b/app/skills_v2/noon-ads/SKILL.md
@@ -351,17 +351,158 @@ low-performing queries (add as negatives).
 
 ## 7. Export Data
 
-**Two distinct exports:**
+**Two distinct exports — opposite reliability. Do not conflate them.**
 
-- **List-level `Export all campaigns`** — on the Campaigns tab
-  (top-right of the list, § 2). One file covering every campaign in the
-  current filter; the reliable bulk read when you need account-wide
-  campaign data.
-- **Per-tab `Export Data`** — on the Products / Targets / Customer
-  Queries tabs, exports the current filtered view. **Unreliable in this
-  environment** — see § 4 caveat. Prefer DOM eval extraction. ⚠️ **If the file doesn't land within ~10 s, do NOT re-click
-or retry** — a no-op export button is an environment quirk, not a
-transient miss. Switch to DOM eval extraction (§ 4 / § 5) immediately;
+| | `Export all campaigns` (list level) | `Export Data` (per tab) |
+|---|---|---|
+| Where | Campaigns tab, top-right of the list (§ 2) | Products / Targets / Customer Queries tabs |
+| Reliability | **Works** — but ASYNC, takes ~1–5 min | **Unreliable here** — often a silent no-op |
+| On no file | keep waiting (§ 7.1) | give up immediately, use DOM eval |
+
+### 7.1 `Export all campaigns` — the per-SKU ad-spend source
+
+This is the only practical way to get **ad spend per SKU**. It honours
+the list's **date-range filter**, so set the range first.
+
+**Async, and the button is your progress indicator:**
+
+1. Click it once. It flips to **`disabled`** while noon builds the file.
+2. The file lands in `~/.vibe-seller/downloads/<slug>/` as
+   **`_OVERVIEW_ALL_Report_{from}_{to}.xlsx`** (e.g.
+   `_OVERVIEW_ALL_Report_2026-06-01_2026-06-30.xlsx`), typically after
+   1–5 min for a few dozen campaigns.
+3. **`disabled: true` means "generating", not "broken".** Poll the
+   download dir; do NOT re-click — and do NOT apply § 4's
+   "don't retry the export" rule here, that one is about the *per-tab*
+   button.
+
+> ⚠️ **The filename carries the date range but NOT the country.** An SA
+> and an AE export for the same range produce the **same filename**.
+> Rename on arrival (`ads_overview_{CC}_{YYYY-MM}.xlsx`) before starting
+> the other country's export.
+
+Country comes from the `en-{cc}` URL segment, same as everywhere else.
+
+**Setting a custom month range** (the presets are Last 30 days / Last 7
+days / Yesterday / Today):
+
+```bash
+browser-use <<'PY'
+import time, json
+def rect(expr):
+    r = js("(function(){%s})()" % expr)
+    return json.loads(r) if r and r.startswith('{') else None
+def click_text(t, lo=0, hi=99999):
+    r = rect("""
+      var want=%s, lo=%d, hi=%d;
+      var el=Array.from(document.querySelectorAll('div,li,span,button,a,p')).filter(e=>
+        e.children.length===0 && (e.textContent||'').trim()===want
+        && e.getBoundingClientRect().height>4
+        && e.getBoundingClientRect().y>lo && e.getBoundingClientRect().y<hi);
+      if(!el.length) return 'nf';
+      var b=el[0].getBoundingClientRect();
+      return JSON.stringify({x:Math.round(b.x+b.width/2), y:Math.round(b.y+b.height/2)});
+    """ % (json.dumps(t), lo, hi))
+    if not r: return False
+    click_at_xy(r['x'], r['y']); time.sleep(2); return True
+
+# 1. open the range dropdown (the button showing the current preset), 2. Custom range
+r = rect("""var b=Array.from(document.querySelectorAll('button')).find(x=>
+             /Last 30 days|Last 7 days|Custom|20\\d\\d/i.test(x.textContent||'')
+             && x.getBoundingClientRect().y<260);
+           if(!b) return 'nf'; var q=b.getBoundingClientRect();
+           return JSON.stringify({x:Math.round(q.x+q.width/2), y:Math.round(q.y+q.height/2)});""")
+click_at_xy(r['x'], r['y']); time.sleep(2)
+click_text("Custom range")
+
+# 3. page the calendar back with the  <  arrow (y 350-395, x 580-620) until the
+#    header reads the month you want, then click the first day then the last day,
+#    then Apply. Verify the range button text before exporting.
+click_text("Apply")
+print(js("""(function(){var b=Array.from(document.querySelectorAll('button')).find(x=>
+  x.getBoundingClientRect().y<260 && /20\\d\\d|Last|Custom/i.test(x.textContent||''));
+  return b?b.textContent.trim():'?'})()"""))
+PY
+```
+
+Then click the export (the handler is on the **`<button>`**, not the
+label `<span>` inside it — clicking the span does nothing):
+
+```bash
+browser-use <<'PY'
+import time, json
+r = js("""(function(){
+  var d=document.querySelector('[class*=CampaignStatusTabs_headerExportAction]');
+  if(!d) return 'nf';
+  var b=d.querySelector('button')||d, q=b.getBoundingClientRect();
+  return JSON.stringify({x:Math.round(q.x+q.width/2), y:Math.round(q.y+q.height/2), dis:String(b.disabled)});
+})()""")
+c=json.loads(r); print("export btn:", c)
+click_at_xy(c['x'], c['y'])          # ONCE. then poll the download dir.
+PY
+```
+
+### 7.2 What's inside the workbook
+
+Ten sheets — `(Product)` and `(Brand)` families:
+
+| Sheet | Grain | Columns |
+|---|---|---|
+| `(Product|Brand) Campaign` | campaign | Campaign Name, Views, Clicks, Orders, ATC, Spends, Revenue, CTR, ROAS, CPC, CPS, CVR |
+| **`(Product|Brand) Sku`** | **campaign x SKU** | as above **+ `Sku`** |
+| `(Product|Brand) Target` | keyword / target | + Target Value, Targeting Type, Bid, Strategy |
+| `(Product|Brand) Placement` | placement | + Placement Type |
+| `(Product|Brand) Queries` | search term | + Sku, Query |
+
+**Per-SKU ad spend** = `Spends` from `(Product) Sku` **+** `(Brand) Sku`,
+grouped by `Sku`. Verified live: the SKU sheets sum **exactly** to the
+Campaign sheets, so this is a complete decomposition — no residual.
+
+```python
+frames = [xl.parse(s)[['Sku','Spends','Orders','Clicks','Views','Revenue']]
+          for s in ['(Product) Sku', '(Brand) Sku']]
+per_sku = pd.concat(frames).groupby('Sku', as_index=False).sum()
+```
+
+Three things to handle:
+
+- **`header` is not a SKU.** Brand-ad banner spend is booked against a
+  literal `Sku` value of `header` (a few % of spend). It is real spend
+  attributable to no SKU — keep it as an explicit "unattributed"
+  bucket; don't silently drop it or let it pollute a SKU.
+- **Parent vs variant SKUs.** `(Product) Sku` mixes noon-internal
+  variant (`Z…Z-<n>`) and parent (`Z…Z`) forms; `(Brand) Sku` is
+  mostly variant. These are noon-internal keys, **not** the seller
+  codes in the Transaction View's `Partner SKUs` — bridge via that
+  export's `SKUs` column (see
+  `noon-fbn/references/fee-reports.md` § 5).
+- **`Queries` sheets are capped at 30,000 rows.** Exactly 30000 means
+  truncated, not complete. Narrow the range if you need full
+  search-term coverage.
+
+### 7.3 Reconciling ad spend against the statement
+
+Ad spend does **not** tie exactly to the Transaction View's
+`Advertising Fee` (`statement_fee` rows, `Non-Order Fees`):
+
+```
+sum(Spends over the calendar month) x (1 + VAT)  ~=  sum(statement_fee Advertising Fee)
+```
+
+within a couple of percent (observed ~2–3%). The gap is structural, not
+an error: **ad statements are issued on a weekly cycle** whose periods
+straddle month boundaries, while the export is filtered on *performance*
+date. For per-SKU attribution use the **export** (so the per-SKU parts
+sum to the reported total); use `statement_fee` only when you need the
+amount actually invoiced.
+
+### 7.4 Per-tab `Export Data`
+
+Exports the current filtered view on Products / Targets / Customer
+Queries. **Unreliable in this environment** — see § 4 caveat. Prefer DOM
+eval extraction. ⚠️ **If the file doesn't land within ~10 s, do NOT
+re-click or retry** — a no-op export button is an environment quirk, not
+a transient miss. Switch to DOM eval extraction (§ 4 / § 5) immediately;
 retrying just burns steps.
 
 ```bash

--- a/app/skills_v2/noon-exports/SKILL.md
+++ b/app/skills_v2/noon-exports/SKILL.md
@@ -271,7 +271,33 @@ Status shows "Completed" (1-10 minutes depending on size).
 - **Export files land in `~/.vibe-seller/downloads/<store-slug>/`**,
   not `~/Downloads`.
 
+## 4. What the Transaction View does NOT give you
+
+The Transaction View is **order-grained for sales but lumped for FBN
+fees**. Two things a finance/profitability task usually needs are not in
+it:
+
+- **Per-SKU storage / return fees.** The whole month's FBN storage
+  settles as a single `balance_transfer` row whose `Others including
+  VAT` is opaque. Per-SKU monthly / long-term / non-saleable storage and
+  RTV removal fees come from the **FBN Reports** page — see
+  `noon-fbn` § 8 and `noon-fbn/references/fee-reports.md`. That
+  reference also carries the reconciliation proving the four reports sum
+  to this settlement (with a **one-month lag** and a **VAT gross-up**).
+- **Per-SKU ad spend.** `statement_fee` rows give only an account-level
+  `Advertising Fee`. Per-SKU spend comes from Ad Manager's
+  `Export all campaigns` — see `noon-ads` § 7.1.
+
+**This export is, however, the SKU bridge for both.** Its `SKUs` column
+is the noon-internal key (`Z…Z-<n>`) and `Partner SKUs` the seller's own
+code, on the same row — the only place the two keyspaces meet. Keep the
+transaction CSV alongside the fee/ads files; without it the per-SKU
+numbers cannot be mapped to seller SKUs.
+
 ## See also
 
 - `noon-shared` — login, page structure (prerequisite)
+- `noon-fbn` § 8 + `references/fee-reports.md` — per-SKU FBN storage /
+  RTV-removal fees, and the reconciliation against § 2's settlement line
+- `noon-ads` § 7.1 — per-SKU ad spend export
 - `amazon-reports` — Amazon equivalent + general "Download Behavior" pattern

--- a/app/skills_v2/noon-fbn/SKILL.md
+++ b/app/skills_v2/noon-fbn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: noon-fbn
-description: "Noon Fulfilled-by-noon (FBN) — ASN creation flow, ASN status enum, inventory export, barcode print. Load when scheduling a shipment, managing FBN inventory, creating an ASN, or exporting warehouse stock."
+description: "Noon Fulfilled-by-noon (FBN) — ASN creation flow, ASN status enum, inventory export, barcode print, and the FBN Reports page for PER-SKU storage / RTV-removal fee reports. Load when scheduling a shipment, managing FBN inventory, creating an ASN, exporting warehouse stock, or pulling per-SKU storage / return fees."
 requires: [noon-shared]
 review:
   criteria: |
@@ -10,11 +10,25 @@ review:
       showing in the list is not done.
     - If an inventory export was requested, the CSV exists and is
       non-empty with the expected columns.
+    - If per-SKU FBN fees were requested: ALL FOUR Finance reports
+      (Monthly Storage, Long Term Storage, Non Saleable Storage, RTV
+      Removal) exist for EVERY requested country x service month, each
+      as its own file whose name states the country and month. A report
+      that was missing on the page and never generated is a gap, not
+      "not applicable" — the only acceptable empty report is one that
+      downloads with a header row and genuinely zero data rows.
+    - The reconciliation in references/fee-reports.md § 4 was actually
+      computed and closes: sum(charged_amount) over the four reports for
+      service month M-1, x (1+VAT), equals month M's Transaction View
+      balance_transfer. An unreconciled pull is not done.
   verify_by: |
     Open the FBN ASN page (fbn.noon.partners/.../asn); confirm the new
     ASN number + status + shipment contents match. If inventory export
     was asked, open the CSV and confirm non-zero rows + warehouse/stock
-    columns.
+    columns. For per-SKU fees: list the output dir and confirm one file
+    per (report type x country), each with a sku (or barcode) column and
+    a charged_amount column; then print the § 4 reconciliation showing
+    the detail total, the VAT gross-up, and the settlement it matches.
 ---
 
 # Noon — FBN (Fulfilled by noon)
@@ -162,12 +176,53 @@ the page; don't hardcode.
 The My ASN & Storage page has a **Print Barcodes** button at the top
 to generate printable barcodes for FBN shipments.
 
+## 8. FBN Reports — per-SKU storage & RTV removal fees
+
+**URL**: `https://fbn.noon.partners/en-{cc}/fbnreports?project=PRJ{project_id}`
+
+The Transaction View export gives the month's FBN storage as **one
+lumped `balance_transfer` row with no SKU attribution**. This page is
+where the per-SKU breakdown lives — four Finance reports that together
+reconcile exactly to that settlement:
+
+| Report | Key | Gives you |
+|---|---|---|
+| Monthly Storage Charge | `sku` | per-SKU monthly storage fee + average stock |
+| Long Term Storage Charge | `sku` | per-SKU long-term (aged 6m/12m) storage fee |
+| Non Saleable Storage Charge | `sku` | per-SKU non-saleable ageing storage fee |
+| RTV Removal Charge | `barcode` | per-barcode removal/return fee + `shipped_qty` |
+
+Four things that will bite you, each covered in the reference:
+
+1. **No country field in the modal** — country comes from the
+   `en-{cc}` URL segment. The report *list* is project-wide, so you
+   only switch URL to generate, not to download.
+2. **Downloads are named by report type only** (no country, no month) —
+   rename each file immediately or SA/AE overwrite each other.
+3. **`charged_amount` is ex-VAT and the settlement lags by one month** —
+   month M's settlement is service month M−1, grossed up by VAT
+   (SA 15% / AE 5%).
+4. **RTV Removal has no `sku`** — join `barcode` → the storage reports'
+   `pbarcode` → `sku`. And FBN/ads SKUs are noon-internal
+   (`Z…Z-<n>`), NOT the seller codes in the Transaction View's
+   `Partner SKUs`; that export's `SKUs` column is the bridge.
+
+> **Read `references/fee-reports.md`** before generating or downloading
+> anything here — it has the generation flow, the download/rename
+> pattern, the reconciliation formula, and the join keys.
+
 ## Tips
 
 - **Don't "Agree & Proceed" ASN unless committing** — it reserves
   quota that counts against your allocation.
+- **A country can be missing a fee report entirely.** Reconcile (see
+  the reference § 4); if the sum doesn't close, generate the missing
+  report rather than assuming rounding.
 
 ## See also
 
+- `noon-fbn/references/fee-reports.md` — per-SKU fee reports in full
 - `noon-shared` — login, page structure (prerequisite)
 - `noon-listing` — Add FBN Stock from listing edit page
+- `noon-exports` — Transaction View (the settlement + the SKU bridge)
+- `noon-ads` — per-SKU ad spend (same keyspace trap)

--- a/app/skills_v2/noon-fbn/references/fee-reports.md
+++ b/app/skills_v2/noon-fbn/references/fee-reports.md
@@ -1,0 +1,263 @@
+# Noon FBN — per-SKU fee reports (storage, RTV removal)
+
+> Loaded from `noon-fbn/SKILL.md` § 8. Read this when a task needs
+> **per-SKU** FBN charges — monthly storage, long-term storage,
+> non-saleable ageing storage, RTV removal — rather than the single
+> lumped settlement line the Transaction View gives you.
+
+The Transaction View export (see `noon-exports` § 2) reports the whole
+month's FBN storage settlement as **one `balance_transfer` row** with an
+opaque `Others including VAT` amount and **no SKU attribution**. The FBN
+Reports page is where the per-SKU decomposition lives.
+
+## 1. Page + report catalogue
+
+**URL**: `https://fbn.noon.partners/en-{cc}/fbnreports?project=PRJ{project_id}`
+
+`Generate Report` (top-right) opens a two-level picker —
+**category** → **report** — then the report's own parameters:
+
+| Category | Reports |
+|---|---|
+| **Finance** | Estimated Monthly Storage Fee, **Monthly Storage Charge**, **Long Term Storage Charge**, **Non Saleable Storage Charge**, **RTV Removal Charge**, Non-Saleable Ageing |
+| Inbound | FBN Received, Scheduled Delivery Accuracy, Inbound Performance Score |
+| Inventory | FBN Inventory Detail, Inventory Ledger (Summary View), Inventory Ledger (Detailed View), SKU Level Inventory Ledger |
+| Inventory v2 | Ledger Detailed View, Ledger Summary View, aging |
+| Returns | Saleable Recommended RTV, Non-saleable Recommended RTV, RTV Report – Requests, RTV Report – Shipments |
+
+The **four bolded Finance reports are the complete decomposition** of the
+storage settlement (see § 4). The others are not needed for fee work.
+
+### Critical facts
+
+1. **There is NO country field in the modal.** The report's country comes
+   from the **`en-{cc}` segment of the page URL**. To generate an AE
+   report you must be on `…/en-ae/fbnreports…`. Generating from
+   `en-sa` silently produces an `sa` report.
+2. **The report LIST is project-wide** — an `en-sa` page lists both `sa`
+   and `ae` rows. So you only need to switch URL to *generate*, never to
+   *download*.
+3. **`Service Month` is a month picker**, not a date range. Future
+   months are greyed out. The field must read `YYYY-MM` before the
+   modal's `Generate Report` submits — verify it, don't assume the click
+   landed.
+4. **Modal geometry moves.** The category select sits higher when no
+   report is chosen yet (fewer fields rendered). Never hardcode
+   coordinates — locate each control by its placeholder
+   (`Select a category` / `Select a report` / `Select month`) and read
+   its rect. Reload the page between generations; a stale modal is the
+   usual cause of a "category not found" failure.
+5. **Status is `Pending → Complete`.** Small reports finish in well
+   under a minute; a data-heavy Monthly Storage report can take a few.
+   `Nr. of Rows` shows `...` for some completed reports — that is a UI
+   placeholder, **not** an error and **not** an empty report.
+
+## 2. Generating a missing report
+
+Reports are not auto-generated for every month/country — a country can
+simply be **missing** one (observed live: a store had Monthly / LTS /
+Non-Saleable for one month but **no RTV Removal report at all** for one
+of its two countries). Always reconcile (§ 4); if the sum doesn't close,
+a report is missing, not "noon rounds differently".
+
+```bash
+browser-use <<'PY'
+import time, json
+def rect(expr):
+    r = js("(function(){%s})()" % expr)
+    return json.loads(r) if r and r.startswith('{') else None
+
+def click_ph(ph):                      # click a control by its placeholder
+    r = rect("""
+      var ph=%s;
+      var e=Array.from(document.querySelectorAll('input')).find(x=>x.placeholder===ph)
+         || Array.from(document.querySelectorAll('div,span')).find(
+              x=>x.children.length===0 && (x.textContent||'').trim()===ph);
+      if(!e) return 'nf';
+      var b=e.getBoundingClientRect();
+      return JSON.stringify({x:Math.round(b.x+b.width/2), y:Math.round(b.y+b.height/2)});
+    """ % json.dumps(ph))
+    if not r: return False
+    click_at_xy(r['x'], r['y']); time.sleep(2); return True
+
+def click_opt(t, below):               # click a dropdown option below y=below
+    r = rect("""
+      var want=%s, lo=%d;
+      var el=Array.from(document.querySelectorAll('div,li,span')).filter(e=>
+        e.children.length===0 && (e.textContent||'').trim()===want
+        && e.getBoundingClientRect().y>lo && e.getBoundingClientRect().height>5);
+      if(!el.length) return 'nf';
+      var b=el[0].getBoundingClientRect();
+      return JSON.stringify({x:Math.round(b.x+b.width/2), y:Math.round(b.y+b.height/2)});
+    """ % (json.dumps(t), below))
+    if not r: return False
+    click_at_xy(r['x'], r['y']); time.sleep(2); return True
+
+# ALWAYS reload first — a stale modal breaks the next generation.
+goto_url("https://fbn.noon.partners/en-{cc}/fbnreports?project=PRJ{project_id}")
+wait_for_load(); time.sleep(7)
+js("window.scrollTo(0,0)")
+
+r = rect("""var b=Array.from(document.querySelectorAll('button')).find(
+             x=>/generate report/i.test(x.textContent) && x.getBoundingClientRect().y<200);
+           if(!b) return 'nf'; var q=b.getBoundingClientRect();
+           return JSON.stringify({x:Math.round(q.x+q.width/2), y:Math.round(q.y+q.height/2)});""")
+click_at_xy(r['x'], r['y']); time.sleep(3)
+
+click_ph("Select a category"); click_opt("Finance", 150)
+click_ph("Select a report");   click_opt("<Report Name>", 200)
+click_ph("Select month")
+# month grid: click the 3-letter month cell (y>380); page back with the
+# «  arrow near y 350-395 / x 580-620 if the picker opened on a later year.
+click_opt("<Mon>", 380)
+
+val = js("(function(){var i=document.querySelector('input[placeholder=\"Select month\"]');"
+         "return i? i.value : '?'})()")
+assert val == "<YYYY-MM>", f"service month did not take: {val}"
+
+# submit = the SECOND 'Generate Report' button (y>200); the first is the
+# page's top-right one, which would just re-open the modal.
+r = rect("""var b=Array.from(document.querySelectorAll('button')).filter(
+             x=>/generate report/i.test(x.textContent) && x.getBoundingClientRect().y>200);
+           if(!b.length) return 'nf'; var q=b[0].getBoundingClientRect();
+           return JSON.stringify({x:Math.round(q.x+q.width/2), y:Math.round(q.y+q.height/2)});""")
+click_at_xy(r['x'], r['y']); time.sleep(5)
+PY
+```
+
+## 3. Downloading — the filename collision
+
+`Download` in the Actions column is a real `<button>` that writes the CSV
+straight to `~/.vibe-seller/downloads/<slug>/`. No modal, no signed URL.
+
+> **The filename contains ONLY the report type** — e.g.
+> `fbn_finance_monthlystoragechargereport.csv`. It carries **no country
+> and no service month**. Downloading `sa` then `ae` for the same report
+> overwrites / produces ` (1)` suffixes and you lose track of which is
+> which. **Rename immediately after each download, before clicking the
+> next one**, to something like
+> `monthly_storage_{CC}_{YYYY-MM}.csv`.
+
+Two mechanical gotchas:
+
+- **Scroll the row into view first.** `click_at_xy` on a row below the
+  viewport does nothing (silently). `row.scrollIntoView({block:'center'})`,
+  wait, then re-read the button's rect — the coordinates change.
+- Match the row by its **Report Code** (`EXP…`), not by report name —
+  names repeat across countries and months.
+
+```bash
+browser-use <<'PY'
+import time, json
+CODE = "EXP..."          # the row's Report Code
+r = js("""
+var rows=document.querySelectorAll('table tr');
+for(var i=0;i<rows.length;i++){
+  if(/%s/.test(rows[i].textContent||'')){ rows[i].scrollIntoView({block:'center'}); return 'ok'; }
+}
+return 'rownf';
+""" % CODE)
+time.sleep(1.5)
+r = js("""
+var rows=document.querySelectorAll('table tr');
+for(var i=0;i<rows.length;i++){
+  if(/%s/.test(rows[i].textContent||'')){
+    var b=rows[i].querySelector('button'); var q=b.getBoundingClientRect();
+    return JSON.stringify({x:Math.round(q.x+q.width/2), y:Math.round(q.y+q.height/2)});
+  }
+}
+return 'rownf';
+""" % CODE)
+c=json.loads(r); click_at_xy(c['x'], c['y'])
+PY
+# then, in the shell, rename the newest file before the next download:
+#   mv ~/.vibe-seller/downloads/<slug>/fbn_finance_*.csv \
+#      <out>/monthly_storage_SA_2026-06.csv
+```
+
+## 4. Reconciliation — the check that proves nothing is missing
+
+```
+Transaction View  balance_transfer."Others including VAT"  for month M
+  ==  SUM(charged_amount) over the four Finance reports
+        WHERE service_month = M - 1
+      x (1 + VAT)
+```
+
+- **VAT**: SA 15%, AE 5%. `charged_amount` in every FBN report is
+  **ex-VAT**; the Transaction View column is **VAT-inclusive**. Never
+  compare them raw.
+- **The one-month offset is real.** The settlement that appears in month
+  M's transaction export is service month **M − 1**'s storage. So
+  per-SKU storage for analysis month M must be read from the **service
+  month M** reports — never from month M's `balance_transfer`.
+- Verified live to the **cent** on both countries of a two-country
+  store across two consecutive service months. If your sum doesn't
+  close, in order of likelihood: (a) a report for that country/month
+  was never generated (§ 2); (b) you compared ex-VAT to incl-VAT;
+  (c) you used the wrong service month.
+
+Illustrative shape (round numbers, not live figures):
+
+```
+service month M-1, country SA        ex-VAT
+  monthly storage                   5,300.00
+  long term storage                     0.00
+  non-saleable ageing storage         180.00
+  RTV removal                         100.00
+                                    --------
+                                    5,580.00  x 1.15 = 6,417.00
+month M Transaction View balance_transfer     = 6,417.00   ✓
+```
+
+## 5. Column shapes + join keys
+
+All three **storage** reports share a spine:
+`soa_reference_nr, description_en, id_partner, service_month, sku,
+pbarcode, year_month, country_code, cost_per_cubic_feet, charged_amount`
+plus per-type quantity columns (`average_stock_on_hand` /
+`qty_aged_6m` / `qty_aged_0_to_1m` …). `description_en` is the
+human-readable fee name — use it as the fee-type label.
+
+**RTV Removal is the odd one out**: it has **no `sku` and no
+`country_code`** column. It carries `barcode`, `return_request_nr`,
+`shipment_nr`, `return_type` (`saleable` / non-saleable),
+`shipped_qty`, `currency_code`, `charged_amount`.
+
+> To attribute RTV removal per SKU, join `rtv.barcode` →
+> `storage.pbarcode` → `storage.sku`. The storage reports for the same
+> month are the barcode→SKU dictionary; this joined 100% of rows live.
+> Use `currency_code` (not `country_code`) to bucket RTV by country.
+
+### The SKU keyspace trap
+
+Three different keys are in play — do **not** assume they match:
+
+| Source | SKU column | Form |
+|---|---|---|
+| FBN fee reports | `sku` | noon internal, `Z<20 hex>Z-<n>` |
+| Ad Manager export | `Sku` | noon internal, parent `Z…Z` **or** variant `Z…Z-<n>` |
+| Transaction View | `Partner SKUs` | **the seller's own code**, e.g. `WIDGET-006` |
+
+The Transaction View is the bridge: its **`SKUs`** column is the noon
+internal key and **`Partner SKUs`** the seller code, on the same row.
+Build the map from the same month's transaction export:
+
+```python
+bridge = (txn[['SKUs', 'Partner SKUs']].dropna()
+              .astype(str).apply(lambda s: s.str.strip())
+              .drop_duplicates())
+noon_to_partner = dict(zip(bridge['SKUs'], bridge['Partner SKUs']))
+```
+
+Coverage is high but **not** total — a SKU can hold stock (and accrue
+storage) while making no sales that month, so it has no transaction row
+and no bridge entry. Carry those through as unmapped rather than
+dropping them, or the per-SKU total stops matching § 4.
+
+## See also
+
+- `noon-exports` § 2 — the Transaction View export that provides both
+  the settlement line to reconcile against and the SKU bridge
+- `noon-ads` § Export all campaigns — per-SKU **ad spend**, same
+  keyspace trap, same rename-on-arrival rule


### PR DESCRIPTION
## Problem

The monthly noon pull fetched only the Transaction View, which reports FBN
storage as **one `balance_transfer` row with no SKU attribution** and
advertising as **account-level `statement_fee` rows**. Downstream
profitability work therefore had no per-SKU storage or ad spend for noon at
all — those fields were structurally unavailable, not merely unpopulated.

The per-SKU detail does exist on noon, on two surfaces this repo did not
document:

- **FBN Reports → Generate Report → Finance** — four CSVs per country per
  service month: Monthly Storage Charge, Long Term Storage Charge, Non
  Saleable Storage Charge, RTV Removal Charge.
- **Ad Manager → Export all campaigns** — a workbook whose
  `(Product) Sku` / `(Brand) Sku` sheets carry per-SKU `Spends`.

## Changes

- **`noon-fbn` § 8 + new `references/fee-reports.md`** — the FBN Reports
  page: the Generate Report category/report catalogue, the generation flow,
  the download-and-rename pattern, the reconciliation, and the join keys.
- **`noon-ads` § 7.1–7.3`** — `Export all campaigns` in full: custom range,
  async behaviour, the workbook's ten sheets, per-SKU spend extraction, and
  how it reconciles (or deliberately does not) against the statement fees.
- **`noon-exports` § 4** — states what the Transaction View does *not* give
  you, and that it is nonetheless the SKU bridge both other exports need.
- **`noon-fbn` review gate** — a fee pull is not done unless all four
  Finance reports exist for every requested country × service month **and**
  the reconciliation was computed and closes.

## Field-verified traps now written down

Each of these silently produces wrong numbers rather than an error, which is
why they are documented rather than left to be rediscovered:

1. **No country field in the FBN modal** — the report's country comes from
   the `en-{cc}` URL segment. The report *list* is project-wide, so you
   switch URL only to generate, never to download.
2. **Downloads carry no country** — FBN files are named by report type only
   (`fbn_finance_monthlystoragechargereport.csv`), the ads export by date
   range only. Two countries overwrite each other unless renamed on arrival.
3. **`charged_amount` / `Spends` are ex-VAT** while the Transaction View
   columns are VAT-inclusive, **and the settlement lags one service month** —
   month M's `balance_transfer` is service month M−1 grossed up by VAT.
   Verified to the cent on two consecutive service months across both
   countries of a two-country store.
4. **RTV Removal has no `sku` column** — join `barcode` → the storage
   reports' `pbarcode`. And FBN/ads SKUs are noon-internal (`Z<hex>Z-<n>`),
   *not* the seller codes in the Transaction View's `Partner SKUs`; that
   export's `SKUs` column is the only place the two keyspaces meet.
5. **`header` is not a SKU** — brand-banner spend is booked against a
   literal `Sku` of `header` and belongs to no SKU. The `Queries` sheets cap
   at exactly 30,000 rows when truncated.
6. **The list-level export works; only the per-tab one is unreliable.** § 7
   now separates them so the existing "don't retry a no-op export" rule is
   not misapplied to the list-level export, which is merely slow (the button
   goes `disabled` while noon builds the file).

A country can also be **missing a fee report entirely** — observed live on a
store that had three of the four for one country. Hence the review gate
change: reconcile, and if the sum does not close, generate the missing
report rather than assuming rounding.

## Testing

Exercised end-to-end against a live two-country noon store: all four Finance
reports generated/downloaded per country, the ads workbook exported per
country, and the reconciliation closed to the cent for both countries across
two consecutive service months. A scheduled task re-planned from these
skills then reproduced the whole flow unattended, including generating the
prior service month's reports on its own to perform the lag-corrected
reconciliation.

Docs-only change — no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWm1S2xXebKUMq3HiokCWc
