### PR TITLE
fix(skills): noon FBN reference shipped a helper that crashed on the common not-found path

### DIFF
--- a/app/skills_v2/noon-fbn/SKILL.md
+++ b/app/skills_v2/noon-fbn/SKILL.md
@@ -17,6 +17,14 @@ review:
       that was missing on the page and never generated is a gap, not
       "not applicable" — the only acceptable empty report is one that
       downloads with a header row and genuinely zero data rows.
+    - Every non-empty storage report was OPENED and its own
+      `country_code` / `service_month` columns match the country and
+      month in its filename. The filename is a manual rename applied
+      after the download, so it proves nothing on its own — a
+      mis-clicked row yields a perfectly named file full of the wrong
+      country's money. Two files for the same report type and month must
+      not be byte-identical, and the two ads xlsx must not have equal
+      `Spends` totals.
     - The reconciliation in references/fee-reports.md § 4 was actually
       computed and closes: sum(charged_amount) over the four reports for
       service month M-1, x (1+VAT), equals month M's Transaction View

--- a/app/skills_v2/noon-fbn/references/fee-reports.md
+++ b/app/skills_v2/noon-fbn/references/fee-reports.md
@@ -60,12 +60,40 @@ Non-Saleable for one month but **no RTV Removal report at all** for one
 of its two countries). Always reconcile (§ 4); if the sum doesn't close,
 a report is missing, not "noon rounds differently".
 
+> **Two quoting rules for these heredocs, both learned the hard way.**
+> A `js()` string is Python *and* JavaScript at once, so nested quotes
+> collide: `js("...querySelector('input[placeholder="Select month"]')...")`
+> is a Python syntax error, and the `SyntaxError` you get back points at
+> the JS, not the quote. Build any JS string literal with
+> `json.dumps(value)` instead of hand-quoting. And never `return` a bare
+> JS object from `js()` — CDP hands back `[object Object]`; always
+> `JSON.stringify` it.
+
 ```bash
 browser-use <<'PY'
 import time, json
 def rect(expr):
+    """Centre point of an element, or None when it isn't on the page yet."""
     r = js("(function(){%s})()" % expr)
     return json.loads(r) if r and r.startswith('{') else None
+
+def must_click(expr, what):
+    """Click a located element, or fail with a message that names it.
+
+    ALWAYS go through this rather than `click_at_xy(rect(...)['x'], ...)`.
+    The modal renders asynchronously, so `rect()` returning None is the
+    NORMAL slow-page case — and subscripting None gives you
+    `TypeError: 'NoneType' object is not subscriptable` with no clue
+    which control was missing. Retry, then say what was not found.
+    """
+    for attempt in range(3):
+        r = rect(expr)
+        if r:
+            click_at_xy(r['x'], r['y'])
+            return True
+        time.sleep(2)
+    print(f'NOT FOUND after 3 tries: {what} — page state: {page_info()}')
+    return False
 
 def click_ph(ph):                      # click a control by its placeholder
     r = rect("""
@@ -98,11 +126,12 @@ goto_url("https://fbn.noon.partners/en-{cc}/fbnreports?project=PRJ{project_id}")
 wait_for_load(); time.sleep(7)
 js("window.scrollTo(0,0)")
 
-r = rect("""var b=Array.from(document.querySelectorAll('button')).find(
+must_click("""var b=Array.from(document.querySelectorAll('button')).find(
              x=>/generate report/i.test(x.textContent) && x.getBoundingClientRect().y<200);
            if(!b) return 'nf'; var q=b.getBoundingClientRect();
-           return JSON.stringify({x:Math.round(q.x+q.width/2), y:Math.round(q.y+q.height/2)});""")
-click_at_xy(r['x'], r['y']); time.sleep(3)
+           return JSON.stringify({x:Math.round(q.x+q.width/2), y:Math.round(q.y+q.height/2)});""",
+           'top-right Generate Report button')
+time.sleep(3)
 
 click_ph("Select a category"); click_opt("Finance", 150)
 click_ph("Select a report");   click_opt("<Report Name>", 200)
@@ -117,11 +146,12 @@ assert val == "<YYYY-MM>", f"service month did not take: {val}"
 
 # submit = the SECOND 'Generate Report' button (y>200); the first is the
 # page's top-right one, which would just re-open the modal.
-r = rect("""var b=Array.from(document.querySelectorAll('button')).filter(
+must_click("""var b=Array.from(document.querySelectorAll('button')).filter(
              x=>/generate report/i.test(x.textContent) && x.getBoundingClientRect().y>200);
            if(!b.length) return 'nf'; var q=b[0].getBoundingClientRect();
-           return JSON.stringify({x:Math.round(q.x+q.width/2), y:Math.round(q.y+q.height/2)});""")
-click_at_xy(r['x'], r['y']); time.sleep(5)
+           return JSON.stringify({x:Math.round(q.x+q.width/2), y:Math.round(q.y+q.height/2)});""",
+           "the modal's submit button")
+time.sleep(5)
 PY
 ```
 
@@ -168,12 +198,49 @@ for(var i=0;i<rows.length;i++){
 }
 return 'rownf';
 """ % CODE)
-c=json.loads(r); click_at_xy(c['x'], c['y'])
+if not r.startswith('{'):
+    print(f'row {CODE} not on screen: {r}')      # never json.loads('rownf')
+else:
+    c=json.loads(r); click_at_xy(c['x'], c['y'])
 PY
 # then, in the shell, rename the newest file before the next download:
 #   mv ~/.vibe-seller/downloads/<slug>/fbn_finance_*.csv \
 #      <out>/monthly_storage_SA_2026-06.csv
 ```
+
+### Assert what you just downloaded — the rename is a claim, not a fact
+
+The file you saved as `monthly_storage_SA_2026-01.csv` is only SA and
+only January because *you* said so. Click one row too far and the name
+is still perfect while the contents are another country's or another
+month's money. This has happened: an `ae` / `2026-05` Non Saleable
+report landed in the `sa` / `2026-01` slot, and the error only surfaced
+much later as a reconciliation that missed by 3%.
+
+Every storage report carries its own `country_code` and `service_month`.
+Check the file against its name immediately, before the next download —
+one command, and it turns a silent wrong number into an instant retry:
+
+```bash
+python3 - <<'PY'          # NOTE: needs pandas — use the project venv's
+import pandas as pd, sys  # python if bare python3 lacks it
+path, want_cc, want_sm = sys.argv[1], sys.argv[2], sys.argv[3]
+df = pd.read_csv(path)
+if len(df) == 0:
+    print(f'{path}: header only — legitimately empty, or a failed download')
+else:
+    cc = set(df['country_code'].astype(str).str.lower())
+    sm = set(df['service_month'].astype(str))
+    assert cc == {want_cc}, f'{path}: holds {cc}, expected {want_cc}'
+    assert sm == {want_sm}, f'{path}: holds {sm}, expected {want_sm}'
+    print(f'{path}: OK {cc} {sm} {len(df)} rows')
+PY
+```
+
+RTV Removal has neither column — bucket it by `currency_code` instead.
+The Ad Manager xlsx has no country column at all, so for those the only
+check is that SA's and AE's `Spends` totals **differ**; if they match,
+the second download overwrote the first.
 
 ## 4. Reconciliation — the check that proves nothing is missing
 


### PR DESCRIPTION
## Why

A long report-collection run spent most of its tool errors on a single
line of copy-paste code **from our own reference**. Reading its
transcript: 13 of 59 tool errors were

```
TypeError: 'NoneType' object is not subscriptable
```

every one of them from the `rect()` pattern this reference tells agents
to use:

```python
r = rect("""…if(!b) return 'nf';…""")
click_at_xy(r['x'], r['y'])        # r is None whenever the modal hasn't rendered
```

The report picker renders asynchronously, so "control not on the page
yet" is the **common** path, not the edge case. When it happened the
agent got a traceback that named no control, so it had to re-probe blind
— which is most of why **119 of its 163 coordinate-clicks** went on
fighting that one modal instead of downloading reports.

The reference's own `click_ph` / `click_opt` helpers guard this correctly.
The two snippets around them did not.

## What changed

`references/fee-reports.md`

- **`must_click(expr, what)`** replaces the unguarded deref: retries 3×,
  then prints which control was missing plus `page_info()`. Used for both
  the top-right *Generate Report* button and the modal's submit button.
- The download snippet called `json.loads(r)` on a value that is the
  string `'rownf'` when the row is scrolled out of view. Guarded.
- **Quoting rules documented.** A `js()` argument is Python and JavaScript
  at once, so hand-quoting nested quotes produces a `SyntaxError` that
  points at the JS rather than the quote. Build JS string literals with
  `json.dumps`, and always `JSON.stringify` a returned object — a bare
  object comes back as `[object Object]`.
- Note that the CSV checks need pandas, so use the project venv's python
  rather than bare `python3` (a run hit `ModuleNotFoundError` on this).

**New § "Assert what you just downloaded"** — the check that matters most.
These downloads are named by report type only: no country, no service
month. So the country and month in `<kind>_<cc>_<YYYY-MM>.csv` are a
rename applied by hand afterwards, and they prove nothing. Click one row
too far in the table and the file is still named perfectly while holding
another country's or another month's money.

That is not hypothetical — it happened, and it surfaced only much later
as a reconciliation that missed by 3%. Every storage report carries its
own `country_code` and `service_month`; the section adds a one-command
assertion to run before the next download, which turns a silent wrong
number into an immediate retry. RTV Removal carries neither column
(bucket by `currency_code`); the ads xlsx has no country column at all,
so there the only check is that the two countries' `Spends` totals differ.

`SKILL.md`

- Promotes that assertion to a **review criterion**, so a pull that never
  opened its own files doesn't pass review.

## Notes

- Docs only — no runtime code paths touched.
- The corresponding server-side guard (refusing a fee report whose
  contents contradict its filename, rather than logging a warning and
  grossing the money into the wrong country) lives in the downstream
  consumer, not this repo.
