### PR TITLE
fix(tasks): a plan-mode run that never executed must not ship its plan as the result

### DIFF
--- a/app/ai/claude_backend_persist.py
+++ b/app/ai/claude_backend_persist.py
@@ -22,6 +22,68 @@ logger = logging.getLogger(__name__)
 class _PersistMixin:
     """Deliverable persistence — the streaming-prose result fallback."""
 
+    async def _settle_missing_plan(self):
+        """Decide what a ``plan_then_execute`` run with no plan produced.
+
+        ``_executing`` is the whole distinction, because two very
+        different runs are otherwise identical at that point (both: no
+        plan saved, rc 0, some prose):
+
+        * ``_executing=True`` — the documented plan-skip. Never called
+          ExitPlanMode but DID go on to do the work (some models just
+          execute a simple task directly), so the prose is a genuine
+          result. Nothing to do but note it.
+        * ``_executing=False`` — neither planned nor executed. The run
+          produced a plan DRAFT, not a deliverable: its prose narrates
+          what it intended to do. Recorded as an error, below.
+
+        This has to be recorded as an infra error rather than logged.
+        The prose reaches ``transcript_tail``, and
+        :func:`app.task_outcome.resolve_outcome` promotes prose to
+        DELIVERED whenever no error exists — so a run that navigated
+        nowhere and extracted nothing completed GREEN with its own
+        planning narration as the result. Observed live: an agent wrote
+        its plan to Claude Code's native ``~/.claude/plans/<slug>.md``
+        and its turn ended one step before the ExitPlanMode call it had
+        itself listed as the next step. The task reported success having
+        done no work.
+
+        Recording the error is enough to fix the verdict — the infra
+        branch of ``resolve_outcome`` outranks prose, so the transcript
+        is still kept and shown, it just stops counting as the answer.
+        The category is deliberately NOT ``AGENT_REPORTED``: this is the
+        platform detecting a broken run, not the agent describing one.
+        """
+        if self._executing:
+            logger.warning(
+                f'plan_then_execute skipped ExitPlanMode for task '
+                f'{self.task_id} but executed — keeping its output'
+            )
+            return
+
+        logger.error(
+            f'plan_then_execute for task {self.task_id} neither planned '
+            f'nor executed — failing it; its output is a plan draft'
+        )
+        try:
+            async with async_session() as db:
+                task = await db.get(Task, self.task_id)
+                if not task:
+                    return
+                task.error = (
+                    'Agent ended plan mode without delivering a plan: it '
+                    'never called ExitPlanMode and never entered '
+                    'execution, so nothing was carried out. Any text it '
+                    'produced is a plan draft, not a result. Retry the '
+                    'task.'
+                )
+                task.error_category = 'plan_not_delivered'
+                apply_outcome(task, resolve_outcome(task))
+                task.updated_at = datetime.now(UTC).isoformat()
+                await db.commit()
+        except Exception as e:
+            logger.error(f'Failed to record plan_not_delivered: {e}')
+
     async def _save_result(self, result_text: str):
         """Save the streamed prose tail and parse wait-condition.
 

--- a/app/ai/claude_backend_stream.py
+++ b/app/ai/claude_backend_stream.py
@@ -187,16 +187,14 @@ class _StreamMixin:
             if self._result_text and return_code == 0:
                 await self._save_result(self._result_text)
 
-            # plan_then_execute exited without plan → fail
+            # Exited plan mode with no plan — benign or a dead run,
+            # depending on whether execution ever started.
             if (
                 self.mode == 'plan_then_execute'
                 and not self._plan_saved
                 and return_code == 0
             ):
-                logger.warning(
-                    'plan_then_execute ended without ExitPlanMode for task %s',
-                    self.task_id,
-                )
+                await self._settle_missing_plan()
 
             await event_bus.emit(
                 'agent_done',

--- a/tests/unit/test_task_outcome.py
+++ b/tests/unit/test_task_outcome.py
@@ -278,3 +278,100 @@ class TestApplyOutcome:
 
         apply_outcome(row, resolve_outcome(row))
         assert row.result == first
+
+
+class TestPlanDraftIsNotADeliverable:
+    """A plan-mode run that never executed must not ship its plan as a result.
+
+    Live failure this pins: a `plan_then_execute` agent wrote its plan to
+    Claude Code's native `~/.claude/plans/<slug>.md` and its turn ended
+    one step before the ExitPlanMode call it had itself listed as next.
+    No plan was saved, execution never started, and nothing was carried
+    out — but the planning narration had already landed in
+    `transcript_tail`, which `resolve_outcome` promotes to DELIVERED when
+    no error exists. The task reported SUCCESS having done no work, and
+    only an end-to-end assertion on the extracted content caught it.
+
+    The backend now records `plan_not_delivered` for exactly that shape.
+    These tests pin that such an error outranks the prose, and that it is
+    NOT demoted to a caveat the way an agent-reported error is.
+    """
+
+    PROSE = (
+        "I'll design an execution plan for this task. Let me start by "
+        'exploring the relevant skills, then write the plan file and '
+        'call ExitPlanMode to present it.'
+    )
+
+    def test_plan_draft_prose_does_not_become_the_deliverable(self):
+        out = resolve_outcome(
+            _Row(
+                transcript_tail=self.PROSE,
+                error='Agent ended plan mode without delivering a plan',
+                error_category='plan_not_delivered',
+            )
+        )
+        assert out.kind is OutcomeKind.FAILED
+        assert out.content is None, 'plan narration must not ship as a result'
+        assert out.status is TaskStatus.FAILED
+
+    def test_same_prose_ships_when_no_error_was_recorded(self):
+        """Control: prose alone IS a legitimate deliverable.
+
+        A lookup or an answered question legitimately has the chat output
+        as its answer, so the fix must be the recorded error — not a new
+        rule about what prose looks like.
+        """
+        out = resolve_outcome(_Row(transcript_tail=self.PROSE))
+        assert out.kind is OutcomeKind.DELIVERED
+        assert out.content == self.PROSE
+
+    def test_the_reason_reaches_the_verdict(self):
+        """The FAILED outcome carries the actionable reason, not the prose.
+
+        Prose-only rows never survive *any* recorded error — the caveat
+        demotion that `agent_reported` gets applies to real submissions,
+        not to narration (see `test_a_real_submission_still_wins...`).
+        So supplying the error IS the whole fix, and what matters here is
+        that the message the user sees explains what went wrong rather
+        than being the agent's own planning text.
+        """
+        out = resolve_outcome(
+            _Row(
+                transcript_tail=self.PROSE,
+                error='never delivered a plan',
+                error_category='plan_not_delivered',
+            )
+        )
+        assert out.kind is OutcomeKind.FAILED
+        assert out.reason == 'never delivered a plan'
+        assert out.category == 'plan_not_delivered'
+        assert self.PROSE not in (out.reason or '')
+
+    def test_a_real_submission_still_wins_over_the_error(self):
+        """If execution DID produce something, that outranks the flag.
+
+        Guards the documented plan-skip: an agent that skipped
+        ExitPlanMode but went on to do the work has a real deliverable,
+        and this must not be able to bury it.
+        """
+        out = resolve_outcome(
+            _Row(
+                accepted_result='contact email: hello@example.test',
+                transcript_tail=self.PROSE,
+                error='partially done',
+                error_category='agent_reported',
+            )
+        )
+        assert out.kind is OutcomeKind.DELIVERED
+        assert 'hello@example.test' in out.content
+
+    def test_apply_outcome_lands_the_task_in_failed(self):
+        row = _Row(
+            transcript_tail=self.PROSE,
+            error='Agent ended plan mode without delivering a plan',
+            error_category='plan_not_delivered',
+        )
+        row.status = TaskStatus.DESIGNING
+        apply_outcome(row, resolve_outcome(row))
+        assert row.result is None


### PR DESCRIPTION
## The failure

`TestLLMWebBrowserNoStore::test_web_browser_extracts_contact_details`
failed on CI. The task reached **COMPLETED in 114s having navigated
nowhere** — the assertion caught it only because it checks for the
extracted email rather than for task status.

The server log states the cause directly:

```
plan_then_execute ended without ExitPlanMode for task 0b794879
```

Its 19 tool calls were: 3 Explore subagents, 4 `Read`, 6 `Bash` (all
`find` / `ls` / `pwd`), 1 `Skill`, 1 `Write`. The `Write` went to Claude
Code's **native plan file**, `~/.claude/plans/<slug>.md`, and the agent's
own message listed what was meant to follow:

> …write the plan file  **3. Call ExitPlanMode to present it to the user**

The turn ended before step 3. `browser-use` was never invoked.

## Why nothing caught it

The platform accepts exactly one plan-delivery channel — the
`ExitPlanMode` tool — while the model has two plausible ones. When it
picks the file-write and stops, three separately-reasonable behaviours
compose into a green task:

1. `_save_result` puts the agent's narration into `transcript_tail`
2. `resolve_outcome` promotes prose to `DELIVERED` whenever no error exists
3. so a run that did nothing reports **success**, with its own planning
   text as the deliverable

The contract *"a plan-mode task must not complete without executing"*
existed only as a comment reading `→ fail` sitting above a
`logger.warning`. A contract in prose rather than in code — the same
shape as the bug it was supposed to guard.

## The fix

`_executing` already distinguishes the two runs that are otherwise
identical at that point (both: no plan saved, `rc == 0`, some prose):

| | meaning | verdict |
|---|---|---|
| `_executing=True` | the documented plan-skip — never called `ExitPlanMode` but **did** do the work | warning only; prose is a real deliverable |
| `_executing=False` | neither planned nor executed | records `error_category='plan_not_delivered'` → task **FAILS** |

Recording the error is the *entire* fix. The infra branch of
`resolve_outcome` already outranks prose, so no caller special-cases
this, and the transcript is still kept and shown — it just stops counting
as the answer. The failure message tells the user to retry.

## Tests

5 new tests in `tests/unit/test_task_outcome.py`, including two that keep
the guard honest:

- **control:** prose alone *is* still a legitimate deliverable (a lookup,
  an answered question), so this can't regress into a rule about what
  prose looks like
- **control:** a real submission still outranks the flag, so the
  documented plan-skip case can't be buried by it

`46 passed` across the plan/outcome/finalizer unit tests; full unit suite
green.

## Scope note

Found while debugging CI for #125 (a docs-only change, which cannot cause
this). Split into its own PR because it changes task-lifecycle behaviour
and deserves separate review. The underlying trigger is model
non-determinism — the same test has passed on other branches — but the
design flaw it exposed is real and independent of any PR: **any** plan-mode
run that stops one step early currently reports success.
