### PR TITLE
fix(e2e): scope catalog-sync assertions to the batch this call triggered, not a 120s window

### DIFF
--- a/tests/e2e/test_catalog_sync.py
+++ b/tests/e2e/test_catalog_sync.py
@@ -161,6 +161,25 @@ def _trigger_catalog_sync(
     (expected to skip via staleness check).
     """
     base = f'{BASE_URL}/api/schedules/{SYSTEM_CATALOG_SYNC_ID}'
+
+    # Snapshot the batch ids that already exist, so the trigger below can
+    # be identified by the one it adds. Every task a fanout creates — the
+    # two_phase L2 prereq AND every per-store L3 — shares a single
+    # `batch_id`, so "the new batch" is exactly this call's work and
+    # nothing else's.
+    #
+    # Selecting by a 120s wall-clock window instead (what this did
+    # before) quietly defeats `--reruns 1`: a rerun fires seconds after
+    # the attempt it replaces, so the window still holds the previous
+    # attempt's tasks and the assertion trips over their already-`failed`
+    # rows. Observed live — attempt 1 lost its LLM connection
+    # mid-response at 02:42:35, the rerun triggered 9s later at 02:42:44,
+    # and the rerun then reported attempt 1's error. No retry could have
+    # passed, however healthy the second run was.
+    resp = client.get(f'{base}/tasks')
+    resp.raise_for_status()
+    seen_batches = {t['batch_id'] for t in resp.json() if t.get('batch_id')}
+
     # AI-profile routing for system schedules is configured centrally in
     # conftest's _setup_worker_profile (which pins the worker's provider
     # onto every schedule that would otherwise resolve to the
@@ -169,8 +188,8 @@ def _trigger_catalog_sync(
     resp = client.post(f'{base}/trigger')
     resp.raise_for_status()
 
-    cutoff = time.time() - 120
     start = time.time()
+    batch_id: str | None = None
 
     # Catalog sync fans out N tasks (1 L2 + 1 per store ≈ 12) that
     # serialize through the agent concurrency semaphore (default 9
@@ -186,7 +205,28 @@ def _trigger_catalog_sync(
         resp = client.get(f'{base}/tasks')
         resp.raise_for_status()
         tasks = resp.json()
-        recent = [t for t in tasks if _parse_ts(t['created_at']) > cutoff]
+
+        if batch_id is None:
+            fresh = {
+                t['batch_id']
+                for t in tasks
+                if t.get('batch_id') and t['batch_id'] not in seen_batches
+            }
+            if not fresh:
+                time.sleep(3)
+                continue
+            # Pin the batch once and never re-derive it, so a concurrent
+            # trigger later in the run cannot move the goalposts.
+            batch_id = max(
+                fresh,
+                key=lambda b: max(
+                    _parse_ts(t['created_at'])
+                    for t in tasks
+                    if t.get('batch_id') == b
+                ),
+            )
+
+        recent = [t for t in tasks if t.get('batch_id') == batch_id]
         if not recent:
             time.sleep(3)
             continue
@@ -200,7 +240,7 @@ def _trigger_catalog_sync(
             time.sleep(3)
             continue
 
-        # Wait for ALL recent tasks to finish
+        # Wait for ALL of THIS batch's tasks to finish
         if all(t['status'] in ('completed', 'failed') for t in recent):
             relevant = [
                 t


### PR DESCRIPTION
## The failure

`test_catalog_sync_and_agent_usage` failed, was retried by the suite's
own `--reruns 1 --only-rerun 'Connection closed mid-response'`, and
failed again — **reporting the first attempt's error**. The retry never
had a chance.

The cause is the helper's task selector:

```python
cutoff = time.time() - 120
recent = [t for t in tasks if _parse_ts(t['created_at']) > cutoff]
```

A 120-second wall-clock window. A rerun fires *seconds* after the attempt
it replaces, so the window still contains that attempt's tasks. From the
CI logs:

```
02:40:50  fan-out: created 10 tasks   (batch A)
02:42:35  a batch-A task lost its LLM connection mid-response
02:42:44  rerun triggers fan-out: created 13 tasks  (batch B)
          -> cutoff is 02:40:44, so batch A is STILL in the window
02:49:06  FAILED, reporting batch A's error
```

So the suite's retry facility was **inert for this test**: any first
attempt that leaves a `failed` row poisons every rerun within two
minutes. `--maxfail=1` then aborted the remainder — which is why 18 tests
passed instead of the usual 31.

## The fix

The fanout already provides the right key. Every task a trigger creates —
the `two_phase` L2 prereq **and** every per-store L3 — shares one
`batch_id` (`app/scheduler/fanout.py`), and `batch_id` is already exposed
on `TaskResponse`. So:

1. snapshot the batch ids that already exist
2. trigger
3. pin the one new batch, and scope every assertion to it

The batch is pinned **once** and never re-derived, so a later concurrent
trigger can't move the goalposts mid-poll either.

This is not a retry, a sleep, or a loosened assertion — it corrects
*what the test looks at*. The upstream connection drop that triggered
this particular run remains a genuine transient; the point is that a
rerun can now actually clear it instead of re-reading a corpse.

## Scope note

Found while getting CI green on #125 (docs-only). The defect is
pre-existing and can hit any PR that happens to catch a transient in this
test, so it is split out here rather than buried in an unrelated change.
