### PR TITLE
fix(frontend): typecheck the tests, so fixtures cannot drift from the types

### DIFF
--- a/frontend/src/__tests__/retryTaskRace.test.tsx
+++ b/frontend/src/__tests__/retryTaskRace.test.tsx
@@ -28,32 +28,21 @@ import { renderHook, act } from '@testing-library/react'
 import { useState } from 'react'
 import { retryTask } from '../handlers/retryTask'
 import type { Task } from '../types'
+import { makeTask as baseTask } from '../test/factories'
 
 function makeTask(
   id: string,
   status: Task['status'] = 'failed',
   extra: Partial<Task> = {},
 ): Task {
-  return {
+  return baseTask({
     id,
-    store_id: null,
     title: `T-${id}`,
-    description: null,
     status,
-    plan: null,
-    result: null,
-    todos: null,
-    wait_condition: null,
-    error: null,
-    plan_mode: false,
     ai_profile_id: 'profile-old',
-    schedule_id: null,
-    batch_id: null,
     created_at: '',
-    started_at: null,
-    completed_at: null,
     ...extra,
-  }
+  })
 }
 
 function useHarness(initial: Task[]) {

--- a/frontend/src/__tests__/scheduleDisplay.test.tsx
+++ b/frontend/src/__tests__/scheduleDisplay.test.tsx
@@ -7,32 +7,10 @@ import { I18nextProvider } from 'react-i18next'
 import { ScheduleList } from '../components/ScheduleList'
 import { i18nTestInstance } from '../test/helpers'
 import type { Schedule, Store } from '../types'
+import { makeSchedule as baseSchedule } from '../test/factories'
 
 function makeSchedule(overrides: Partial<Schedule> = {}): Schedule {
-  return {
-    id: `sched-${Math.random().toString(36).slice(2)}`,
-    store_id: null,
-    title: 'Test Schedule',
-    description: null,
-    platform: null,
-    country: null,
-    plan: null,
-    schedule_type: 'daily',
-    schedule_time: '09:00',
-    schedule_day: null,
-    interval_value: 1,
-    timezone: 'UTC',
-    is_active: true,
-    plan_mode: false,
-    ai_profile_id: null,
-    created_by: 'user1',
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
-    next_run: null,
-    child_task_count: 0,
-    last_run_status: null,
-    ...overrides,
-  }
+  return baseSchedule({ title: 'Test Schedule', ...overrides })
 }
 
 const defaultProps = {

--- a/frontend/src/__tests__/selectScheduleRace.test.tsx
+++ b/frontend/src/__tests__/selectScheduleRace.test.tsx
@@ -17,9 +17,23 @@ import { describe, it, expect, vi } from 'vitest'
 import { useRef } from 'react'
 import { act, renderHook } from '@testing-library/react'
 import { selectSchedule } from '../handlers/selectSchedule'
+import type { SelectScheduleApi } from '../handlers/selectSchedule'
 
 interface Sched { id: string }
 interface Tsk { id: string; schedule_id: string }
+
+/**
+ * Adapt a concrete task-list fetcher to `SelectScheduleApi`.
+ *
+ * `api.get` is generic (`get<T>(url): Promise<T>`), so a plain
+ * `() => Promise<Tsk[]>` is not assignable to it — it cannot honour a
+ * caller that asks for some other `T`. These tests only ever drive the
+ * one call site, which asks for `Tsk[]`, so narrowing here is sound and
+ * keeps the cast in a single documented place instead of at every mock.
+ */
+function taskApi(get: (url: string) => Promise<Tsk[]>): SelectScheduleApi {
+  return { get: <T,>(url: string) => get(url) as unknown as Promise<T> }
+}
 
 function deferred<T>() {
   let resolve!: (v: T) => void
@@ -37,7 +51,7 @@ describe('selectSchedule — stale-list + race guard', () => {
     const setSelectedSchedule = vi.fn()
     const setSelectedTask = vi.fn()
     // fetch blocks forever so we can observe the pre-fetch state
-    const api = { get: () => new Promise<Tsk[]>(() => {}) }
+    const api = taskApi(() => new Promise<Tsk[]>(() => {}))
 
     void selectSchedule<Sched, Tsk>(
       { id: 'B' },
@@ -69,13 +83,11 @@ describe('selectSchedule — stale-list + race guard', () => {
     const pendingA = deferred<Tsk[]>()
     const pendingB = deferred<Tsk[]>()
     let seenA = false
-    const api = {
-      get: (url: string) => {
-        if (url.includes('/schedules/A/')) { seenA = true; return pendingA.promise }
-        if (url.includes('/schedules/B/')) return pendingB.promise
-        throw new Error(`unexpected ${url}`)
-      },
-    }
+    const api = taskApi((url: string) => {
+      if (url.includes('/schedules/A/')) { seenA = true; return pendingA.promise }
+      if (url.includes('/schedules/B/')) return pendingB.promise
+      throw new Error(`unexpected ${url}`)
+    })
 
     const deps = {
       api,
@@ -119,13 +131,11 @@ describe('selectSchedule — stale-list + race guard', () => {
     const setScheduleTasks = vi.fn()
 
     const pendingA = deferred<Tsk[]>()
-    const api = {
-      get: (url: string) => {
-        if (url.includes('/schedules/A/')) return pendingA.promise
-        // B's fetch resolves immediately.
-        return Promise.resolve([{ id: 't-b', schedule_id: 'B' }] as Tsk[])
-      },
-    }
+    const api = taskApi((url: string) => {
+      if (url.includes('/schedules/A/')) return pendingA.promise
+      // B's fetch resolves immediately.
+      return Promise.resolve([{ id: 't-b', schedule_id: 'B' }] as Tsk[])
+    })
 
     const deps = {
       api,
@@ -159,12 +169,10 @@ describe('selectSchedule — stale-list + race guard', () => {
     const setScheduleTasks = vi.fn()
 
     const pendingA = deferred<Tsk[]>()
-    const api = {
-      get: (url: string) => {
-        if (url.includes('/schedules/A/')) return pendingA.promise
-        throw new Error(`unexpected ${url}`)
-      },
-    }
+    const api = taskApi((url: string) => {
+      if (url.includes('/schedules/A/')) return pendingA.promise
+      throw new Error(`unexpected ${url}`)
+    })
     const deps = {
       api,
       inFlightScheduleIdRef: result.current,

--- a/frontend/src/__tests__/sseCreateTaskRace.test.tsx
+++ b/frontend/src/__tests__/sseCreateTaskRace.test.tsx
@@ -28,6 +28,7 @@ import { renderHook, act } from '@testing-library/react'
 import { useState } from 'react'
 import { useSSE } from '../hooks/useSSE'
 import type { Task } from '../types'
+import { makeTask as baseTask } from '../test/factories'
 
 /* ── EventSource mock ──────────────────────────────── */
 
@@ -54,13 +55,7 @@ function emit(data: Record<string, unknown>) {
 }
 
 function makeTask(id: string, status = 'pending'): Task {
-  return {
-    id, store_id: null, title: 'T', description: null,
-    status, plan: null, result: null, todos: null,
-    wait_condition: null, error: null, plan_mode: false,
-    ai_profile_id: null, schedule_id: null, batch_id: null,
-    created_at: '', started_at: null, completed_at: null,
-  }
+  return baseTask({ id, title: 'T', status, created_at: '' })
 }
 
 /**

--- a/frontend/src/__tests__/sseQueuedOutputReconcile.test.tsx
+++ b/frontend/src/__tests__/sseQueuedOutputReconcile.test.tsx
@@ -24,6 +24,7 @@ import { renderHook, act } from '@testing-library/react'
 import { useState } from 'react'
 import { useSSE } from '../hooks/useSSE'
 import type { Task } from '../types'
+import { makeTask as baseTask } from '../test/factories'
 
 type Listener = ((evt: MessageEvent) => void) | null
 let esInstances: { onmessage: Listener; close: ReturnType<typeof vi.fn> }[] = []
@@ -51,13 +52,7 @@ function emit(data: Record<string, unknown>) {
 }
 
 function makeTask(id: string, status = 'queued', plan_mode = false): Task {
-  return {
-    id, store_id: null, title: `T-${id}`, description: null,
-    status, plan: null, result: null, todos: null,
-    wait_condition: null, error: null, plan_mode,
-    ai_profile_id: null, schedule_id: null, batch_id: null,
-    created_at: '', started_at: null, completed_at: null,
-  }
+  return baseTask({ id, title: `T-${id}`, status, plan_mode, created_at: '' })
 }
 
 function useHarness(initial: Task[]) {

--- a/frontend/src/__tests__/sseScheduleTasks.test.tsx
+++ b/frontend/src/__tests__/sseScheduleTasks.test.tsx
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useSSE } from '../hooks/useSSE'
 import type { Task } from '../types'
+import { makeTask as baseTask } from '../test/factories'
 
 /* ── EventSource mock ─────────────────────────────── */
 
@@ -35,13 +36,7 @@ function emit(data: Record<string, unknown>) {
 /* ── Minimal params factory ───────────────────────── */
 
 function makeTask(id: string, status = 'pending'): Task {
-  return {
-    id, store_id: null, title: 'T', description: null,
-    status, plan: null, result: null, todos: null,
-    wait_condition: null, error: null, plan_mode: false,
-    ai_profile_id: null, schedule_id: 's1', batch_id: null,
-    created_at: '', started_at: null, completed_at: null,
-  }
+  return baseTask({ id, title: 'T', status, schedule_id: 's1', created_at: '' })
 }
 
 function makeParams(overrides: Record<string, unknown> = {}) {
@@ -87,7 +82,10 @@ describe('SSE task_update patches scheduleTasks', () => {
 
     // Verify the mapper produces the right status
     const task = makeTask('t1')
-    const tasksMapper = params.setTasks.mock.calls[0][0] as (prev: Task[]) => Task[]
+    // `makeParams` casts to useSSE's prop type, so these read as plain
+    // setters rather than mocks — same cast as setScheduleTasks below.
+    const tasksMapper = (params.setTasks as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0] as (prev: Task[]) => Task[]
     expect(tasksMapper([task])[0].status).toBe('running')
 
     const schedMapper = (params.setScheduleTasks as ReturnType<typeof vi.fn>)

--- a/frontend/src/__tests__/sseTaskCreated.test.tsx
+++ b/frontend/src/__tests__/sseTaskCreated.test.tsx
@@ -12,6 +12,7 @@ import { renderHook, act } from '@testing-library/react'
 import { useState } from 'react'
 import { useSSE } from '../hooks/useSSE'
 import type { Task } from '../types'
+import { makeTask as baseTask } from '../test/factories'
 
 type Listener = ((evt: MessageEvent) => void) | null
 let esInstances: { onmessage: Listener; close: ReturnType<typeof vi.fn> }[] = []
@@ -40,13 +41,7 @@ function emit(data: Record<string, unknown>) {
 }
 
 function makeTask(id: string, store_id: string | null = null, status = 'pending'): Task {
-  return {
-    id, store_id, title: `T-${id}`, description: null,
-    status, plan: null, result: null, todos: null,
-    wait_condition: null, error: null, plan_mode: false,
-    ai_profile_id: null, schedule_id: null, batch_id: null,
-    created_at: '', started_at: null, completed_at: null,
-  }
+  return baseTask({ id, store_id, title: `T-${id}`, status, created_at: '' })
 }
 
 interface ViewProps {

--- a/frontend/src/__tests__/triggerScheduleChain.test.tsx
+++ b/frontend/src/__tests__/triggerScheduleChain.test.tsx
@@ -20,8 +20,13 @@ import { render, screen, waitFor, act } from '@testing-library/react'
 import { I18nextProvider } from 'react-i18next'
 import type { ReactElement } from 'react'
 import type { Task, Schedule, Store } from '../types'
+import {
+  makeSchedule as baseSchedule,
+  makeTask as baseTask,
+} from '../test/factories'
 import { i18nTestInstance } from '../test/helpers'
 import { TasksView } from '../views/TasksView'
+import type { TasksViewProps } from '../views/TasksView'
 import { triggerSchedule } from '../handlers/triggerSchedule'
 import { api } from '../api'
 
@@ -29,50 +34,11 @@ import { api } from '../api'
 /* ── Helpers ───────────────────────────────────────── */
 
 function makeSchedule(overrides: Partial<Schedule> = {}): Schedule {
-  return {
-    id: 'sched-1',
-    store_id: null,
-    title: 'Email review',
-    description: null,
-    platform: null,
-    country: null,
-    plan: null,
-    schedule_type: 'daily',
-    schedule_time: '09:00',
-    schedule_day: null,
-    interval_value: 1,
-    timezone: 'UTC',
-    is_active: true,
-    plan_mode: false,
-    ai_profile_id: null,
-    created_by: 'u1',
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
-    ...overrides,
-  } as Schedule
+  return baseSchedule({ id: 'sched-1', title: 'Email review', ...overrides })
 }
 
 function makeTask(overrides: Partial<Task> = {}): Task {
-  return {
-    id: `t-${Math.random().toString(36).slice(2, 8)}`,
-    store_id: null,
-    title: 'Email review',
-    description: null,
-    status: 'pending',
-    plan: null,
-    result: null,
-    todos: null,
-    wait_condition: null,
-    error: null,
-    plan_mode: false,
-    ai_profile_id: null,
-    schedule_id: 'sched-1',
-    batch_id: null,
-    created_at: new Date().toISOString(),
-    started_at: null,
-    completed_at: null,
-    ...overrides,
-  } as Task
+  return baseTask({ title: 'Email review', schedule_id: 'sched-1', ...overrides })
 }
 
 function wrap(ui: ReactElement) {
@@ -213,16 +179,21 @@ describe('schedule trigger integration — real handler + api + fetch stub', () 
 /* ── UI chain test — render + click → button greys out ── */
 
 describe('TasksView Run Now button reflects scheduleTasks', () => {
-  const TASKSVIEW_PROPS = {
+  // Typed against the real props, minus the two each case varies. A
+  // prop added to TasksView now breaks this line loudly instead of
+  // arriving as `undefined` and silently changing what renders.
+  const TASKSVIEW_PROPS: Omit<
+    TasksViewProps,
+    'scheduleTasks' | 'triggerSchedule'
+  > = {
     stores: [] as Store[],
     selectedStore: null,
-    storeTasks: [],
     showAllTasks: false,
     tasks: [],
     schedules: [makeSchedule()],
     selectedTask: null,
     steps: [],
-    screenshots: [],
+    screenshots: {},
     logs: [],
     agentMessages: [],
     todoItems: [],
@@ -240,8 +211,6 @@ describe('TasksView Run Now button reflects scheduleTasks', () => {
     retryTask: vi.fn(),
     debugMode: false,
     setDebugMode: vi.fn(),
-    executePlan: vi.fn(),
-    onToggleAutoMode: vi.fn(),
     selectTask: vi.fn(),
     setSelectedTask: vi.fn(),
     selectAnswer: vi.fn(),
@@ -251,17 +220,44 @@ describe('TasksView Run Now button reflects scheduleTasks', () => {
     profiles: [],
     selectedProfileId: 'default',
     setSelectedProfileId: vi.fn(),
-    onCreateTask: vi.fn(),
-    onOpenCreateTask: vi.fn(),
-    onOpenCreateSchedule: vi.fn(),
-    onSelectStore: vi.fn(),
-    onShowAllTasks: vi.fn(),
     questionBannerRef: { current: null },
     selectedSchedule: makeSchedule(),
-    onSelectSchedule: vi.fn(),
     toggleSchedulePause: vi.fn(),
-    setEditingSchedule: vi.fn(),
     deleteSchedule: vi.fn(),
+    isMobile: false,
+    onOpenNav: vi.fn(),
+    taskPanelActive: false,
+    taskPanelTitle: '',
+    tasksLoading: false,
+    currentUser: {
+      id: 'u1',
+      username: 'tester',
+      email: null,
+      role: 'admin',
+      is_active: true,
+      avatar_url: null,
+      plan_mode_default: false,
+      debug_mode: false,
+      default_profile_id: 'default',
+      sync_profile_to_schedules: false,
+      created_at: '',
+    },
+    openCreateModal: vi.fn(),
+    continueTask: vi.fn(),
+    deleteTask: vi.fn(),
+    submitImageDecision: vi.fn(),
+    setTasks: vi.fn(),
+    setCurrentUser: vi.fn(),
+    setEditingProfile: vi.fn(),
+    setShowProfileModal: vi.fn(),
+    taskSubTab: 'scheduled',
+    setTaskSubTab: vi.fn(),
+    showCreateSchedule: false,
+    setShowCreateSchedule: vi.fn(),
+    selectSchedule: vi.fn(),
+    replanSchedule: vi.fn(),
+    setSelectedSchedule: vi.fn(),
+    onScheduleUpdated: vi.fn(),
   }
 
   afterEach(() => vi.restoreAllMocks())

--- a/frontend/src/hooks/__tests__/useSessionKeepalive.test.ts
+++ b/frontend/src/hooks/__tests__/useSessionKeepalive.test.ts
@@ -5,8 +5,13 @@ import { useSessionKeepalive } from '../useSessionKeepalive'
 // Mock the shared API client — we only assert which endpoint each tick
 // hits. The 401 → AUTH_EXPIRED_EVENT behavior lives in api.ts and is
 // covered by apiAuthExpired.test.ts.
-const get = vi.fn(() => Promise.resolve({}))
-const post = vi.fn(() => Promise.resolve({}))
+// Typed to ACCEPT arguments even though the body ignores them: the
+// forwarders below spread the real call's arguments in, and a
+// zero-arity mock cannot be spread into. The assertions then read those
+// arguments back off `.mock.calls`.
+type ApiCall = (...args: unknown[]) => Promise<object>
+const get = vi.fn<ApiCall>(() => Promise.resolve({}))
+const post = vi.fn<ApiCall>(() => Promise.resolve({}))
 vi.mock('../../api', () => ({ api: { get: (...a: unknown[]) => get(...a), post: (...a: unknown[]) => post(...a) } }))
 
 describe('useSessionKeepalive', () => {

--- a/frontend/src/test/factories.ts
+++ b/frontend/src/test/factories.ts
@@ -1,0 +1,131 @@
+/**
+ * Test-double factories, with no rendering dependencies.
+ *
+ * Split out of `helpers.tsx` so a hook or reducer test can build a
+ * `Task` without dragging in `ConversationStream`, i18next and
+ * `@testing-library/react`.
+ *
+ * **Build fixtures through these, never as bare object literals.** Five
+ * separate hand-rolled `makeTask`s had each drifted from the real
+ * `Task` type — they were missing `plan_history`, `error_category` and
+ * `created_by_name` — and nothing noticed, because test files used to
+ * be excluded from typecheck. They are typechecked now, but one shared
+ * factory is what makes the next added field a single-line change
+ * instead of a hunt through every test that happens to construct one.
+ */
+import type {
+  ConversationItem,
+  ConversationItemType,
+  PlanVersion,
+  Schedule,
+  Task,
+} from '../types'
+
+let _idCounter = 0
+
+export function makeSchedule(overrides: Partial<Schedule> = {}): Schedule {
+  return {
+    id: `sched-${++_idCounter}`,
+    store_id: null,
+    title: 'Test Schedule',
+    description: null,
+    platform: null,
+    country: null,
+    plan: null,
+    // 'days' + interval_value 1 IS the daily case; Schedule has no
+    // 'daily' member.
+    schedule_type: 'days',
+    schedule_time: '09:00',
+    schedule_day: null,
+    interval_value: 1,
+    timezone: 'UTC',
+    is_active: true,
+    phase_mode: 'single',
+    plan_mode: false,
+    finalize_description: null,
+    ai_profile_id: null,
+    created_by: 'user1',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    next_run: null,
+    child_task_count: 0,
+    last_run_status: null,
+    plan_status: 'none',
+    plan_version: 0,
+    plan_error: null,
+    current_planning_task_id: null,
+    pending_questions_count: 0,
+    ...overrides,
+  }
+}
+
+export function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: `task-${++_idCounter}`,
+    store_id: null,
+    title: 'Test Task',
+    description: null,
+    status: 'pending',
+    plan: null,
+    plan_history: null,
+    result: null,
+    todos: null,
+    wait_condition: null,
+    error: null,
+    error_category: null,
+    plan_mode: false,
+    ai_profile_id: null,
+    schedule_id: null,
+    batch_id: null,
+    created_by_name: null,
+    created_at: new Date().toISOString(),
+    started_at: null,
+    completed_at: null,
+    ...overrides,
+  }
+}
+
+export function makePlan(overrides: Partial<PlanVersion> = {}): PlanVersion {
+  return {
+    version: 1,
+    content: '## Plan\n1. Step one\n2. Step two',
+    isCurrent: true,
+    ...overrides,
+  }
+}
+
+export function makeConversationItem(
+  type: ConversationItemType,
+  overrides: Partial<ConversationItem> = {},
+): ConversationItem {
+  const base: ConversationItem = {
+    id: `item-${++_idCounter}`,
+    type,
+    timestamp: new Date().toISOString(),
+  }
+
+  if (type === 'plan') {
+    base.plan = makePlan()
+  } else if (type === 'user_message') {
+    base.message = { role: 'user', content: 'Hello' }
+  } else if (type === 'agent_message') {
+    base.message = { role: 'assistant', content: 'Working on it...' }
+  } else if (type === 'streaming') {
+    base.message = { role: '_streaming', content: 'typing...' }
+  } else if (type === 'result') {
+    base.result = 'Task completed successfully'
+  } else if (type === 'question') {
+    base.questions = {
+      request_id: 'q1',
+      questions: [
+        { question: 'Which option?', options: [{ label: 'A' }, { label: 'B' }] },
+      ],
+    }
+  } else if (type === 'tool_call') {
+    base.toolCall = { tool: 'Read', input: { file_path: 'app/models.py' } }
+  } else if (type === 'thinking') {
+    base.thinking = { content: 'Analyzing the code...', isStreaming: false }
+  }
+
+  return { ...base, ...overrides }
+}

--- a/frontend/src/test/helpers.tsx
+++ b/frontend/src/test/helpers.tsx
@@ -8,7 +8,8 @@ import { initReactI18next } from 'react-i18next'
 import { createRef } from 'react'
 import enTranslation from '../i18n/locales/en/translation.json'
 import { ConversationStream } from '../components/conversation/ConversationStream'
-import type { Task, ConversationItem, ConversationItemType, PlanVersion, TodoItem, TaskStep } from '../types'
+import type { Task, ConversationItem, TodoItem, TaskStep } from '../types'
+import { makeTask } from './factories'
 
 // ── i18n test instance ─────────────────────────────────
 
@@ -21,74 +22,11 @@ i18nTestInstance.use(initReactI18next).init({
 })
 
 // ── Factories ──────────────────────────────────────────
+//
+// Defined in `./factories` (no rendering imports, so hook tests can use
+// them too) and re-exported here for the render-helper callers.
 
-let _idCounter = 0
-
-export function makeTask(overrides: Partial<Task> = {}): Task {
-  return {
-    id: `task-${++_idCounter}`,
-    store_id: null,
-    title: 'Test Task',
-    description: null,
-    status: 'pending',
-    plan: null,
-    result: null,
-    todos: null,
-    wait_condition: null,
-    error: null,
-    plan_mode: false,
-    ai_profile_id: null,
-    schedule_id: null,
-    batch_id: null,
-    created_at: new Date().toISOString(),
-    started_at: null,
-    completed_at: null,
-    ...overrides,
-  }
-}
-
-export function makePlan(overrides: Partial<PlanVersion> = {}): PlanVersion {
-  return {
-    version: 1,
-    content: '## Plan\n1. Step one\n2. Step two',
-    isCurrent: true,
-    ...overrides,
-  }
-}
-
-export function makeConversationItem(
-  type: ConversationItemType,
-  overrides: Partial<ConversationItem> = {},
-): ConversationItem {
-  const base: ConversationItem = {
-    id: `item-${++_idCounter}`,
-    type,
-    timestamp: new Date().toISOString(),
-  }
-
-  if (type === 'plan') {
-    base.plan = makePlan()
-  } else if (type === 'user_message') {
-    base.message = { role: 'user', content: 'Hello' }
-  } else if (type === 'agent_message') {
-    base.message = { role: 'assistant', content: 'Working on it...' }
-  } else if (type === 'streaming') {
-    base.message = { role: '_streaming', content: 'typing...' }
-  } else if (type === 'result') {
-    base.result = 'Task completed successfully'
-  } else if (type === 'question') {
-    base.questions = {
-      request_id: 'q1',
-      questions: [{ question: 'Which option?', options: [{ label: 'A' }, { label: 'B' }] }],
-    }
-  } else if (type === 'tool_call') {
-    base.toolCall = { tool: 'Read', input: { file_path: 'app/models.py' } }
-  } else if (type === 'thinking') {
-    base.thinking = { content: 'Analyzing the code...', isStreaming: false }
-  }
-
-  return { ...base, ...overrides }
-}
+export { makeTask, makePlan, makeConversationItem } from './factories'
 
 // ── ConversationStream render helper ───────────────────
 

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -26,7 +26,7 @@ function formatDate(dateStr: string): string {
   return `${d.getFullYear()}.${pad(d.getMonth() + 1)}.${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
 }
 
-interface TasksViewProps {
+export interface TasksViewProps {
   isMobile: boolean
   /** Audit console open state, owned by the URL. */
   auditOpen?: boolean

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -24,6 +24,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"],
-  "exclude": ["src/**/__tests__", "src/test"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## The hole

`frontend/tsconfig.app.json` excluded `src/**/__tests__` and `src/test`, and vitest only transpiles. Between them, **a type error in a test was unreachable by any check this repo runs.**

Not theoretical — this is the follow-up promised in [#129](https://github.com/zpoint/vibe-seller/pull/129). That PR added two *required* fields to `DecisionSubmission.totals`, and the test fixture kept submitting the old shape — one the UI cannot produce — with everything green. Review caught it by eye, which is not a control. Dropping the exclusion surfaced **21 more of the same, across 10 files**.

## Not 21 patches

Almost all of them were one bug class: a hand-rolled test double that had fallen behind the type it stands in for. So the fix is consolidation, not patching:

- **Five** separate `makeTask`s had each drifted from `Task` (missing `plan_history`, `error_category`, `created_by_name`). They now delegate to one factory.
- `makeSchedule` existed twice, both laundered through `as Schedule` — a cast that would have kept the hole open whatever tsconfig said. Both go through the shared factory now, casts gone.
- Factories moved to `src/test/factories.ts`, split out of `helpers.tsx` so a hook test can build a `Task` without pulling in `ConversationStream`, i18next and testing-library. `helpers.tsx` re-exports them, so **no caller changed**.

Net **−104 lines**.

## What the checker found once it could look

None of this was caught by the 497 passing tests:

| Finding | Why it matters |
|---|---|
| `TasksView` handed **nine** props it does not accept (`executePlan`, `onCreateTask`, `onSelectSchedule`, …) | React ignored them silently — the test was configuring nothing |
| `screenshots: []` where the component wants `Record<string, string>` | wrong container type reaching a real component |
| `schedule_type: 'daily'` | not a member of that union; the app can never produce it |
| `api.get` mocks that cannot satisfy the generic signature they stand in for | now adapted in one documented place |

`TASKSVIEW_PROPS` is now typed `Omit<TasksViewProps, …>`, so a prop added to the view breaks the fixture **loudly** instead of arriving as `undefined` and quietly changing what renders.

## Verification

Not "the suite went green" — a negative control. Adding a required field to `Task` and a required prop to `TasksViewProps` makes `tsc -b` fail, and the `Task` one now fails in a **single** place rather than five. Reverted → back to 0 errors.

- `tsc -b`: 0 errors
- `vitest run`: 497 passed, 50 files
- `pre-commit run --all-files`: clean

`tsc -b` is already what pre-commit and CI run, so this is enforced everywhere with **no workflow change**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNLgs9eR2mg74hs5T6nSe