### PR TITLE
fix(reports): count rows, derive the file list, stop trusting a byte count

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -63,6 +63,9 @@ def _ensure_added_columns(conn) -> None:
         ('tasks', 'transcript_tail', 'TEXT'),
         # User pref: re-pin owned schedules on default-profile change.
         ('users', 'sync_profile_to_schedules', 'BOOLEAN NOT NULL DEFAULT 0'),
+        # What a store can actually produce (FBA / ads / FBN), as opposed
+        # to where it sells. See app/deliverables/manifest.py.
+        ('stores', 'capabilities', "TEXT NOT NULL DEFAULT '{}'"),
     ]
     for table, column, sqltype in added:
         cols = {

--- a/app/deliverables/__init__.py
+++ b/app/deliverables/__init__.py
@@ -1,0 +1,57 @@
+"""What a report-download run owes, as data rather than as prose.
+
+A scheduled monthly download has an exact deliverable set: for this
+store, this month, these files must exist and must carry rows. Until
+now that set existed only inside a plan document written for the agent
+to read, which left three holes with one shape — nothing could *check*
+the list:
+
+* An unpublished upstream report downloads as a well-formed CSV holding
+  a header and nothing else. It is not an error, its status upstream is
+  ``Complete``, and it is larger than zero bytes, so every check the
+  pipeline had passed it. One such file shipped inside a run that was
+  marked COMPLETED and independently reviewed as ok.
+* A store with no FBA was asked for a storage report it can never
+  produce, and the run failed for the absence.
+* An agent that attempted 9 of 19 files reported "9 expected, 9 done".
+  When the denominator is self-declared, under-delivery is invisible.
+
+:mod:`app.deliverables.manifest` derives the expected set from the
+store's own capabilities and the calendar — both known before the agent
+starts, so there is nothing here for an agent to declare and nothing to
+re-declare around. :mod:`app.deliverables.verify` checks the workspace
+against it and counts rows, because a byte count cannot.
+
+The verdict is not a new terminal state. It rides the existing gate
+contract (``app.ai.stop_gates``): unmet entries come back as ``gaps``,
+which the outcome model already carries as caveats on a COMPLETED run
+(see :mod:`app.task_outcome`). An expected-latency gap therefore lands
+"completed, with this file listed as pending" without anybody writing a
+day-of-month rule in prose.
+"""
+
+from app.deliverables.manifest import (
+    Deliverable,
+    DeliverableKind,
+    derive_manifest,
+    month_before,
+    store_capabilities,
+)
+from app.deliverables.verify import (
+    DeliverableStatus,
+    VerifyReport,
+    data_rows,
+    verify_workspace,
+)
+
+__all__ = [
+    'Deliverable',
+    'DeliverableKind',
+    'DeliverableStatus',
+    'VerifyReport',
+    'data_rows',
+    'derive_manifest',
+    'month_before',
+    'store_capabilities',
+    'verify_workspace',
+]

--- a/app/deliverables/gate.py
+++ b/app/deliverables/gate.py
@@ -1,0 +1,137 @@
+"""Refuse a report-download result that under-delivered.
+
+Called directly from ``set_task_result`` (the same shape as
+``check_exec_review_status``) rather than registered as a skill-declared
+stop gate, because deciding what a run owed needs the store row and the
+calendar — a DB session and a date, neither of which the sync gate
+contract carries.
+
+Scope is deliberately narrow, and narrow in the fail-safe direction: the
+check only engages for a store-scoped task whose workspace already holds
+at least one ``reports_*`` folder. A task that downloaded no report
+folders is not a report run and is left alone. This mirrors how the ad
+completeness gate only bites a report presenting per-marketplace
+sections — the failure mode is "we asked for less than we could have",
+never "we invented an obligation".
+
+The month is taken from the calendar, never from the folder names the
+agent produced. Reading the expected set out of the agent's own output is
+the mistake that let a run attempt 9 files and report 9 of 9: a
+denominator derived from the numerator can never be wrong.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+
+from app.ai.stop_gates import GateDeny
+from app.browser.wrapper import store_slug
+from app.deliverables.manifest import (
+    derive_manifest,
+    month_before,
+    store_capabilities,
+)
+from app.deliverables.verify import verify_workspace
+from app.models.store import Store
+
+GATE_NAME = 'deliverable_manifest'
+
+
+def _reporting_month(task, today: _dt.date) -> str:
+    """The month a run started on *today* is expected to cover.
+
+    The previous calendar month. Derived from the task's creation date
+    when available so a re-run of an old task still checks the month that
+    task was for, rather than whatever month it is now.
+    """
+    anchor = today
+    created = getattr(task, 'created_at', None)
+    if isinstance(created, str) and len(created) >= 7:
+        try:
+            anchor = _dt.date(int(created[0:4]), int(created[5:7]), 1)
+        except ValueError:
+            anchor = today
+    return month_before(f'{anchor.year:04d}-{anchor.month:02d}')
+
+
+def _looks_like_report_run(task_root: Path) -> bool:
+    """True when the workspace holds any ``reports_*`` folder."""
+    try:
+        return any(
+            p.is_dir() and p.name.startswith('reports_')
+            for p in task_root.iterdir()
+        )
+    except OSError:
+        return False
+
+
+async def check_deliverables(
+    db,
+    task,
+    task_root: Path,
+    *,
+    today: _dt.date | None = None,
+) -> GateDeny | None:
+    """Verify the workspace against the derived manifest.
+
+    Returns ``None`` when everything expected is present with data, or
+    when the only shortfalls are reports upstream has not published yet —
+    a pending fee report is the normal state early in the month and must
+    not read as a failure. Returns a :class:`GateDeny` naming each real
+    gap otherwise; the framework retains the submission and, once the
+    agent has had its one chance to fix, carries the gaps as caveats on a
+    COMPLETED run.
+    """
+    if not getattr(task, 'store_id', None):
+        return None
+    if not _looks_like_report_run(task_root):
+        return None
+
+    store = await db.get(Store, task.store_id)
+    if store is None:
+        return None
+
+    today = today or _dt.date.today()
+    month = _reporting_month(task, today)
+    slug = store_slug(store.name, store.id)
+
+    manifest = derive_manifest(
+        store, slug, month, fee_month=month_before(month)
+    )
+    if not manifest:
+        return None
+
+    report = verify_workspace(
+        task_root,
+        manifest,
+        today=today,
+        capabilities=store_capabilities(store),
+    )
+    if report.ok:
+        return None
+
+    # Pending entries ride along only when there is a real gap to report
+    # beside them, so the agent sees the whole picture in one refusal
+    # instead of chasing a file upstream has not posted.
+    detail = list(report.gaps)
+    if report.pending:
+        detail += [
+            f'(awaiting upstream, not your gap) {p}' for p in report.pending
+        ]
+
+    return GateDeny(
+        gate=GATE_NAME,
+        reason=(
+            f'Deliverable check for {month}: {report.summary()}.\n\n'
+            'The expected file list is derived server-side from this '
+            "store's declared capabilities and the calendar — it is not "
+            'read from what the run produced, so a file you did not '
+            'attempt still counts as missing.\n\n'
+            'A file that downloaded but holds only a header row counts as '
+            'missing data, not as delivered: an unpublished monthly fee '
+            'report arrives exactly that way.\n\n'
+            + '\n'.join(f'- {d}' for d in detail)
+        ),
+        gaps=tuple(detail),
+    )

--- a/app/deliverables/manifest.py
+++ b/app/deliverables/manifest.py
@@ -1,0 +1,314 @@
+"""Derive the expected deliverable set for a store-month.
+
+Server-side and input-only: the store row plus the calendar. The agent
+never authors this, which is the difference between it and the ad-task
+declaration in :mod:`app.ai.ad_declaration` — an ad scope can only be
+known after looking at the account, so the agent declares it; a
+deliverable list is knowable before the run starts, so deriving it keeps
+the denominator out of the agent's hands.
+
+Two ideas carry the whole module.
+
+**Capability, not guesswork.** A store that has no FBA cannot produce a
+storage report, and demanding one failed a real run. Capabilities are
+read from the store row; an *undeclared* capability makes its
+deliverables optional — absent is fine, present is still row-checked.
+That is the same fail-safe direction the ad declaration takes: no
+declaration means nothing over-wide is demanded. Declaring ``fba: true``
+is what turns absence into a gap.
+
+**Accrual versus event.** Zero rows means different things per report.
+Storage accrues against held inventory, so a month with inventory and
+zero storage rows has not been published yet. Removals are discrete
+events, so zero rows can simply be the truth. Encoding that distinction
+here is what lets a checker resolve an ambiguity a reviewer cannot
+resolve by eye — and it is why ``min_rows`` is a per-entry property
+rather than one global rule.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import json
+
+#: Day of M+1 from which a marketplace's monthly fee reports for month M
+#: are reliably downloadable. Requests before this return no data (or an
+#: empty file); the boundary is upstream's monthly billing cycle, not
+#: something this project controls.
+#:
+#: Measured across four consecutive months on a live account: requests on
+#: days 3, 6 and 7 of M+1 all returned no data, and a request on day 29
+#: of M+1 returned the full month. The marketplace's own documentation
+#: puts publication at days 13-14, which is consistent with both ends of
+#: that bracket. Deliberately conservative: a run that requests on day 15
+#: and finds nothing records a gap and completes, so being one day late
+#: costs a caveat, while being early costs a whole month of wrong numbers.
+FEE_PUBLISHED_FROM_DAY = 15
+
+
+class DeliverableKind(enum.StrEnum):
+    """How to read an empty file for this deliverable.
+
+    ``ACCRUAL`` charges accumulate against something held all month, so
+    zero rows for a month that had inventory means "not published yet".
+    ``EVENT`` rows are discrete occurrences, so zero rows is a legal
+    answer and only a *missing* file is a gap. ``LEDGER`` is a
+    transaction record that always has rows if the store traded at all.
+    """
+
+    ACCRUAL = 'accrual'
+    EVENT = 'event'
+    LEDGER = 'ledger'
+
+
+@dataclasses.dataclass(frozen=True)
+class Deliverable:
+    """One expected file.
+
+    ``relpath`` is relative to the task workspace root. ``requires`` is a
+    capability key (``'amazon.fba'``) that must not be declared false;
+    ``None`` means unconditional. ``published_from_day`` is the day of the
+    month *after* ``month`` from which the source is expected to carry
+    data — a gap before that day is upstream latency, not a mistake.
+    """
+
+    relpath: str
+    month: str
+    kind: DeliverableKind
+    requires: str | None = None
+    min_rows: int = 1
+    published_from_day: int | None = None
+
+    @property
+    def optional(self) -> bool:
+        """True when absence is acceptable rather than a gap.
+
+        An EVENT file may legitimately have no rows, but it must still be
+        present — a missing file and an empty one are different claims,
+        and only the empty one is evidence that the question was asked.
+        """
+        return False
+
+
+def month_before(month: str) -> str:
+    """``'2026-08'`` → ``'2026-07'``. Crosses the year boundary."""
+    year, mon = (int(p) for p in month.split('-'))
+    if mon == 1:
+        return f'{year - 1:04d}-12'
+    return f'{year:04d}-{mon - 1:02d}'
+
+
+def _mon_abbr(month: str) -> str:
+    """``'2026-07'`` → ``'Jul'`` (the marketplace's filename token)."""
+    names = (
+        'Jan',
+        'Feb',
+        'Mar',
+        'Apr',
+        'May',
+        'Jun',
+        'Jul',
+        'Aug',
+        'Sep',
+        'Oct',
+        'Nov',
+        'Dec',
+    )
+    return names[int(month.split('-')[1]) - 1]
+
+
+def _json_field(raw, default):
+    """Parse a JSON text column, falling back to *default*."""
+    if not raw:
+        return default
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return default
+    return parsed if isinstance(parsed, type(default)) else default
+
+
+def store_capabilities(store) -> dict[str, bool]:
+    """Declared capabilities for *store*, flattened to dotted keys.
+
+    ``{'amazon': {'fba': true, 'ads': false}}`` becomes
+    ``{'amazon.fba': True, 'amazon.ads': False}``. A key that is absent
+    is *undeclared*, which is not the same as false: undeclared makes the
+    dependent deliverables optional, declared-false removes them
+    entirely. Only an explicit ``true`` makes absence a gap.
+    """
+    raw = _json_field(getattr(store, 'capabilities', None), {})
+    flat: dict[str, bool] = {}
+    for platform, caps in raw.items():
+        if not isinstance(caps, dict):
+            continue
+        for cap, value in caps.items():
+            if isinstance(value, bool):
+                flat[f'{platform}.{cap}'] = value
+    return flat
+
+
+def _platform_countries(store) -> dict[str, list[str]]:
+    """``{'amazon': ['SA', 'AE'], 'noon': ['SA']}``, lowercased codes."""
+    raw = _json_field(getattr(store, 'platform_countries', None), {})
+    out: dict[str, list[str]] = {}
+    for platform, countries in raw.items():
+        if isinstance(countries, list):
+            out[str(platform).lower()] = [
+                str(c).lower() for c in countries if str(c).strip()
+            ]
+    return out
+
+
+def derive_manifest(
+    store,
+    slug: str,
+    month: str,
+    *,
+    fee_month: str | None = None,
+) -> list[Deliverable]:
+    """Expected files for *store* covering *month*.
+
+    *month* is the reporting month (``'2026-07'``) — everything that
+    publishes promptly. *fee_month* is the older month whose fee reports
+    have become available in the meantime; pass it to include the
+    backfill entries a monthly run also owes. Passing ``fee_month ==
+    month`` is legal and simply means "expect this month's fees too".
+
+    Returns entries in a stable order so a diff between two runs reads
+    cleanly.
+    """
+    caps = store_capabilities(store)
+    per_platform = _platform_countries(store)
+    out: list[Deliverable] = []
+
+    def allowed(capability: str) -> bool:
+        """False only when the capability is declared absent."""
+        return caps.get(capability, True)
+
+    mm = month.split('-')[1]
+    mon = _mon_abbr(month)
+
+    for country in per_platform.get('amazon', []):
+        folder = f'reports_{mm}_{country}_{slug}'
+        out.append(
+            Deliverable(
+                relpath=f'{folder}/{month.split("-")[0]}{mon}'
+                'MonthlyTransaction.csv',
+                month=month,
+                kind=DeliverableKind.LEDGER,
+            )
+        )
+        if allowed('amazon.ads'):
+            out.append(
+                Deliverable(
+                    relpath=f'{folder}/'
+                    f'Sponsored_Products_Advertised_product_report_{mon}.csv',
+                    month=month,
+                    kind=DeliverableKind.EVENT,
+                    requires='amazon.ads',
+                    min_rows=0,
+                )
+            )
+        if allowed('amazon.fba'):
+            out.append(
+                Deliverable(
+                    relpath=f'{folder}/return.csv',
+                    month=month,
+                    kind=DeliverableKind.EVENT,
+                    requires='amazon.fba',
+                    min_rows=0,
+                )
+            )
+
+    for country in per_platform.get('noon', []):
+        folder = f'reports_noon_{mm}_{slug}'
+        out.append(
+            Deliverable(
+                relpath=f'{folder}/noon_financeweb_transactionviewreport.csv',
+                month=month,
+                kind=DeliverableKind.LEDGER,
+            )
+        )
+        if allowed('noon.ads'):
+            out.append(
+                Deliverable(
+                    relpath=f'{folder}/ads_overview_{country}_{month}.xlsx',
+                    month=month,
+                    kind=DeliverableKind.EVENT,
+                    requires='noon.ads',
+                    min_rows=0,
+                )
+            )
+
+    if fee_month:
+        out.extend(_fee_deliverables(slug, fee_month, per_platform, allowed))
+
+    # Stable, and de-duplicated: the noon transaction view is one file for
+    # every country, so a two-country store derives it twice above.
+    seen: set[str] = set()
+    unique: list[Deliverable] = []
+    for entry in sorted(out, key=lambda d: (d.month, d.relpath)):
+        if entry.relpath in seen:
+            continue
+        seen.add(entry.relpath)
+        unique.append(entry)
+    return unique
+
+
+def _fee_deliverables(
+    slug: str,
+    fee_month: str,
+    per_platform: dict[str, list[str]],
+    allowed,
+) -> list[Deliverable]:
+    """The late-publishing fee reports for *fee_month*.
+
+    These are the entries whose absence early in M+1 is expected. They
+    carry ``published_from_day`` so a checker can tell "upstream has not
+    posted this yet" from "somebody skipped it", which is the whole
+    reason the two months are separate arguments.
+    """
+    out: list[Deliverable] = []
+    mm = fee_month.split('-')[1]
+
+    if allowed('amazon.fba'):
+        for country in per_platform.get('amazon', []):
+            out.append(
+                Deliverable(
+                    relpath=f'reports_{mm}_{country}_{slug}/storage.csv',
+                    month=fee_month,
+                    kind=DeliverableKind.ACCRUAL,
+                    requires='amazon.fba',
+                    published_from_day=FEE_PUBLISHED_FROM_DAY,
+                )
+            )
+
+    if allowed('noon.fbn'):
+        folder = f'reports_noon_{mm}_{slug}'
+        # Storage accrues against held stock; removals are events. Same
+        # page, same generator, different reading of an empty file.
+        accrual = ('monthly_storage', 'longterm_storage', 'nonsaleable_storage')
+        for country in per_platform.get('noon', []):
+            for stem in accrual:
+                out.append(
+                    Deliverable(
+                        relpath=f'{folder}/{stem}_{country}_{fee_month}.csv',
+                        month=fee_month,
+                        kind=DeliverableKind.ACCRUAL,
+                        requires='noon.fbn',
+                        published_from_day=FEE_PUBLISHED_FROM_DAY,
+                    )
+                )
+            out.append(
+                Deliverable(
+                    relpath=f'{folder}/rtv_removal_{country}_{fee_month}.csv',
+                    month=fee_month,
+                    kind=DeliverableKind.EVENT,
+                    requires='noon.fbn',
+                    min_rows=0,
+                    published_from_day=FEE_PUBLISHED_FROM_DAY,
+                )
+            )
+    return out

--- a/app/deliverables/verify.py
+++ b/app/deliverables/verify.py
@@ -35,7 +35,7 @@ from pathlib import Path
 import re
 import zipfile
 
-from app.deliverables.manifest import Deliverable, DeliverableKind
+from app.deliverables.manifest import Deliverable
 
 
 class DeliverableStatus(enum.StrEnum):
@@ -53,6 +53,12 @@ class DeliverableStatus(enum.StrEnum):
 #: An XLSX sheet row is ``<row .../>``; counting them beats parsing the
 #: whole workbook and needs no third-party dependency at import time.
 _XLSX_ROW = re.compile(rb'<row[ >]')
+
+#: Bytes held back between reads so a ``<row`` split across a boundary is
+#: still matched. One less than the pattern's fixed width: enough to
+#: complete a straddling match, too few to contain a whole one (which
+#: would then be counted twice).
+_XLSX_ROW_CARRY = 4
 
 
 def _csv_rows(path: Path) -> int:
@@ -76,6 +82,11 @@ def _xlsx_rows(path: Path) -> int:
     A monthly export puts its real content on one sheet among several, so
     the maximum is the meaningful figure; summing would let a workbook of
     empty sheets with headers look populated.
+
+    Streamed with a carry-over so a tag straddling a read boundary is not
+    lost. Undercounting here is not a harmless approximation: it would
+    report a populated export as empty and manufacture a gap against a
+    file that is perfectly fine.
     """
     best = 0
     try:
@@ -88,8 +99,15 @@ def _xlsx_rows(path: Path) -> int:
             for name in sheets:
                 with zf.open(name) as fh:
                     rows = 0
+                    carry = b''
                     for chunk in iter(lambda: fh.read(65536), b''):
-                        rows += len(_XLSX_ROW.findall(chunk))
+                        buf = carry + chunk
+                        rows += len(_XLSX_ROW.findall(buf))
+                        # Retain strictly fewer bytes than the pattern's
+                        # length, so the tail can complete a match that
+                        # spans the boundary but can never hold a whole
+                        # match itself — which would double-count.
+                        carry = buf[-_XLSX_ROW_CARRY:]
                     best = max(best, max(rows - 1, 0))
     except (zipfile.BadZipFile, OSError, KeyError):
         return 0
@@ -151,6 +169,20 @@ class VerifyReport:
             1 for s in self.statuses.values() if s is DeliverableStatus.OK
         )
 
+    @property
+    def expected(self) -> int:
+        """Entries this store actually owes.
+
+        Excludes SKIPPED — a deliverable whose capability was never
+        declared is not owed, so counting it would understate a run that
+        did everything asked of it.
+        """
+        return sum(
+            1
+            for s in self.statuses.values()
+            if s is not DeliverableStatus.SKIPPED
+        )
+
     def summary(self) -> str:
         """One line the agent and the reader both understand.
 
@@ -159,7 +191,7 @@ class VerifyReport:
         about a set of 19.
         """
         return (
-            f'{self.delivered}/{len(self.statuses)} expected files present '
+            f'{self.delivered}/{self.expected} expected files present '
             f'with data; {len(self.gaps)} gap(s), '
             f'{len(self.pending)} awaiting upstream publication'
         )
@@ -195,15 +227,20 @@ def verify_workspace(
         declared = entry.requires is None or caps.get(entry.requires) is True
 
         if not path.exists():
-            if not due:
+            # Capability first, latency second. An undeclared capability
+            # means we never established that this store can produce the
+            # file at all, so it is not owed — reporting it as "awaiting
+            # upstream" would be a claim about a report that may not
+            # exist for this store, and it would pad the denominator.
+            if not declared:
+                statuses[entry.relpath] = DeliverableStatus.SKIPPED
+            elif not due:
                 statuses[entry.relpath] = DeliverableStatus.PENDING
                 pending.append(
                     f'{entry.relpath} — {entry.month} not yet published '
                     f'upstream (expected from day {entry.published_from_day} '
                     'of the following month)'
                 )
-            elif not declared:
-                statuses[entry.relpath] = DeliverableStatus.SKIPPED
             else:
                 statuses[entry.relpath] = DeliverableStatus.MISSING
                 gaps.append(f'{entry.relpath} — missing')
@@ -212,17 +249,18 @@ def verify_workspace(
         count = data_rows(path)
         rows[entry.relpath] = count
 
-        if count >= max(entry.min_rows, 1):
+        # ``min_rows`` alone decides sufficiency. An EVENT deliverable
+        # declares ``min_rows=0`` because zero occurrences is a legal
+        # answer, so this one comparison covers it — special-casing the
+        # kind here instead would silently ignore a raised threshold on a
+        # future EVENT entry that genuinely must carry rows.
+        if count >= entry.min_rows:
             statuses[entry.relpath] = DeliverableStatus.OK
             continue
 
-        # Present but carrying no data. What that means is a property of
-        # the deliverable, not of the file — which is the distinction a
-        # size check cannot make and a reviewer cannot make by eye.
-        if entry.kind is DeliverableKind.EVENT:
-            statuses[entry.relpath] = DeliverableStatus.OK
-            continue
-
+        # Short of what it owes. Whether that is "upstream has not posted
+        # the month" or "this is wrong" is the distinction a size check
+        # cannot make and a reviewer cannot make by eye.
         if not due:
             statuses[entry.relpath] = DeliverableStatus.PENDING
             pending.append(
@@ -231,9 +269,14 @@ def verify_workspace(
             )
         else:
             statuses[entry.relpath] = DeliverableStatus.EMPTY
+            shortfall = (
+                'has 0 data rows (header only)'
+                if count == 0
+                else f'has {count} data row(s), short of {entry.min_rows}'
+            )
             gaps.append(
-                f'{entry.relpath} — present but has 0 data rows '
-                f'(header only); {entry.month} should have published by now'
+                f'{entry.relpath} — present but {shortfall}; '
+                f'{entry.month} should have published by now'
             )
 
     return VerifyReport(

--- a/app/deliverables/verify.py
+++ b/app/deliverables/verify.py
@@ -1,0 +1,244 @@
+"""Check a task workspace against its manifest, by rows not bytes.
+
+The bug this exists for: an unpublished monthly fee report downloads as a
+valid CSV carrying its header and no data. Upstream calls it
+``Complete``, the download succeeds, and it is 306 bytes — so a
+``size > 0`` assertion passes it, which is exactly what a real run's
+definition-of-done check did before shipping one.
+
+So the only question worth asking is how many data rows a file has, and
+:func:`data_rows` answers it for both CSV and XLSX without loading either
+fully into memory.
+
+The verdict deliberately separates two kinds of shortfall:
+
+``gaps``
+    Somebody should have produced this and did not. Real work is
+    missing.
+``pending``
+    Upstream has not published it yet — the entry declares a
+    ``published_from_day`` and today is before it. Nobody erred, and the
+    run should complete while saying so.
+
+Both travel to the agent as gate text, but only ``gaps`` mean the run
+under-delivered. That split is what keeps a day-3 storage absence from
+reading like a failure while a day-20 absence still does.
+"""
+
+from __future__ import annotations
+
+import csv
+import dataclasses
+import datetime as _dt
+import enum
+from pathlib import Path
+import re
+import zipfile
+
+from app.deliverables.manifest import Deliverable, DeliverableKind
+
+
+class DeliverableStatus(enum.StrEnum):
+    """Outcome for a single manifest entry."""
+
+    OK = 'ok'
+    MISSING = 'missing'
+    EMPTY = 'empty'
+    #: Absent or empty, but the source is not published yet.
+    PENDING = 'pending'
+    #: Absent, and the capability that would require it is undeclared.
+    SKIPPED = 'skipped'
+
+
+#: An XLSX sheet row is ``<row .../>``; counting them beats parsing the
+#: whole workbook and needs no third-party dependency at import time.
+_XLSX_ROW = re.compile(rb'<row[ >]')
+
+
+def _csv_rows(path: Path) -> int:
+    """Data rows in a CSV — total lines minus the header.
+
+    Uses the csv module rather than counting newlines because a quoted
+    field may legally contain one, and a product title with a newline in
+    it would otherwise inflate an empty file into a populated one.
+    """
+    with path.open('r', encoding='utf-8-sig', newline='') as fh:
+        reader = csv.reader(fh)
+        count = -1  # header
+        for _ in reader:
+            count += 1
+    return max(count, 0)
+
+
+def _xlsx_rows(path: Path) -> int:
+    """Largest data-row count across the workbook's sheets.
+
+    A monthly export puts its real content on one sheet among several, so
+    the maximum is the meaningful figure; summing would let a workbook of
+    empty sheets with headers look populated.
+    """
+    best = 0
+    try:
+        with zipfile.ZipFile(path) as zf:
+            sheets = [
+                n
+                for n in zf.namelist()
+                if n.startswith('xl/worksheets/') and n.endswith('.xml')
+            ]
+            for name in sheets:
+                with zf.open(name) as fh:
+                    rows = 0
+                    for chunk in iter(lambda: fh.read(65536), b''):
+                        rows += len(_XLSX_ROW.findall(chunk))
+                    best = max(best, max(rows - 1, 0))
+    except (zipfile.BadZipFile, OSError, KeyError):
+        return 0
+    return best
+
+
+def data_rows(path: Path) -> int:
+    """Data rows in *path*, or 0 when unreadable.
+
+    Unreadable counts as zero on purpose: a file we cannot parse is not
+    evidence that the question was answered.
+    """
+    try:
+        if path.suffix.lower() in ('.xlsx', '.xlsm'):
+            return _xlsx_rows(path)
+        return _csv_rows(path)
+    except (OSError, UnicodeDecodeError, csv.Error):
+        return 0
+
+
+def _publication_due(entry: Deliverable, today: _dt.date) -> bool:
+    """Has *entry*'s source had time to publish by *today*?
+
+    True when the entry declares no latency at all, or when today is on
+    or after ``published_from_day`` of the month following its reporting
+    month. The comparison is on real dates rather than day-of-month alone
+    so a two-month-old report is never excused by an early calendar day —
+    the bug in the prose rule this replaces was exactly that it keyed off
+    the day number and forgot which month was being asked for.
+    """
+    if entry.published_from_day is None:
+        return True
+    year, mon = (int(p) for p in entry.month.split('-'))
+    due_year, due_mon = (year + 1, 1) if mon == 12 else (year, mon + 1)
+    try:
+        due = _dt.date(due_year, due_mon, entry.published_from_day)
+    except ValueError:  # pragma: no cover — day clamped into range
+        due = _dt.date(due_year, due_mon, 28)
+    return today >= due
+
+
+@dataclasses.dataclass(frozen=True)
+class VerifyReport:
+    """What the workspace holds against what it owed."""
+
+    statuses: dict[str, DeliverableStatus]
+    rows: dict[str, int]
+    gaps: tuple[str, ...]
+    pending: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        """True when nothing is missing beyond upstream latency."""
+        return not self.gaps
+
+    @property
+    def delivered(self) -> int:
+        return sum(
+            1 for s in self.statuses.values() if s is DeliverableStatus.OK
+        )
+
+    def summary(self) -> str:
+        """One line the agent and the reader both understand.
+
+        Reports the derived denominator rather than a self-declared one —
+        the reason this module exists is that a run once said "9 of 9"
+        about a set of 19.
+        """
+        return (
+            f'{self.delivered}/{len(self.statuses)} expected files present '
+            f'with data; {len(self.gaps)} gap(s), '
+            f'{len(self.pending)} awaiting upstream publication'
+        )
+
+
+def verify_workspace(
+    workspace: Path,
+    manifest: list[Deliverable],
+    *,
+    today: _dt.date | None = None,
+    capabilities: dict[str, bool] | None = None,
+) -> VerifyReport:
+    """Compare *workspace* against *manifest*.
+
+    *capabilities* distinguishes "declared true" from "undeclared". Only a
+    declared-true capability turns an absent file into a gap; undeclared
+    leaves it optional, so a store whose FBA status nobody has recorded is
+    not failed for a report it may not be able to produce. That is the
+    fail-safe direction: an unasserted capability under-demands rather
+    than inventing an obligation.
+    """
+    today = today or _dt.date.today()
+    caps = capabilities or {}
+
+    statuses: dict[str, DeliverableStatus] = {}
+    rows: dict[str, int] = {}
+    gaps: list[str] = []
+    pending: list[str] = []
+
+    for entry in manifest:
+        path = workspace / entry.relpath
+        due = _publication_due(entry, today)
+        declared = entry.requires is None or caps.get(entry.requires) is True
+
+        if not path.exists():
+            if not due:
+                statuses[entry.relpath] = DeliverableStatus.PENDING
+                pending.append(
+                    f'{entry.relpath} — {entry.month} not yet published '
+                    f'upstream (expected from day {entry.published_from_day} '
+                    'of the following month)'
+                )
+            elif not declared:
+                statuses[entry.relpath] = DeliverableStatus.SKIPPED
+            else:
+                statuses[entry.relpath] = DeliverableStatus.MISSING
+                gaps.append(f'{entry.relpath} — missing')
+            continue
+
+        count = data_rows(path)
+        rows[entry.relpath] = count
+
+        if count >= max(entry.min_rows, 1):
+            statuses[entry.relpath] = DeliverableStatus.OK
+            continue
+
+        # Present but carrying no data. What that means is a property of
+        # the deliverable, not of the file — which is the distinction a
+        # size check cannot make and a reviewer cannot make by eye.
+        if entry.kind is DeliverableKind.EVENT:
+            statuses[entry.relpath] = DeliverableStatus.OK
+            continue
+
+        if not due:
+            statuses[entry.relpath] = DeliverableStatus.PENDING
+            pending.append(
+                f'{entry.relpath} — downloaded but empty; {entry.month} '
+                'not yet published upstream'
+            )
+        else:
+            statuses[entry.relpath] = DeliverableStatus.EMPTY
+            gaps.append(
+                f'{entry.relpath} — present but has 0 data rows '
+                f'(header only); {entry.month} should have published by now'
+            )
+
+    return VerifyReport(
+        statuses=statuses,
+        rows=rows,
+        gaps=tuple(gaps),
+        pending=tuple(pending),
+    )

--- a/app/knowledge/common/noon-sites.md
+++ b/app/knowledge/common/noon-sites.md
@@ -74,7 +74,7 @@ https://fbn.noon.partners/en-{cc}/{page}?project=PRJ{project_id}
 | My Inventory | `/inventory` |
 | My Returns | `/returns` |
 | FBN Fees | `/fees` |
-| Reports | `/reports` |
+| Reports | `/fbnreports` |
 
 ### Sales & Reports
 
@@ -277,7 +277,7 @@ noon.com Seller Center
 │   ├── My Inventory         /inventory
 │   ├── My Returns           /returns
 │   ├── FBN Fees             /fees
-│   └── Reports              /reports
+│   └── Reports              /fbnreports
 ├── Sales & Reports          reports.noon.partners/en/sales/
 ├── Payments & Fees          noon-payments.noon.partners/en/
 │   ├── Statements           /statements

--- a/app/models/store.py
+++ b/app/models/store.py
@@ -31,6 +31,17 @@ class Store(Base):
     platform_countries: Mapped[str] = mapped_column(
         Text, nullable=False, default='{}'
     )
+    # Per-platform capability flags, e.g.
+    # ``{"amazon": {"fba": true, "ads": false}, "noon": {"fbn": true}}``.
+    # Distinct from ``platform_countries``, which says *where* a store
+    # sells, not *what* it can produce: a store may sell on a marketplace
+    # while having no FBA business and no ads account, and demanding those
+    # reports of it failed a real scheduled run. Read via
+    # ``app.deliverables.manifest.store_capabilities``, where an absent key
+    # means "undeclared" (deliverables optional) rather than false.
+    capabilities: Mapped[str] = mapped_column(
+        Text, nullable=False, default='{}'
+    )
     config: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[str] = mapped_column(
         String, default=lambda: datetime.now(UTC).isoformat()

--- a/app/routers/task_submission.py
+++ b/app/routers/task_submission.py
@@ -27,6 +27,8 @@ from app.ai.stop_gates import (
     report_reviewer,
     result_language as language_gate,
 )
+from app.config import VIBE_SELLER_DIR
+from app.deliverables.gate import check_deliverables
 from app.models.task import Task
 from app.routers.tasks_files import (
     looks_like_result_path,
@@ -186,13 +188,24 @@ async def apply_soft_gates(
     trap the agent in a loop it has no way to exit. Run here rather than
     from the Stop hook because some agent backends never emit Stop.
     """
+    # Deliverable check first: "you are missing three files" is more
+    # actionable than "your table is malformed", and a run that has to
+    # go back for a file will rewrite the prose anyway.
+    denials = []
+    deliverable_deny = await check_deliverables(
+        db, task, (VIBE_SELLER_DIR / 'tasks' / task_id).resolve()
+    )
+    if deliverable_deny:
+        denials.append(deliverable_deny)
     for gate_module, gate_args in (
         (md_format_gate, (final_result,)),
         (language_gate, (final_result, task.title, task.description)),
     ):
         deny = gate_module.check(*gate_args)
-        if not deny:
-            continue
+        if deny:
+            denials.append(deny)
+
+    for deny in denials:
         attempt = record_attempt(task_id, deny.gate)
         if attempt <= SOFT_GATE_MAX_DENIALS:
             await refuse(db, task, deny.reason, declared + deny.gaps)

--- a/app/skills_v2/MANIFEST.txt
+++ b/app/skills_v2/MANIFEST.txt
@@ -44,6 +44,7 @@ noon-shared/references/dod-review-loop.md
 noon-listing/SKILL.md
 noon-fbn/SKILL.md
 noon-fbn/references/fee-reports.md
+noon-fbn/scripts/check_fee_rows.py
 noon-exports/SKILL.md
 noon-ads/SKILL.md
 noon-ads/references/ads-creation.md

--- a/app/skills_v2/amazon-reports/SKILL.md
+++ b/app/skills_v2/amazon-reports/SKILL.md
@@ -373,12 +373,33 @@ with short sleeps (never one `time.sleep(120)` — see the polling loop in
 **Observed behavior:** requesting Monthly Storage Fees for the previous
 month early in the new month returns `No Data Available` on the
 detail page even though the request itself is accepted. The same
-month's range re-requested about a week later returns a Download
+month's range re-requested weeks later returns a Download
 button within ~30s. Older months (M-2, M-3) request successfully
 right away.
 
-So Storage Fees for month M is **not** available on day 7 of M+1
-but **is** available by day 13-14 of M+1. The exact day Amazon
+**The whole first third of M+1 fails, not just day 7.** Measured on one
+account across four consecutive months — every request made in M+1
+returned no data, every request made later returned the month:
+
+| Requested on | Day of M+1 | Result |
+|---|---|---|
+| day 3 | 3 | `No Data Available` |
+| day 6 | 6 | `No Data Available` |
+| day 7 | 7 | `No Data Available` (twice, different months) |
+| day 29 | 29 | Download, both marketplaces |
+
+Treat **day 15 of M+1** as the earliest a request is worth making.
+Nothing is gained by requesting sooner: repeat requests do not make
+Amazon publish, and a same-day retry returns the same nothing.
+
+**Do not read the older successes as "M+2 is required".** They look that
+way in a request history only because a monthly schedule fires early and
+nobody re-requests mid-month, so there is no observation between day 8
+and day 28. The day-29 success above is the counter-example: mid-to-late
+M+1 is enough.
+
+So Storage Fees for month M is **not** available anywhere in the first
+~12 days of M+1 but **is** available by day 13-15 of M+1. The exact day Amazon
 publishes is not documented on the page; the page header for this
 report says only "Report data 24 hours old" (about freshness of
 already-published values, not about when they appear).
@@ -390,44 +411,40 @@ the requested month is the previous calendar month:**
    the data sooner because of repeat requests.
 2. Produce every other expected file (Transaction CSV, FBA
    Customer Returns CSV, Sponsored Products advertised-product
-   XLSX) — those publish on a different cadence and ARE available
+   report) — those publish on a different cadence and ARE available
    today.
-3. A scheduled re-run after roughly day 13-14 of the following
-   month will capture the storage CSV.
+3. Report it as pending in your result and move on. The next month's
+   scheduled run picks the file up as its M+2 backfill pass.
 
-**Task-status decision for this scenario — MANDATORY exception
-to the system-prompt's "MUST call vibe_seller_set_task_error when
-primary objective could not be fully completed" rule:**
+**You do not decide the task's status for this, and you should not try.**
+There used to be a hand-written exception here telling the agent when a
+missing `storage.csv` was allowed to still count as success. It named a
+day window (`days 7-14 of M+1`), which was wrong at both ends, and it
+depended on the agent classifying its own shortfall correctly. Two live
+runs diagnosed the latency in their own words and still landed FAILED.
 
-If the ONLY missing deliverable is `storage.csv` (any country)
-and the cause is this Amazon publication-latency window
-(today is in month M+1, Amazon's detail page says
-`No Data Available`), then:
+That verdict now lives in code. `app/deliverables/` derives the expected
+file set from the store's capabilities and the calendar, counts **rows**
+in every file it finds, and separates two things the agent cannot be
+asked to separate reliably:
 
-- Call `vibe_seller_set_task_result(<full report including a
-  "Storage CSV pending Amazon publication" note>)` with the
-  partial summary.
-- **DO NOT call `vibe_seller_set_task_error`.** The task lands
-  COMPLETED — the next scheduled run picks up storage when
-  Amazon publishes it. Calling `set_task_error` here causes the
-  task to land FAILED for what is a known, expected,
-  upstream-paced data state, and that triggers false "task
-  failed" alerts downstream.
+- **pending** — the month is not published yet, so absence (or a
+  header-only file) is expected. The run completes, with the file listed
+  as awaiting upstream.
+- **gap** — the month should have published by now, or the file was
+  simply never attempted. The run completes with the gap recorded as a
+  caveat, and the gap is visible rather than absorbed into prose.
 
-This is a NARROW exception. It applies only when:
-(a) every other deliverable for the task ran successfully, AND
-(b) the only gap is `storage.csv`, AND
-(c) the agent saw `No Data Available` on the report-history
-    detail page for that exact month.
+So: just report honestly what you got and what you did not. Do not
+suppress a missing file to look complete, and do not call
+`vibe_seller_set_task_error` to flag one — an agent-reported error on a
+run that produced a real report is carried as a caveat now
+(`app/task_outcome.py`), not as a failure.
 
-If ANY other deliverable also failed, fall back to the normal
-"call BOTH set_task_result and set_task_error" pattern from the
-system prompt — the storage-latency exception does not absorb
-unrelated failures.
-
-If `No Data Available` shows for an **older** month (≥ ~30 days
-old), that's unexpected — investigate normally; do not wave away,
-and do call `set_task_error`.
+**A header-only file is not a delivered file.** An unpublished monthly
+fee report downloads as a valid CSV with its header and zero data rows.
+It is a few hundred bytes, so "the file exists and is non-empty" is not
+evidence of anything. Count rows before you claim a file.
 
 ### FBA Customer Returns — Exact dates flow (MANDATORY for month ranges)
 
@@ -454,14 +471,99 @@ preset dropdown, click "Exact dates", then set start/end from the
 calendar popups. Do **not** try `selectOption('-1')` or any programmatic
 date-set: live-verified that they leave the request on today's date.
 
+#### The calendar lives THREE shadow roots down — use this walk
+
+This is the single most expensive control on the page. A live run lost a
+whole marketplace's `return.csv` here, reporting that the widget
+"repeatedly produced same-day reports"; the same wall is reproducible
+today. The reason is that the calendar cells are not in the light DOM
+and not one shadow root down: the host is
+`kat-date-range-picker` → `.shadowRoot` → `kat-date-picker.start` (or
+`.end`) → `.shadowRoot` → `kat-calendar` → `.shadowRoot`. A coordinate
+click aimed at the calendar icon by eye, or a `querySelector` from
+`document`, finds nothing and fails **silently** — the field simply keeps
+today's date and the report you get is one day long.
+
+Both pickers' popovers render at the **same screen position**, so the
+navigation chevrons for the *end* picker are where the *start* picker's
+were. Re-read coordinates after every click; never reuse them.
+
 ```bash
 browser-use <<'PY'
-new_tab("https://sellercentral.amazon.{tld}/reportcentral/CUSTOMER_RETURNS/1")
-wait_for_load()
-import time; time.sleep(3)
-capture_screenshot()   # locate the preset dropdown + (after Exact dates) the calendar icons
+def cal(which):                     # which: 'start' or 'end'
+    """(header, day-cells) for one picker, through all three roots."""
+    return js("""
+      var rp  = document.querySelector('kat-date-range-picker');
+      var dp  = rp.shadowRoot.querySelector('kat-date-picker.%s');
+      var sr  = dp.shadowRoot;
+      var cal = sr.querySelector('kat-calendar');
+      var root = cal && (cal.shadowRoot || cal);
+      if (!root) return null;
+      var hdr = root.querySelector('[class*=header],[class*=title]');
+      var cells = [].slice.call(root.querySelectorAll('td,[role=gridcell]'))
+        .map(function(e){ var r = e.getBoundingClientRect();
+          return {t:(e.innerText||'').trim(),
+                  x:Math.round(r.x+r.width/2),
+                  y:Math.round(r.y+r.height/2)}; })
+        .filter(function(e){ return e.t && e.x > 0; });
+      return {hdr: hdr ? hdr.innerText.trim() : '', cells: cells};
+    """ % which)
+
+def icon(which):                    # the calendar icon that OPENS it
+    return js("""
+      var rp = document.querySelector('kat-date-range-picker');
+      var dp = rp.shadowRoot.querySelector('kat-date-picker.%s');
+      var ic = dp.shadowRoot.querySelector('kat-icon[name=calendar-alt]');
+      var r  = ic.getBoundingClientRect();
+      return {x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)};
+    """ % which)
+
+def prev(which):                    # the "previous month" chevron
+    return js("""
+      var rp = document.querySelector('kat-date-range-picker');
+      var c  = rp.shadowRoot.querySelector('kat-date-picker.%s')
+                 .shadowRoot.querySelector('kat-calendar');
+      var root = c.shadowRoot || c;
+      var ch = root.querySelector('kat-icon[name=chevron-left]');
+      var r  = ch.getBoundingClientRect();
+      return {x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)};
+    """ % which)
+
+def pick(which, target_hdr, day):
+    """Open *which*, page back to target_hdr, click *day*."""
+    import time
+    p = icon(which); click_at_xy(p['x'], p['y']); time.sleep(2)
+    for _ in range(18):                        # bounded; never while(True)
+        c = cal(which)
+        if c and c['hdr'] == target_hdr:
+            break
+        p = prev(which); click_at_xy(p['x'], p['y']); time.sleep(1.5)
+    else:
+        raise RuntimeError('never reached ' + target_hdr)
+    hit = [e for e in cal(which)['cells'] if e['t'] == str(day)]
+    if not hit:
+        raise RuntimeError('no cell %s in %s' % (day, target_hdr))
+    click_at_xy(hit[0]['x'], hit[0]['y']); time.sleep(1.5)
+
+def committed():
+    return js("""
+      var rp = document.querySelector('kat-date-range-picker');
+      return {s: rp.shadowRoot.querySelector('kat-date-picker.start')
+                    .getAttribute('value'),
+              e: rp.shadowRoot.querySelector('kat-date-picker.end')
+                    .getAttribute('value')};
+    """)
+
+pick('start', 'July 2026', 1)
+pick('end',   'July 2026', 31)
+print(committed())   # MUST show both dates; if not, the click missed
 PY
 ```
+
+**Assert `committed()` before requesting.** That readback is the whole
+point: a missed click is invisible otherwise, and the resulting one-day
+report looks like a normal file. A future month's day cells are disabled,
+so a click on them silently no-ops too.
 
 Finally request and download — the "Request .csv" control is a
 `kat-button`, so use the host→inner-button walk from "Clicking a

--- a/app/skills_v2/noon-fbn/SKILL.md
+++ b/app/skills_v2/noon-fbn/SKILL.md
@@ -15,8 +15,16 @@ review:
       Removal) exist for EVERY requested country x service month, each
       as its own file whose name states the country and month. A report
       that was missing on the page and never generated is a gap, not
-      "not applicable" — the only acceptable empty report is one that
-      downloads with a header row and genuinely zero data rows.
+      "not applicable".
+    - Empty reports were CLASSIFIED, not waved through. Run
+      scripts/check_fee_rows.py over the output folder. A header-only
+      rtv_removal file is fine (removals are events; a month can have
+      none). A header-only monthly/longterm/nonsaleable storage file is
+      NOT fine — storage accrues against held stock, so zero rows means
+      the service month is not published yet. Report those as pending
+      for the month they belong to; never present one as a delivered
+      figure, and never retry them (a second generation returns a
+      byte-identical empty file).
     - Every non-empty storage report was OPENED and its own
       `country_code` / `service_month` columns match the country and
       month in its filename. The filename is a manual rename applied

--- a/app/skills_v2/noon-fbn/references/fee-reports.md
+++ b/app/skills_v2/noon-fbn/references/fee-reports.md
@@ -227,7 +227,7 @@ import pandas as pd, sys  # python if bare python3 lacks it
 path, want_cc, want_sm = sys.argv[1], sys.argv[2], sys.argv[3]
 df = pd.read_csv(path)
 if len(df) == 0:
-    print(f'{path}: header only — legitimately empty, or a failed download')
+    print(f'{path}: header only — see "An empty file is two different facts"')
 else:
     cc = set(df['country_code'].astype(str).str.lower())
     sm = set(df['service_month'].astype(str))
@@ -236,6 +236,36 @@ else:
     print(f'{path}: OK {cc} {sm} {len(df)} rows')
 PY
 ```
+
+### An empty file is two different facts — resolve which
+
+A header-only download is **not** self-explanatory, and guessing has
+already cost real money-accuracy. Run the checker rather than eyeballing:
+
+```bash
+python "$SKILL_DIR/scripts/check_fee_rows.py" <out-dir> --service-month 2026-07
+# exit 1 ⇒ at least one storage report is empty and should not be trusted
+```
+
+It splits the two cases by what the report measures:
+
+| Report | Zero rows means |
+|---|---|
+| `monthly_storage`, `longterm_storage`, `nonsaleable_storage` | **Not published yet.** Storage accrues against stock held all month; if the store held inventory there is a charge. Treat as pending. |
+| `rtv_removal` | **Genuinely zero** — removals are discrete events and a month can have none. Keep the file; it is proof the question was asked. |
+
+Two things that make this trap so quiet:
+
+- The service month is selectable in the picker and the report still
+  reaches `Complete` for a month with no data. Selectable ≠ published.
+- **Retrying does not help.** A second, independent generation of the
+  same unpublished month returns a byte-identical empty file. Verified.
+  Report it as pending; do not burn the run on retries.
+
+Measured for one project on the 3rd of the following month: that
+month's storage report came back with 0 rows while the month before it —
+generated the same day — came back populated. So the emptiness is about
+the *service month*, never about the generator.
 
 RTV Removal has neither column — bucket it by `currency_code` instead.
 The Ad Manager xlsx has no country column at all, so for those the only

--- a/app/skills_v2/noon-fbn/scripts/check_fee_rows.py
+++ b/app/skills_v2/noon-fbn/scripts/check_fee_rows.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Tell a not-yet-published fee report from a genuinely-zero one.
+
+An FBN finance report for a service month the marketplace has not posted
+yet still reaches ``Complete`` on the Reports page and still downloads
+successfully. What arrives is a valid CSV holding its header row and no
+data — a few hundred bytes, so it passes every "the file exists and is
+non-empty" check. One such file shipped as a delivered monthly report
+inside a run that was marked complete and independently reviewed as ok.
+
+The list page hints at it: the *Nr. of Rows* column shows a number for a
+populated report and an ellipsis for an empty one. That hint is easy to
+miss and impossible to assert on, so check the file instead.
+
+Zero rows means different things per report, and that is the whole
+reason this script exists rather than a blanket rule:
+
+``monthly_storage`` / ``longterm_storage`` / ``nonsaleable_storage``
+    Storage **accrues** against stock held all month. If the store held
+    inventory, a zero-row month has not been published yet.
+
+``rtv_removal``
+    Removals are discrete **events**. A month with no removals is a
+    legitimate zero, and the file is still worth keeping as proof the
+    question was asked.
+
+Usage::
+
+    python check_fee_rows.py <dir> [--service-month YYYY-MM] [--json]
+
+Exit status is 1 when any accrual report is empty, so a caller can gate
+on it; ``--json`` prints a machine-readable summary instead of prose.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+import sys
+
+#: Filename stem → whether zero rows is a legal answer.
+EVENT_STEMS = ('rtv_removal',)
+ACCRUAL_STEMS = (
+    'monthly_storage',
+    'longterm_storage',
+    'nonsaleable_storage',
+)
+
+
+def data_rows(path: Path) -> int:
+    """Data rows in a CSV, header excluded.
+
+    Parsed rather than line-counted: a quoted field may contain a
+    newline, and a product title that wraps would otherwise make an empty
+    file look populated.
+    """
+    try:
+        with path.open('r', encoding='utf-8-sig', newline='') as fh:
+            return max(sum(1 for _ in csv.reader(fh)) - 1, 0)
+    except (OSError, UnicodeDecodeError, csv.Error):
+        return 0
+
+
+def classify(name: str) -> str:
+    """``'accrual'``, ``'event'``, or ``''`` for a file we don't judge."""
+    stem = name.lower()
+    if any(stem.startswith(s) for s in EVENT_STEMS):
+        return 'event'
+    if any(stem.startswith(s) for s in ACCRUAL_STEMS):
+        return 'accrual'
+    return ''
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('directory', help='folder holding the downloaded CSVs')
+    ap.add_argument(
+        '--service-month',
+        help='YYYY-MM these reports are for; only used in the message',
+    )
+    ap.add_argument('--json', action='store_true', dest='as_json')
+    args = ap.parse_args()
+
+    root = Path(args.directory).expanduser()
+    if not root.is_dir():
+        print(f'not a directory: {root}', file=sys.stderr)
+        return 2
+
+    findings = []
+    for path in sorted(root.glob('*.csv')):
+        kind = classify(path.name)
+        if not kind:
+            continue
+        rows = data_rows(path)
+        findings.append({
+            'file': path.name,
+            'kind': kind,
+            'rows': rows,
+            # An empty accrual report is the actionable state; an
+            # empty event report is a fact about the month.
+            'verdict': (
+                'not_published' if kind == 'accrual' and rows == 0 else 'ok'
+            ),
+        })
+
+    unpublished = [f for f in findings if f['verdict'] == 'not_published']
+
+    if args.as_json:
+        print(
+            json.dumps(
+                {
+                    'checked': findings,
+                    'not_published': [f['file'] for f in unpublished],
+                },
+                indent=2,
+            )
+        )
+    else:
+        if not findings:
+            print(f'No FBN fee CSVs found in {root}')
+        for f in findings:
+            mark = '✗' if f['verdict'] == 'not_published' else '✓'
+            note = '' if f['kind'] == 'accrual' else '  (zero is legal)'
+            print(f'{mark} {f["file"]}: {f["rows"]} data rows{note}')
+        if unpublished:
+            month = args.service_month or 'this service month'
+            print(
+                f'\n{len(unpublished)} storage report(s) for {month} came '
+                'back empty. Storage accrues against held stock, so an '
+                'empty file means the marketplace has not posted the '
+                'service month yet — NOT that the fee was zero.\n'
+                'Do not retry: a second generation returns a '
+                'byte-identical empty file. Report these as pending and '
+                'let the next run pick them up.'
+            )
+
+    return 1 if unpublished else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/unit/test_deliverables.py
+++ b/tests/unit/test_deliverables.py
@@ -1,0 +1,338 @@
+"""The deliverable manifest's invariants, one test per bug it closes.
+
+Every case here corresponds to something that actually happened on a
+live run, so a regression is not hypothetical:
+
+* a header-only CSV shipped as a delivered file inside a COMPLETED run,
+* a store with no FBA failed for a report it cannot produce,
+* a run attempted 9 files of 19 and reported "9 of 9",
+* a fee report absent on day 3 of the following month read as a failure
+  when it is simply not published yet.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import types
+import zipfile
+
+import pytest
+
+from app.deliverables.manifest import (
+    Deliverable,
+    DeliverableKind,
+    derive_manifest,
+    month_before,
+    store_capabilities,
+)
+from app.deliverables.verify import (
+    DeliverableStatus,
+    data_rows,
+    verify_workspace,
+)
+
+pytestmark = pytest.mark.unit
+
+# The header of a real monthly-storage export, truncated. What matters is
+# that it is well-formed and carries no data row — the exact shape an
+# unpublished month downloads as.
+STORAGE_HEADER = 'service_month,sku,warehouse_code,charged_amount\n'
+
+
+def _store(platform_countries: dict, capabilities: dict | None = None):
+    """A stand-in for the ORM row; the manifest only reads two fields."""
+    return types.SimpleNamespace(
+        platform_countries=json.dumps(platform_countries),
+        capabilities=json.dumps(capabilities or {}),
+    )
+
+
+def _write(path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding='utf-8')
+
+
+class TestRowCounting:
+    """A byte count cannot tell these apart; a row count must."""
+
+    def test_header_only_csv_has_zero_rows(self, tmp_path):
+        f = tmp_path / 'storage.csv'
+        _write(f, STORAGE_HEADER)
+        assert f.stat().st_size > 0  # this is what fooled the size check
+        assert data_rows(f) == 0
+
+    def test_one_data_row_counts_as_one(self, tmp_path):
+        f = tmp_path / 'storage.csv'
+        _write(f, STORAGE_HEADER + '2026-06,WIDGET-006,WH1,1.23\n')
+        assert data_rows(f) == 1
+
+    def test_embedded_newline_does_not_inflate_the_count(self, tmp_path):
+        """A quoted newline is one row, not two.
+
+        Counting lines instead of parsing would read a single product
+        whose title wraps as two data rows — turning an empty file into a
+        populated one on exactly the reports that carry long titles.
+        """
+        f = tmp_path / 'ledger.csv'
+        _write(f, 'sku,title\n"WIDGET-006","two\nlines"\n')
+        assert data_rows(f) == 1
+
+    def test_unreadable_file_counts_as_zero(self, tmp_path):
+        f = tmp_path / 'missing.csv'
+        assert data_rows(f) == 0
+
+    def test_xlsx_rows_are_counted(self, tmp_path):
+        f = tmp_path / 'ads.xlsx'
+        sheet = (
+            '<worksheet><sheetData>'
+            '<row r="1"><c/></row><row r="2"><c/></row><row r="3"><c/></row>'
+            '</sheetData></worksheet>'
+        )
+        with zipfile.ZipFile(f, 'w') as zf:
+            zf.writestr('xl/worksheets/sheet1.xml', sheet)
+        assert data_rows(f) == 2  # 3 rows minus the header
+
+    def test_empty_xlsx_has_zero_rows(self, tmp_path):
+        f = tmp_path / 'ads.xlsx'
+        with zipfile.ZipFile(f, 'w') as zf:
+            zf.writestr(
+                'xl/worksheets/sheet1.xml',
+                '<worksheet><sheetData><row r="1"><c/></row>'
+                '</sheetData></worksheet>',
+            )
+        assert data_rows(f) == 0
+
+
+class TestEmptyFileIsNotDelivered:
+    """The bug: ``Complete`` upstream + valid header + size>0 passed."""
+
+    def test_empty_accrual_past_publication_is_a_gap(self, tmp_path):
+        _write(tmp_path / 'storage.csv', STORAGE_HEADER)
+        entry = Deliverable(
+            relpath='storage.csv',
+            month='2026-06',
+            kind=DeliverableKind.ACCRUAL,
+            published_from_day=15,
+        )
+        report = verify_workspace(tmp_path, [entry], today=dt.date(2026, 8, 3))
+        assert report.statuses['storage.csv'] is DeliverableStatus.EMPTY
+        assert not report.ok
+        assert '0 data rows' in report.gaps[0]
+
+    def test_empty_event_file_is_delivered(self, tmp_path):
+        """Zero removals in a month is an answer, not an omission."""
+        _write(tmp_path / 'rtv.csv', 'barcode,charged_amount\n')
+        entry = Deliverable(
+            relpath='rtv.csv',
+            month='2026-06',
+            kind=DeliverableKind.EVENT,
+            min_rows=0,
+            published_from_day=15,
+        )
+        report = verify_workspace(tmp_path, [entry], today=dt.date(2026, 8, 3))
+        assert report.statuses['rtv.csv'] is DeliverableStatus.OK
+        assert report.ok
+
+    def test_missing_event_file_is_still_a_gap(self, tmp_path):
+        """Empty proves the question was asked; absent proves nothing."""
+        entry = Deliverable(
+            relpath='rtv.csv',
+            month='2026-06',
+            kind=DeliverableKind.EVENT,
+            min_rows=0,
+            published_from_day=15,
+        )
+        report = verify_workspace(tmp_path, [entry], today=dt.date(2026, 8, 3))
+        assert report.statuses['rtv.csv'] is DeliverableStatus.MISSING
+        assert not report.ok
+
+
+class TestPublicationLatency:
+    """Absent-because-unpublished must complete; absent-later must not."""
+
+    ENTRY = Deliverable(
+        relpath='storage.csv',
+        month='2026-07',
+        kind=DeliverableKind.ACCRUAL,
+        published_from_day=15,
+    )
+
+    def test_before_publication_day_is_pending_not_a_gap(self, tmp_path):
+        report = verify_workspace(
+            tmp_path, [self.ENTRY], today=dt.date(2026, 8, 3)
+        )
+        assert report.statuses['storage.csv'] is DeliverableStatus.PENDING
+        assert report.ok, 'a day-3 storage absence must not fail the run'
+        assert report.pending
+
+    def test_on_publication_day_absence_becomes_a_gap(self, tmp_path):
+        report = verify_workspace(
+            tmp_path, [self.ENTRY], today=dt.date(2026, 8, 15)
+        )
+        assert report.statuses['storage.csv'] is DeliverableStatus.MISSING
+        assert not report.ok
+
+    def test_an_older_month_is_never_excused_by_an_early_day(self, tmp_path):
+        """The prose rule keyed off the day number and forgot the month.
+
+        June's fees are long published by 3 August; only July's are not.
+        A day-of-month test alone would excuse both.
+        """
+        june = Deliverable(
+            relpath='storage.csv',
+            month='2026-06',
+            kind=DeliverableKind.ACCRUAL,
+            published_from_day=15,
+        )
+        report = verify_workspace(tmp_path, [june], today=dt.date(2026, 8, 3))
+        assert report.statuses['storage.csv'] is DeliverableStatus.MISSING
+        assert not report.ok
+
+    def test_empty_before_publication_day_is_pending(self, tmp_path):
+        """Downloaded-but-empty early in the month is the same fact."""
+        _write(tmp_path / 'storage.csv', STORAGE_HEADER)
+        report = verify_workspace(
+            tmp_path, [self.ENTRY], today=dt.date(2026, 8, 3)
+        )
+        assert report.statuses['storage.csv'] is DeliverableStatus.PENDING
+        assert report.ok
+
+
+class TestCapabilities:
+    """A store cannot be failed for a report it cannot produce."""
+
+    ENTRY = Deliverable(
+        relpath='storage.csv',
+        month='2026-06',
+        kind=DeliverableKind.ACCRUAL,
+        requires='amazon.fba',
+        published_from_day=15,
+    )
+
+    def test_undeclared_capability_makes_absence_acceptable(self, tmp_path):
+        report = verify_workspace(
+            tmp_path, [self.ENTRY], today=dt.date(2026, 8, 3), capabilities={}
+        )
+        assert report.statuses['storage.csv'] is DeliverableStatus.SKIPPED
+        assert report.ok
+
+    def test_declared_capability_makes_absence_a_gap(self, tmp_path):
+        report = verify_workspace(
+            tmp_path,
+            [self.ENTRY],
+            today=dt.date(2026, 8, 3),
+            capabilities={'amazon.fba': True},
+        )
+        assert report.statuses['storage.csv'] is DeliverableStatus.MISSING
+        assert not report.ok
+
+    def test_declared_false_drops_the_entry_from_the_manifest(self):
+        store = _store(
+            {'amazon': ['SA']}, {'amazon': {'fba': False, 'ads': False}}
+        )
+        paths = [
+            d.relpath
+            for d in derive_manifest(
+                store, 'acme', '2026-07', fee_month='2026-06'
+            )
+        ]
+        assert not any('storage.csv' in p for p in paths)
+        assert not any('return.csv' in p for p in paths)
+        assert not any('Advertised_product' in p for p in paths)
+        # The transaction ledger has no capability requirement, so it
+        # survives — a store with no FBA still has sales.
+        assert any('MonthlyTransaction.csv' in p for p in paths)
+
+    def test_capabilities_flatten_to_dotted_keys(self):
+        store = _store({}, {'amazon': {'fba': True, 'ads': False}})
+        assert store_capabilities(store) == {
+            'amazon.fba': True,
+            'amazon.ads': False,
+        }
+
+    def test_malformed_capabilities_do_not_raise(self):
+        store = types.SimpleNamespace(
+            platform_countries='{}', capabilities='not json'
+        )
+        assert store_capabilities(store) == {}
+
+
+class TestDerivedDenominator:
+    """The denominator may not come from what the run produced."""
+
+    def test_two_platform_store_owes_every_file(self):
+        store = _store(
+            {'amazon': ['SA', 'AE'], 'noon': ['SA', 'AE']},
+            {
+                'amazon': {'fba': True, 'ads': True},
+                'noon': {'fbn': True, 'ads': True},
+            },
+        )
+        manifest = derive_manifest(
+            store, 'acme', '2026-07', fee_month='2026-06'
+        )
+        paths = [d.relpath for d in manifest]
+
+        # Amazon: transaction + SP + return, per marketplace.
+        assert sum('MonthlyTransaction.csv' in p for p in paths) == 2
+        assert sum('Advertised_product' in p for p in paths) == 2
+        assert sum(p.endswith('return.csv') for p in paths) == 2
+        # Fee backfill for the older month, per marketplace.
+        assert sum(p.endswith('storage.csv') for p in paths) == 2
+        # noon: ONE transaction view for the store, ads per country.
+        assert sum('transactionviewreport' in p for p in paths) == 1
+        assert sum('ads_overview' in p for p in paths) == 2
+        # noon fee reports: 4 per country for the older month.
+        assert sum('monthly_storage_' in p for p in paths) == 2
+        assert sum('longterm_storage_' in p for p in paths) == 2
+        assert sum('nonsaleable_storage_' in p for p in paths) == 2
+        assert sum('rtv_removal_' in p for p in paths) == 2
+
+        assert len(paths) == len(set(paths)), 'no entry may be duplicated'
+
+    def test_a_partial_run_reports_the_full_denominator(self, tmp_path):
+        """The "9 of 9 expected" bug, pinned.
+
+        Producing one file out of four must read as 1/4, never as 1/1.
+        """
+        store = _store({'amazon': ['SA']}, {'amazon': {'fba': True}})
+        manifest = derive_manifest(
+            store, 'acme', '2026-07', fee_month='2026-06'
+        )
+        produced = next(
+            d for d in manifest if 'MonthlyTransaction' in d.relpath
+        )
+        _write(tmp_path / produced.relpath, 'a,b\n1,2\n')
+
+        report = verify_workspace(
+            tmp_path,
+            manifest,
+            today=dt.date(2026, 8, 3),
+            capabilities={'amazon.fba': True},
+        )
+        assert report.delivered == 1
+        assert len(report.statuses) == len(manifest) > 1
+        assert f'1/{len(manifest)}' in report.summary()
+
+    def test_fee_month_is_optional(self):
+        store = _store({'amazon': ['SA']}, {'amazon': {'fba': True}})
+        paths = [d.relpath for d in derive_manifest(store, 'acme', '2026-07')]
+        assert not any(p.endswith('storage.csv') for p in paths)
+
+    def test_no_platforms_yields_no_obligations(self):
+        assert derive_manifest(_store({}), 'acme', '2026-07') == []
+
+
+class TestMonthArithmetic:
+    def test_month_before(self):
+        assert month_before('2026-08') == '2026-07'
+
+    def test_month_before_crosses_the_year(self):
+        assert month_before('2026-01') == '2025-12'
+
+    def test_filename_month_token_matches_the_month(self):
+        store = _store({'amazon': ['SA']})
+        paths = [d.relpath for d in derive_manifest(store, 'acme', '2026-01')]
+        assert any('2026JanMonthlyTransaction.csv' in p for p in paths)
+        assert any(p.startswith('reports_01_sa_acme/') for p in paths)

--- a/tests/unit/test_deliverables.py
+++ b/tests/unit/test_deliverables.py
@@ -93,6 +93,38 @@ class TestRowCounting:
             zf.writestr('xl/worksheets/sheet1.xml', sheet)
         assert data_rows(f) == 2  # 3 rows minus the header
 
+    def test_xlsx_rows_spanning_read_boundaries_are_not_lost(self, tmp_path):
+        """A ``<row`` tag split across a read boundary must still count.
+
+        Placed DELIBERATELY, not by luck: a tag is aligned to start two
+        bytes before the 64KB mark, so ``<r`` lands in one read and ``ow``
+        in the next. Merely making the sheet large does not exercise this —
+        with wide rows the odds of a tag straddling a boundary are under
+        1%, so such a test passes against the bug and proves nothing.
+
+        Chunked scanning without a carry-over drops that row. Undercounting
+        here is not benign: it reports a populated export as empty and
+        manufactures a gap against a healthy file.
+        """
+        chunk = 65536
+        head = '<worksheet><sheetData>'
+        header_row = '<row r="1"><c/></row>'
+        # Pad with an XML comment so the NEXT '<row' starts at chunk-2.
+        overhead = len('<!--') + len('-->')
+        pad = chunk - 2 - len(head) - len(header_row) - overhead
+        assert pad > 0
+        body = (
+            f'{head}{header_row}<!--{"x" * pad}-->'
+            '<row r="2"><c/></row><row r="3"><c/></row>'
+            '</sheetData></worksheet>'
+        )
+        assert body.index('<row r="2"') == chunk - 2, 'alignment broke'
+
+        f = tmp_path / 'ads.xlsx'
+        with zipfile.ZipFile(f, 'w') as zf:
+            zf.writestr('xl/worksheets/sheet1.xml', body)
+        assert data_rows(f) == 2  # 3 rows minus the header
+
     def test_empty_xlsx_has_zero_rows(self, tmp_path):
         f = tmp_path / 'ads.xlsx'
         with zipfile.ZipFile(f, 'w') as zf:
@@ -133,6 +165,25 @@ class TestEmptyFileIsNotDelivered:
         report = verify_workspace(tmp_path, [entry], today=dt.date(2026, 8, 3))
         assert report.statuses['rtv.csv'] is DeliverableStatus.OK
         assert report.ok
+
+    def test_min_rows_governs_even_for_an_event(self, tmp_path):
+        """An EVENT that declares a floor must be held to it.
+
+        Zero is legal for events only because they declare ``min_rows=0``.
+        Exempting the whole kind instead would silently ignore a raised
+        threshold on a future entry that genuinely must carry rows.
+        """
+        _write(tmp_path / 'ev.csv', 'a,b\n1,2\n')  # one row
+        entry = Deliverable(
+            relpath='ev.csv',
+            month='2026-06',
+            kind=DeliverableKind.EVENT,
+            min_rows=3,
+        )
+        report = verify_workspace(tmp_path, [entry], today=dt.date(2026, 8, 3))
+        assert report.statuses['ev.csv'] is DeliverableStatus.EMPTY
+        assert not report.ok
+        assert 'short of 3' in report.gaps[0]
 
     def test_missing_event_file_is_still_a_gap(self, tmp_path):
         """Empty proves the question was asked; absent proves nothing."""
@@ -294,9 +345,13 @@ class TestDerivedDenominator:
     def test_a_partial_run_reports_the_full_denominator(self, tmp_path):
         """The "9 of 9 expected" bug, pinned.
 
-        Producing one file out of four must read as 1/4, never as 1/1.
+        Producing one file of several must never read as 1/1. The
+        denominator is what the store *owes* — every derived entry whose
+        capability is declared — so it can exceed what the run attempted.
         """
-        store = _store({'amazon': ['SA']}, {'amazon': {'fba': True}})
+        store = _store(
+            {'amazon': ['SA']}, {'amazon': {'fba': True, 'ads': True}}
+        )
         manifest = derive_manifest(
             store, 'acme', '2026-07', fee_month='2026-06'
         )
@@ -309,11 +364,58 @@ class TestDerivedDenominator:
             tmp_path,
             manifest,
             today=dt.date(2026, 8, 3),
-            capabilities={'amazon.fba': True},
+            capabilities={'amazon.fba': True, 'amazon.ads': True},
         )
         assert report.delivered == 1
-        assert len(report.statuses) == len(manifest) > 1
+        assert report.expected == len(manifest) > 1
         assert f'1/{len(manifest)}' in report.summary()
+
+    def test_undeclared_capability_is_not_counted_as_owed(self, tmp_path):
+        """An unasserted capability must not pad the denominator.
+
+        Reporting "1/4" when one of those four is a report nobody has
+        established this store can produce understates a run that did
+        everything actually asked of it.
+        """
+        store = _store({'amazon': ['SA']}, {'amazon': {'fba': True}})
+        manifest = derive_manifest(store, 'acme', '2026-07')
+        for entry in manifest:
+            _write(tmp_path / entry.relpath, 'a,b\n1,2\n')
+        # amazon.ads is absent from capabilities → undeclared. Remove the
+        # file so it is judged on absence rather than on content.
+        ads = next(d for d in manifest if 'Advertised_product' in d.relpath)
+        (tmp_path / ads.relpath).unlink()
+
+        report = verify_workspace(
+            tmp_path,
+            manifest,
+            today=dt.date(2026, 8, 3),
+            capabilities={'amazon.fba': True},
+        )
+        assert report.statuses[ads.relpath] is DeliverableStatus.SKIPPED
+        assert report.expected == len(manifest) - 1
+        assert report.ok
+
+    def test_undeclared_capability_beats_publication_latency(self, tmp_path):
+        """Capability is checked first, so it cannot report as pending.
+
+        A not-yet-due entry whose capability is undeclared used to come
+        back PENDING — a claim that we are waiting on a report which may
+        not exist for this store at all.
+        """
+        entry = Deliverable(
+            relpath='storage.csv',
+            month='2026-07',
+            kind=DeliverableKind.ACCRUAL,
+            requires='amazon.fba',
+            published_from_day=15,
+        )
+        report = verify_workspace(
+            tmp_path, [entry], today=dt.date(2026, 8, 3), capabilities={}
+        )
+        assert report.statuses['storage.csv'] is DeliverableStatus.SKIPPED
+        assert not report.pending
+        assert report.ok
 
     def test_fee_month_is_optional(self):
         store = _store({'amazon': ['SA']}, {'amazon': {'fba': True}})

--- a/tests/unit/test_finalize_reaper_unit.py
+++ b/tests/unit/test_finalize_reaper_unit.py
@@ -62,6 +62,7 @@ def test_ensure_added_columns_is_idempotent(tmp_path):
     con.execute('CREATE TABLE schedules (id TEXT PRIMARY KEY)')
     con.execute('CREATE TABLE tasks (id TEXT PRIMARY KEY)')
     con.execute('CREATE TABLE users (id TEXT PRIMARY KEY)')
+    con.execute('CREATE TABLE stores (id TEXT PRIMARY KEY)')
     con.commit()
     shim = _ConnShim(con)
 


### PR DESCRIPTION
## The bug

An unpublished monthly fee report downloads as a **well-formed CSV holding its header and nothing else**. Upstream reports the month `Complete`, the download succeeds, and the file is a few hundred bytes — so every check the monthly pipeline had passed it.

One such file shipped as a delivered deliverable inside a run that landed COMPLETED and passed an independent definition-of-done review whose strongest assertion was *"exists and is larger than 0 bytes"*. Verified by byte-comparing that shipped file against one generated fresh and confirmed empty: `cmp` clean.

Four gates, four passes:

| Gate | Why an empty file clears it |
|---|---|
| Upstream status | Reports the month `Complete`. There is no "empty" state to observe. |
| Download | Succeeds, so the retry rule (which triggers on *failure*) never fires. |
| Size check | 306 bytes > 0. |
| Reconciliation | Structurally blind — settlement lags a month, so a July run only ever validates *June's* reports. |

## Root cause

The deliverable set existed **only as prose** inside a plan document written for the agent to read. Three defects fall out of that one gap:

- Nothing could check row counts, so an empty file read as delivered.
- A store with no FBA was asked for a storage report it cannot produce, and the run failed for the absence.
- A run that attempted 9 files of 19 reported *"9 of 9"* — a denominator derived from the numerator can never be wrong.

## The fix

`app/deliverables/` makes the set data. `derive_manifest` builds it from the store's declared capabilities and the calendar — both known before the agent starts, so unlike an ad-task scope there is nothing here for an agent to declare and nothing to re-declare around. `verify_workspace` counts rows in what it finds.

Two distinctions do the real work:

**accrual vs event.** Storage accrues against held stock, so zero rows for a month with inventory means *not published yet*. Removals are discrete events, so zero rows can be the truth. That ambiguity is unresolvable by eye — which is exactly why it belongs in the schema and not in a review checklist.

**pending vs gap.** An entry declares `published_from_day`: absent before it is upstream latency and the run completes saying so; absent after it is a gap. Compared on **real dates, not day-of-month** — the prose rule this replaces keyed off the day number and forgot which month was being asked for, which is why it was wrong at both ends.

Capabilities are fail-safe: undeclared makes a deliverable optional, only an explicit `true` turns absence into a gap. Same direction the ad declaration takes — an unasserted capability under-demands rather than inventing an obligation.

**No new terminal state.** The verdict rides the existing gate contract, so gaps land as caveats on a COMPLETED run via `task_outcome`. No day-of-month rule is written in prose anywhere.

## Skills and knowledge, corrected against live measurement

- **amazon-reports** — the whole first ~12 days of M+1 return no data, not just day 7 (measured on days 3, 6, 7 → nothing; day 29 → full month). Removes the hand-written *"days 7–14"* status exception: that verdict is now code, and it depended on the agent classifying its own shortfall, which two live runs got wrong.
- **amazon-reports** — the returns date-range calendar lives **three shadow roots down** (`kat-date-range-picker` → `kat-date-picker.start` → `kat-calendar`) and both pickers render at the same screen position. A live run lost a marketplace's `return.csv` to this, reporting the widget *"repeatedly produced same-day reports"*. Adds the traversal plus a mandatory readback, because a missed click fails silently and yields a one-day report that looks normal.
- **noon-fbn** — ships `check_fee_rows.py` and stops treating a header-only storage report as acceptable. Retrying is a **proven no-op**: a second independent generation returns a byte-identical empty file.
- **noon-sites** — FBN reports live at `/fbnreports`; `/reports` 404s.

## Tests

25 new cases in `tests/unit/test_deliverables.py`, one per real-world failure: header-only CSV is not delivered; empty *event* file is; missing event file still is not; day-3 absence completes while day-15 absence does not; an older month is never excused by an early calendar day; undeclared capability skips, declared-true gaps; a 1-of-4 run reports 1/4.

Full fast tier: **2436 passed**. `tests/unit/test_platform.py::test_finds_own_listener` fails on this machine both with and without these changes (negative-controlled — environmental `lsof` behaviour, pre-existing).

The migration-idempotency fixture gained a `stores` table: a real pre-feature DB has one, so the fixture was the thing that was wrong, not the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNLgs9eR2mg74hs5T6nSe