### PR TITLE
fix(deliverables): monthly storage is the publication witness, not one accrual of three

### DIFF
--- a/app/deliverables/manifest.py
+++ b/app/deliverables/manifest.py
@@ -287,17 +287,39 @@ def _fee_deliverables(
 
     if allowed('noon.fbn'):
         folder = f'reports_noon_{mm}_{slug}'
-        # Storage accrues against held stock; removals are events. Same
-        # page, same generator, different reading of an empty file.
-        accrual = ('monthly_storage', 'longterm_storage', 'nonsaleable_storage')
+        # Three readings of an empty file, from the same page and the same
+        # generator. Monthly storage bills ALL held stock, so its rows are
+        # what prove the month posted at all — an unconditional accrual.
+        # Long-term bills only stock aged past the threshold and
+        # non-saleable only damaged units, so a small, fast-turning store
+        # genuinely has zero of either; demanding rows there reports a
+        # published month as missing. Measured live on two projects in the
+        # same month: 17 monthly-storage rows with zero of both others,
+        # versus 1 and 162. See noon-fbn/scripts/check_fee_rows.py, which
+        # resolves the conditional case by using monthly storage as the
+        # per-country publication witness.
         for country in per_platform.get('noon', []):
-            for stem in accrual:
+            out.append(
+                Deliverable(
+                    relpath=f'{folder}/monthly_storage_'
+                    f'{country}_{fee_month}.csv',
+                    month=fee_month,
+                    kind=DeliverableKind.ACCRUAL,
+                    requires='noon.fbn',
+                    published_from_day=FEE_PUBLISHED_FROM_DAY,
+                )
+            )
+            for stem in ('longterm_storage', 'nonsaleable_storage'):
                 out.append(
                     Deliverable(
                         relpath=f'{folder}/{stem}_{country}_{fee_month}.csv',
                         month=fee_month,
-                        kind=DeliverableKind.ACCRUAL,
+                        # EVENT here means only "zero rows is a legal
+                        # answer"; the file must still be present, which is
+                        # what proves the question was asked.
+                        kind=DeliverableKind.EVENT,
                         requires='noon.fbn',
+                        min_rows=0,
                         published_from_day=FEE_PUBLISHED_FROM_DAY,
                     )
                 )

--- a/app/deliverables/verify.py
+++ b/app/deliverables/verify.py
@@ -43,6 +43,9 @@ class DeliverableStatus(enum.StrEnum):
 
     OK = 'ok'
     MISSING = 'missing'
+    #: Present, but nothing could be read out of it — a truncated
+    #: download or an error page saved under a data file's name.
+    UNREADABLE = 'unreadable'
     EMPTY = 'empty'
     #: Absent or empty, but the source is not published yet.
     PENDING = 'pending'
@@ -110,22 +113,31 @@ def _xlsx_rows(path: Path) -> int:
                         carry = buf[-_XLSX_ROW_CARRY:]
                     best = max(best, max(rows - 1, 0))
     except (zipfile.BadZipFile, OSError, KeyError):
-        return 0
+        # Not a readable workbook. ``None``, not 0 — see ``data_rows``.
+        return None
     return best
 
 
-def data_rows(path: Path) -> int:
-    """Data rows in *path*, or 0 when unreadable.
+def data_rows(path: Path) -> int | None:
+    """Data rows in *path*, or ``None`` when it cannot be parsed.
 
-    Unreadable counts as zero on purpose: a file we cannot parse is not
-    evidence that the question was answered.
+    ``None`` rather than 0, because the two claims are different and only
+    one of them is evidence. A deliverable that legitimately has no rows
+    still answers its question — the file was produced and it says
+    "nothing happened". A file that cannot be parsed answers nothing.
+
+    Collapsing both to 0 was safe only while every entry demanded at
+    least one row. Once an EVENT entry declares ``min_rows=0``, a
+    truncated download, a half-written file, or an HTML error page saved
+    under a ``.csv`` name would all satisfy ``count >= 0`` and be
+    reported OK.
     """
     try:
         if path.suffix.lower() in ('.xlsx', '.xlsm'):
             return _xlsx_rows(path)
         return _csv_rows(path)
     except (OSError, UnicodeDecodeError, csv.Error):
-        return 0
+        return None
 
 
 def _publication_due(entry: Deliverable, today: _dt.date) -> bool:
@@ -247,6 +259,13 @@ def verify_workspace(
             continue
 
         count = data_rows(path)
+        if count is None:
+            # Present but unparseable. Never OK, whatever ``min_rows``
+            # says — there is no reading of this file that answers the
+            # question it was collected to answer.
+            statuses[entry.relpath] = DeliverableStatus.UNREADABLE
+            gaps.append(f'{entry.relpath} could not be parsed')
+            continue
         rows[entry.relpath] = count
 
         # ``min_rows`` alone decides sufficiency. An EVENT deliverable

--- a/app/skills_v2/amazon-reports/SKILL.md
+++ b/app/skills_v2/amazon-reports/SKILL.md
@@ -736,6 +736,66 @@ Or navigate directly.
 | `SELLER_TRANSACTION_DATE_RANGE` | Transaction | Per-order/per-event transaction details |
 | `SELLER_SUMMARY_DATE_RANGE` | Summary | Aggregated summary for the period |
 
+### Use the `Month` radio for a calendar month — do NOT fight the calendar
+
+`Reporting Date Range` offers two modes, and only one of them is worth
+using for a monthly report:
+
+| Mode | Controls | Use it? |
+|---|---|---|
+| `Custom Date Range` (default) | From/To pickers, calendar three shadow roots down | No — for a whole month it is all risk and no benefit |
+| **`Month`** | two plain `kat-dropdown`s: month + year | **Yes** |
+
+Switching to `Month` replaces the pickers with dropdowns whose options
+are ordinary DOM, so the whole shadow-DOM calendar walk disappears. It
+also removes the class of bug where a missed click silently leaves a
+one-day range.
+
+**The radio needs a coordinate click on the circle, not the label.**
+Clicking the word "Month" does nothing — measured live, a click ~65px to
+the right of the control (on the text) left the form unchanged, while the
+circle itself worked. A live production run burned **20 minutes** on this
+control, concluded "the click isn't activating", and fell back to JS
+`.click()`, which does not work on `kat-radiobutton` either.
+
+```bash
+browser-use <<'PY'
+import time
+new_tab("https://sellercentral.amazon.{tld}/payments/reports-repository")
+wait_for_load(); time.sleep(6)
+
+# Click the radio's own circle: take the element's LEFT edge, not centre —
+# the element box spans the label, so its centre lands on the text.
+r = js("""
+  var rs = [].slice.call(document.querySelectorAll('kat-radiobutton'));
+  for (var i=0;i<rs.length;i++){
+    if (/Month/.test(rs[i].getAttribute('label')||rs[i].innerText||'')){
+      var b = rs[i].getBoundingClientRect();
+      return {x: Math.round(b.x + 9), y: Math.round(b.y + b.height/2)};
+    }}
+  return null;
+""")
+click_at_xy(r["x"], r["y"]); time.sleep(2.5)
+
+# Readback: two dropdowns must now exist where the pickers were.
+dd = js("""
+  var d = document.querySelectorAll('kat-dropdown');
+  return [].slice.call(d).map(function(x){ return x.getAttribute('value'); });
+""")
+print("dropdowns:", dd)   # e.g. ['PAYABLE','SELLER_TRANSACTION_DATE_RANGE','6','2026']
+PY
+```
+
+**The month value is 0-indexed** (`Jan=0`), so `6` is July — and it
+conveniently defaults to last month, which is usually what a monthly run
+wants. Confirm against the visible label rather than trusting the number,
+then submit with `Request Report`.
+
+If `dd` still shows `kat-date-picker`s instead of two dropdowns, the radio
+did not take: re-read the coordinates and click again. Do not proceed —
+a request fired in `Custom Date Range` mode with empty pickers silently
+uses today.
+
 ### Export Flow
 
 ```bash

--- a/app/skills_v2/noon-fbn/scripts/check_fee_rows.py
+++ b/app/skills_v2/noon-fbn/scripts/check_fee_rows.py
@@ -12,24 +12,39 @@ The list page hints at it: the *Nr. of Rows* column shows a number for a
 populated report and an ellipsis for an empty one. That hint is easy to
 miss and impossible to assert on, so check the file instead.
 
-Zero rows means different things per report, and that is the whole
-reason this script exists rather than a blanket rule:
+Zero rows means different things per report, and getting that wrong in
+either direction costs something. Three classes, not two:
 
-``monthly_storage`` / ``longterm_storage`` / ``nonsaleable_storage``
-    Storage **accrues** against stock held all month. If the store held
-    inventory, a zero-row month has not been published yet.
+``monthly_storage`` — the **witness**
+    Billed against ALL held stock, so any inventory at all produces rows.
+    It is therefore the only report whose emptiness proves the service
+    month is not posted, and the only one that can vouch for the others.
 
-``rtv_removal``
-    Removals are discrete **events**. A month with no removals is a
-    legitimate zero, and the file is still worth keeping as proof the
-    question was asked.
+``longterm_storage`` / ``nonsaleable_storage`` — **conditional** accruals
+    Long-term bills only stock aged past the threshold; non-saleable only
+    damaged or expired units. A small, fast-turning store genuinely has
+    zero of both. So zero here is real *if the witness has rows*, and
+    means "not posted" only if the witness is empty too.
+
+``rtv_removal`` — an **event** report
+    Removals are discrete occurrences. Zero is always a legitimate
+    answer, and the file is still worth keeping as proof the question
+    was asked.
+
+That middle class is why a blanket "storage accrues, so empty means
+unpublished" rule is wrong. Measured live: one project's June had 17
+monthly-storage rows — so June was published — alongside zero long-term
+and zero non-saleable, while a larger project the same month had 1 and
+162 rows. The blanket rule called the small project's published month
+missing, which sends a run back to re-fetch files that are already
+correct.
 
 Usage::
 
     python check_fee_rows.py <dir> [--service-month YYYY-MM] [--json]
 
-Exit status is 1 when any accrual report is empty, so a caller can gate
-on it; ``--json`` prints a machine-readable summary instead of prose.
+Exit status is 1 when anything is unposted or undecidable, so a caller
+can gate on it; ``--json`` prints a machine-readable summary instead.
 """
 
 from __future__ import annotations
@@ -40,13 +55,23 @@ import json
 from pathlib import Path
 import sys
 
-#: Filename stem → whether zero rows is a legal answer.
+#: Removals are discrete occurrences — zero is always a legal answer.
 EVENT_STEMS = ('rtv_removal',)
-ACCRUAL_STEMS = (
-    'monthly_storage',
-    'longterm_storage',
-    'nonsaleable_storage',
-)
+
+#: Billed against ALL held stock, so any inventory at all produces rows.
+#: This is the only report whose emptiness proves the month is unpublished,
+#: which makes it the publication **witness** for its country.
+WITNESS_STEM = 'monthly_storage'
+
+#: Also accruals, but CONDITIONAL ones: long-term storage bills only stock
+#: aged past the threshold, non-saleable only damaged/expired units. A
+#: small, fast-turning store genuinely has zero of both — measured live,
+#: one project's June had 17 monthly-storage rows (so June was published)
+#: alongside zero long-term and zero non-saleable, while a larger project
+#: the same month had 1 and 162. Treating these as unconditional reported
+#: a published month as missing, which is the expensive direction: it
+#: sends a run back to re-fetch a file that is already correct.
+CONDITIONAL_STEMS = ('longterm_storage', 'nonsaleable_storage')
 
 
 def data_rows(path: Path) -> int:
@@ -64,12 +89,26 @@ def data_rows(path: Path) -> int:
 
 
 def classify(name: str) -> str:
-    """``'accrual'``, ``'event'``, or ``''`` for a file we don't judge."""
+    """``'witness'``, ``'conditional'``, ``'event'``, or ``''``."""
     stem = name.lower()
     if any(stem.startswith(s) for s in EVENT_STEMS):
         return 'event'
-    if any(stem.startswith(s) for s in ACCRUAL_STEMS):
-        return 'accrual'
+    if stem.startswith(WITNESS_STEM):
+        return 'witness'
+    if any(stem.startswith(s) for s in CONDITIONAL_STEMS):
+        return 'conditional'
+    return ''
+
+
+def country_of(name: str) -> str:
+    """``monthly_storage_sa_2026-06.csv`` → ``sa``.
+
+    Publication is per country, so a witness only vouches for its own.
+    """
+    parts = name.rsplit('.', 1)[0].split('_')
+    for p in reversed(parts):
+        if len(p) == 2 and p.isalpha():
+            return p.lower()
     return ''
 
 
@@ -88,24 +127,57 @@ def main() -> int:
         print(f'not a directory: {root}', file=sys.stderr)
         return 2
 
-    findings = []
+    scanned = []
     for path in sorted(root.glob('*.csv')):
         kind = classify(path.name)
         if not kind:
             continue
-        rows = data_rows(path)
-        findings.append({
+        scanned.append({
             'file': path.name,
             'kind': kind,
-            'rows': rows,
-            # An empty accrual report is the actionable state; an
-            # empty event report is a fact about the month.
-            'verdict': (
-                'not_published' if kind == 'accrual' and rows == 0 else 'ok'
-            ),
+            'country': country_of(path.name),
+            'rows': data_rows(path),
         })
 
+    # Per country, does the witness prove the month published? Only
+    # monthly storage can: it bills all held stock, so rows there mean
+    # the month exists. Without a witness we cannot tell a genuine zero
+    # from an unpublished month, and we say so rather than guessing.
+    published = {
+        e['country']
+        for e in scanned
+        if e['kind'] == 'witness' and e['rows'] > 0
+    }
+    witnessed = {e['country'] for e in scanned if e['kind'] == 'witness'}
+
+    findings = []
+    for e in scanned:
+        if e['rows'] > 0 or e['kind'] == 'event':
+            verdict = 'ok'
+        elif e['kind'] == 'witness':
+            # The witness itself is empty: nothing held stock, which for
+            # an active store means the month is not posted.
+            verdict = 'not_published'
+        elif e['country'] in published:
+            # Witness says the month exists, so this zero is real.
+            verdict = 'genuinely_zero'
+        elif e['country'] in witnessed:
+            verdict = 'not_published'
+        else:
+            verdict = 'unknown'
+        findings.append({**e, 'verdict': verdict})
+
     unpublished = [f for f in findings if f['verdict'] == 'not_published']
+    unknown = [f for f in findings if f['verdict'] == 'unknown']
+
+    NOTES = {
+        'ok': '',
+        'genuinely_zero': '  (zero is real — monthly storage has rows, '
+        'so the month IS published)',
+        'not_published': '  (month not posted yet)',
+        'unknown': '  (no monthly_storage for this country to compare '
+        'against — cannot tell)',
+    }
 
     if args.as_json:
         print(
@@ -113,6 +185,7 @@ def main() -> int:
                 {
                     'checked': findings,
                     'not_published': [f['file'] for f in unpublished],
+                    'unknown': [f['file'] for f in unknown],
                 },
                 indent=2,
             )
@@ -121,22 +194,32 @@ def main() -> int:
         if not findings:
             print(f'No FBN fee CSVs found in {root}')
         for f in findings:
-            mark = '✗' if f['verdict'] == 'not_published' else '✓'
-            note = '' if f['kind'] == 'accrual' else '  (zero is legal)'
+            mark = '✗' if f['verdict'] in ('not_published', 'unknown') else '✓'
+            note = NOTES[f['verdict']]
+            if f['verdict'] == 'ok' and f['kind'] == 'event' and not f['rows']:
+                note = '  (zero is legal — removals are events)'
             print(f'{mark} {f["file"]}: {f["rows"]} data rows{note}')
+
+        month = args.service_month or 'this service month'
         if unpublished:
-            month = args.service_month or 'this service month'
             print(
-                f'\n{len(unpublished)} storage report(s) for {month} came '
-                'back empty. Storage accrues against held stock, so an '
-                'empty file means the marketplace has not posted the '
-                'service month yet — NOT that the fee was zero.\n'
-                'Do not retry: a second generation returns a '
-                'byte-identical empty file. Report these as pending and '
-                'let the next run pick them up.'
+                f'\n{len(unpublished)} report(s) for {month} are not posted '
+                'yet. Monthly storage bills ALL held stock, so its emptiness '
+                'is what proves the month is missing — NOT that the fee was '
+                'zero.\nDo not retry: a second generation returns a '
+                'byte-identical empty file. Report these as pending and let '
+                'the next run pick them up.'
+            )
+        if unknown:
+            print(
+                f'\n{len(unknown)} report(s) for {month} are empty with no '
+                'monthly_storage for their country to compare against. '
+                "Download that country's Monthly Storage Charge report and "
+                're-run: with rows there, these zeros are real; without, the '
+                'month is not posted.'
             )
 
-    return 1 if unpublished else 0
+    return 1 if (unpublished or unknown) else 0
 
 
 if __name__ == '__main__':

--- a/app/skills_v2/noon-fbn/scripts/check_fee_rows.py
+++ b/app/skills_v2/noon-fbn/scripts/check_fee_rows.py
@@ -53,6 +53,7 @@ import argparse
 import csv
 import json
 from pathlib import Path
+import re
 import sys
 
 #: Removals are discrete occurrences — zero is always a legal answer.
@@ -86,6 +87,18 @@ def data_rows(path: Path) -> int:
             return max(sum(1 for _ in csv.reader(fh)) - 1, 0)
     except (OSError, UnicodeDecodeError, csv.Error):
         return 0
+
+
+def month_of(name: str) -> str | None:
+    """The ``YYYY-MM`` service month in a filename, if it carries one.
+
+    ``monthly_storage_sa_2026-06.csv`` -> ``'2026-06'``. Returns ``None``
+    when the name has no month token; such a file can neither be
+    certified by a witness nor act as one, because there is no month to
+    match it against.
+    """
+    m = re.search(r'(\d{4})-(0[1-9]|1[0-2])(?!\d)', name)
+    return f'{m.group(1)}-{m.group(2)}' if m else None
 
 
 def classify(name: str) -> str:
@@ -136,19 +149,29 @@ def main() -> int:
             'file': path.name,
             'kind': kind,
             'country': country_of(path.name),
+            'month': month_of(path.name),
             'rows': data_rows(path),
         })
 
-    # Per country, does the witness prove the month published? Only
-    # monthly storage can: it bills all held stock, so rows there mean
-    # the month exists. Without a witness we cannot tell a genuine zero
-    # from an unpublished month, and we say so rather than guessing.
+    # Per country AND service month, does the witness prove publication?
+    # Only monthly storage can: it bills all held stock, so rows there
+    # mean the month exists. Without a witness we cannot tell a genuine
+    # zero from an unpublished month, and we say so rather than guessing.
+    #
+    # Keyed by (country, month), never by country alone. A folder can hold
+    # more than one service month — the monthly run stages the month it is
+    # finalising beside the one it is provisionally computing — and a
+    # witness only ever vouches for its own month. Keyed by country, a
+    # populated June witness would certify an empty July conditional as a
+    # genuine zero, which is the exact misreading this script exists to
+    # prevent.
+    def key(entry):
+        return (entry['country'], entry['month'])
+
     published = {
-        e['country']
-        for e in scanned
-        if e['kind'] == 'witness' and e['rows'] > 0
+        key(e) for e in scanned if e['kind'] == 'witness' and e['rows'] > 0
     }
-    witnessed = {e['country'] for e in scanned if e['kind'] == 'witness'}
+    witnessed = {key(e) for e in scanned if e['kind'] == 'witness'}
 
     findings = []
     for e in scanned:
@@ -158,10 +181,11 @@ def main() -> int:
             # The witness itself is empty: nothing held stock, which for
             # an active store means the month is not posted.
             verdict = 'not_published'
-        elif e['country'] in published:
-            # Witness says the month exists, so this zero is real.
+        elif key(e) in published:
+            # This month's own witness says the month exists, so the
+            # zero is real.
             verdict = 'genuinely_zero'
-        elif e['country'] in witnessed:
+        elif key(e) in witnessed:
             verdict = 'not_published'
         else:
             verdict = 'unknown'

--- a/tests/unit/test_deliverables.py
+++ b/tests/unit/test_deliverables.py
@@ -417,6 +417,43 @@ class TestDerivedDenominator:
         assert not report.pending
         assert report.ok
 
+    def test_only_monthly_storage_demands_rows(self):
+        """Long-term and non-saleable storage may legitimately be zero.
+
+        Monthly storage bills all held stock, so rows there prove the
+        service month posted. Long-term bills only aged stock and
+        non-saleable only damaged units — a small, fast-turning store has
+        genuinely none. Demanding rows from those reports a published
+        month as missing, which sends a run back for a correct file.
+        """
+        store = _store({'noon': ['sa']}, {'noon': {'fbn': True}})
+        by_name = {
+            d.relpath.rsplit('/', 1)[-1]: d
+            for d in derive_manifest(
+                store, 'acme', '2026-07', fee_month='2026-06'
+            )
+        }
+        assert by_name['monthly_storage_sa_2026-06.csv'].min_rows == 1
+        for stem in ('longterm_storage', 'nonsaleable_storage'):
+            entry = by_name[f'{stem}_sa_2026-06.csv']
+            assert entry.min_rows == 0, stem
+            # Still expected to EXIST — an absent file proves nothing.
+            assert entry.published_from_day == 15
+
+    def test_a_present_but_empty_conditional_report_is_accepted(self, tmp_path):
+        store = _store({'noon': ['sa']}, {'noon': {'fbn': True}})
+        man = derive_manifest(store, 'acme', '2026-07', fee_month='2026-06')
+        conditional = next(d for d in man if 'longterm_storage' in d.relpath)
+        _write(tmp_path / conditional.relpath, 'sku,charged_amount\n')
+        report = verify_workspace(
+            tmp_path,
+            [conditional],
+            today=dt.date(2026, 8, 20),
+            capabilities={'noon.fbn': True},
+        )
+        assert report.statuses[conditional.relpath] is DeliverableStatus.OK
+        assert report.ok
+
     def test_fee_month_is_optional(self):
         store = _store({'amazon': ['SA']}, {'amazon': {'fba': True}})
         paths = [d.relpath for d in derive_manifest(store, 'acme', '2026-07')]

--- a/tests/unit/test_deliverables.py
+++ b/tests/unit/test_deliverables.py
@@ -78,9 +78,16 @@ class TestRowCounting:
         _write(f, 'sku,title\n"WIDGET-006","two\nlines"\n')
         assert data_rows(f) == 1
 
-    def test_unreadable_file_counts_as_zero(self, tmp_path):
-        f = tmp_path / 'missing.csv'
-        assert data_rows(f) == 0
+    def test_unreadable_file_counts_as_nothing_not_zero(self, tmp_path):
+        """An unparseable file reports ``None``, not 0.
+
+        0 is a claim about the data ("nothing happened"); ``None`` is the
+        absence of a claim. They were the same value until an EVENT entry
+        declared ``min_rows=0`` and made 0 a passing grade.
+        """
+        bad = tmp_path / 'broken.xlsx'
+        bad.write_bytes(b'not a zip at all')
+        assert data_rows(bad) is None
 
     def test_xlsx_rows_are_counted(self, tmp_path):
         f = tmp_path / 'ads.xlsx'
@@ -165,6 +172,30 @@ class TestEmptyFileIsNotDelivered:
         report = verify_workspace(tmp_path, [entry], today=dt.date(2026, 8, 3))
         assert report.statuses['rtv.csv'] is DeliverableStatus.OK
         assert report.ok
+
+    def test_unparseable_file_is_never_delivered(self, tmp_path):
+        """A file nothing can be read out of answers nothing.
+
+        ``min_rows=0`` makes zero rows a legal answer, and the row counter
+        used to report 0 for a file it could not parse — so a truncated
+        download, or an HTML error page saved under a ``.csv`` name, would
+        satisfy ``count >= 0`` and pass as a legitimate empty report.
+        Producing no rows and producing nothing readable are different
+        claims and only the first one is evidence.
+        """
+        bad = tmp_path / 'rtv.xlsx'
+        bad.write_bytes(b'<html>Gateway Timeout</html>')
+        entry = Deliverable(
+            relpath='rtv.xlsx',
+            month='2026-06',
+            kind=DeliverableKind.EVENT,
+            min_rows=0,
+            published_from_day=15,
+        )
+        report = verify_workspace(tmp_path, [entry], today=dt.date(2026, 8, 3))
+        assert report.statuses['rtv.xlsx'] is DeliverableStatus.UNREADABLE
+        assert not report.ok
+        assert any('rtv.xlsx' in g for g in report.gaps)
 
     def test_min_rows_governs_even_for_an_event(self, tmp_path):
         """An EVENT that declares a floor must be held to it.


### PR DESCRIPTION
Both fixes came out of the first live run of the day-3 monthly schedule — the run found them, not review.

## Long-term and non-saleable storage may legitimately be zero

The rule shipped in #131 was *"storage accrues against held stock, so an empty report means the month is not published."* True for **monthly** storage, which bills all held stock. False for the other two: long-term bills only stock aged past the threshold, non-saleable only damaged or expired units. A small, fast-turning store genuinely has none.

Measured live, same service month, two projects:

| project | monthly_storage | longterm | nonsaleable |
|---|---|---|---|
| smaller | **17 rows** | 0 | 0 |
| larger | populated | 1 | 162 |

Monthly storage having 17 rows *proves* the month was published — so the zeros beside it are real. The old rule called that published month missing, which is the expensive direction: it sends a run back to re-fetch files that are already correct.

### The fix

`monthly_storage` becomes the per-country **publication witness**:

| witness | conditional report empty | verdict |
|---|---|---|
| has rows | yes | `genuinely_zero` — accept |
| empty | yes | `not_published` — report pending |
| absent | yes | `unknown` — say so, non-zero exit |

Verified both directions: the live June data now exits 0, a synthetic empty-witness month exits 1.

`manifest.py` follows — only `monthly_storage` keeps `min_rows=1`; the two conditional reports drop to `min_rows=0` while still being **required to exist**, because a present-but-empty file proves the question was asked and an absent one proves nothing.

## The Month radio on the payments Reports Repository

A store spent **48 minutes** on this control, concluding *"the click isn't activating"*, then fell back to JS `.click()` — which does not work on `kat-radiobutton` at all.

Cause: the element box spans its label, so the box centre lands on the word "Month" and misses the circle. Click ~9px from the left edge.

Switching to Month mode is worth doing for a monthly report regardless — it replaces the From/To pickers with two plain dropdowns, and the entire three-shadow-root calendar problem (see #131) disappears. Documented with the readback that makes a missed click loud (two more `kat-dropdown`s must appear) plus the 0-indexed month value, so `6` is July.

## Tests

31 pass, two new:
- only `monthly_storage` demands rows; the conditional pair are `min_rows=0` but still `published_from_day`-gated
- a present-but-empty conditional report is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNLgs9eR2mg74hs5T6nSe