### PR TITLE
docs(noon,ziniao): the export window defaults to 30 days, and error.html is not a timeout

### DIFF
--- a/app/knowledge/common/ziniao-block-page.md
+++ b/app/knowledge/common/ziniao-block-page.md
@@ -27,13 +27,16 @@ The same extension id serves both, and they mean different things:
 | `…/stop.html` | URL blocked by policy | whitelist the destination in the Ziniao console |
 | `…/error.html?…&url=<target>` | the extension could not complete the navigation | **not the agent** — Ziniao-side or network |
 
-`error.html` carries the destination in its own query string, which is the
-fastest way to see what was actually being fetched:
+`error.html` carries the destination in its own `url=` parameter, which is
+the fastest way to see what was actually being fetched. Print that
+parameter alone — the full extension URL carries several others, and the
+one you want gets lost among them:
 
 ```bash
 curl -sf --noproxy '*' "http://127.0.0.1:<mux_port>/json/list" \
   | python3 -c "import sys,json,urllib.parse as u; \
-      [print(u.unquote(t['url'])) for t in json.load(sys.stdin) \
+      [print(u.parse_qs(u.urlparse(t['url']).query).get('url',['?'])[0]) \
+       for t in json.load(sys.stdin) \
        if 'error.html' in (t.get('url') or '')][:1]"
 ```
 

--- a/app/knowledge/common/ziniao-block-page.md
+++ b/app/knowledge/common/ziniao-block-page.md
@@ -18,6 +18,38 @@ shows a message like:
 Translation: "The webpage you are accessing may involve content that does not
 comply with relevant laws, regulations and policies, and is not displayed."
 
+## Two different extension pages — `stop.html` vs `error.html`
+
+The same extension id serves both, and they mean different things:
+
+| page | meaning | who can fix it |
+|---|---|---|
+| `…/stop.html` | URL blocked by policy | whitelist the destination in the Ziniao console |
+| `…/error.html?…&url=<target>` | the extension could not complete the navigation | **not the agent** — Ziniao-side or network |
+
+`error.html` carries the destination in its own query string, which is the
+fastest way to see what was actually being fetched:
+
+```bash
+curl -sf --noproxy '*' "http://127.0.0.1:<mux_port>/json/list" \
+  | python3 -c "import sys,json,urllib.parse as u; \
+      [print(u.unquote(t['url'])) for t in json.load(sys.stdin) \
+       if 'error.html' in (t.get('url') or '')][:1]"
+```
+
+**Neither page is a timeout, and both are commonly misread as one.**
+Observed live: a store retried the same noon URL twelve times, reporting
+"the browser is consistently timing out on navigation", while every tab
+held `error.html` for that exact URL. Retrying, resetting the daemon and
+rotating the session all do nothing — the navigation is being intercepted,
+not delayed.
+
+So when navigation "times out" repeatedly, **list the browser's targets
+before touching anything else**. Twelve identical extension pages is a
+configuration answer, not a flaky one. If the profile is affected and a
+sibling store reaches the same platform normally, it is that profile's
+access that differs — report it rather than burning the run on retries.
+
 ## Detection: Always Check When DOM Is Empty
 
 When inspecting the page returns "Empty DOM tree" after opening it,

--- a/app/skills_v2/noon-exports/SKILL.md
+++ b/app/skills_v2/noon-exports/SKILL.md
@@ -48,8 +48,13 @@ filter in the toolbar. Each store shows a flag icon.
 >
 > ```bash
 > browser-use <<'PY'
-> print(js("return [].slice.call(document.querySelectorAll('input'))"
->          ".map(function(i){return i.value;}).filter(function(v){return v;});"))
+> # Read the two date inputs BY NAME. Collecting every input on the page
+> # returns unrelated controls too, and then it is guesswork which pair of
+> # values is the committed range — which is the same guessing this
+> # readback exists to remove.
+> print(js("return ['Start date','End date'].map(function(p){"
+>          "var i=document.querySelector('input[placeholder=\"'+p+'\"]');"
+>          "return p+'='+(i?i.value:'MISSING');});"))
 > # MUST show the 1st and the last day of the target month before you
 > # click Export. If it shows today's date or a 30-day window, the range
 > # never committed — set it again.

--- a/app/skills_v2/noon-exports/SKILL.md
+++ b/app/skills_v2/noon-exports/SKILL.md
@@ -35,6 +35,27 @@ filter in the toolbar. Each store shows a flag icon.
 
 ### Date Range for Last Month
 
+> ⚠️ **The page opens on a ROLLING 30-DAY window, not last month.** On
+> 3 August the inputs read `2026-07-04 → 2026-08-03`. Export without
+> touching them and you get a file that **misses the first days of the
+> month and includes days from this one** — the same trap as the Amazon
+> FBA-returns preset, and just as quiet: the CSV looks perfectly normal.
+> Observed live twice, once by hand and once in a scheduled run.
+>
+> So: set the range, then **read it back before you export**. A monthly
+> report whose window is off by three days at each end is worse than a
+> missing one, because nothing downstream can tell.
+>
+> ```bash
+> browser-use <<'PY'
+> print(js("return [].slice.call(document.querySelectorAll('input'))"
+>          ".map(function(i){return i.value;}).filter(function(v){return v;});"))
+> # MUST show the 1st and the last day of the target month before you
+> # click Export. If it shows today's date or a 30-day window, the range
+> # never committed — set it again.
+> PY
+> ```
+
 ```bash
 browser-use <<'PY'
 fill_input("input[name=start_date]", "01 Mar 2026")   # start-date input


### PR DESCRIPTION
Two traps caught during a live monthly run. Both cost real time, and both were misread the same way — as a slow page.

## The noon Transaction View opens on a rolling 30-day window

On 3 August the date inputs read `2026-07-04 → 2026-08-03`. Export without touching them and you get a file that **misses the first days of the target month and includes days from the current one**.

Caught mid-export in a scheduled run, and reproduced by hand on the same page an hour earlier — so it's the page's behaviour, not a one-off.

Why it matters more than it looks: nothing downstream can detect it. The CSV is well-formed and the row count looks sane, and for noon this file is the **only** bridge between platform SKUs and seller SKUs — so a wrong window quietly reweights every per-SKU figure derived from it.

The skill already showed how to set the range. It never said the default was wrong. Now it does, and it requires a **readback of the committed dates** before exporting.

## `error.html` and `stop.html` are different pages

The knowledge doc described only `stop.html` — URL blocked by policy, fixed by whitelisting. The same extension id also serves `error.html?…&url=<target>`, which means the extension could not complete the navigation.

| page | meaning | who fixes it |
|---|---|---|
| `stop.html` | blocked by policy | whitelist the destination |
| `error.html?…&url=…` | navigation not completed | not the agent — Ziniao-side or network |

The cost of conflating them, observed: a store reported *"the browser is consistently timing out on navigation"* and retried the same URL **twelve times** while every tab held `error.html` for that exact URL. Daemon resets, session rotation and waiting all did nothing, because nothing was slow. A sibling store reached the same platform normally — which is the tell that it's the profile's access that differs.

The doc now separates the two, shows how to decode the intended destination out of `error.html`'s query string, and says to **list the browser's targets before retrying**: twelve identical extension pages is a configuration answer, not a flaky one.

Docs only — no behaviour change. Stacks alongside #132 (witness rule + Month radio); no overlapping files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFNLgs9eR2mg74hs5T6nSe