### PR TITLE
docs(reports): two marketplaces on one account must never share a download

### DIFF
--- a/app/skills_v2/amazon-reports/SKILL.md
+++ b/app/skills_v2/amazon-reports/SKILL.md
@@ -303,60 +303,78 @@ mv "$DL/2026JulMonthlyTransaction.csv" reports_07_<cc2>_<slug>/2026JulMonthlyTra
 `mv`, not `cp`: it leaves nothing behind in the downloads dir for the next
 step to pick up by mistake.
 
-### Rule 2 — identical bytes across two marketplaces is a HARD FAILURE
+### Rules 2 and 3 — one check, run it on every file
 
-Once both are in place, compare them. **Never reason your way past a
-match.**
-
-```bash
-md5 reports_07_<cc1>_<slug>/2026JulMonthlyTransaction.csv \
-    reports_07_<cc2>_<slug>/2026JulMonthlyTransaction.csv
-```
-
-Equal hashes mean one marketplace was never exported. Redo that
-marketplace: reopen the picker, confirm the header shows the intended
-marketplace, download again.
-
-> Transaction and storage reports are **per-marketplace**. They are NOT
-> account-level. A past run compared two storage files, found the same
-> MD5, concluded "the report is account-level, that's fine for downstream
-> use", and shipped one marketplace's numbers twice. If two marketplaces
-> produce byte-identical financial reports, the export did not happen —
-> report it and retry rather than explaining it away.
-
-### Rule 3 — verify the marketplace from the file itself (decisive)
-
-**Both files self-identify.** This is the strongest check available and the
-one that proves *which* marketplace a file holds. Run it on every file
-before it goes into a marketplace directory:
-
-| file | column | values |
-|---|---|---|
-| `storage.csv` | `country_code` | `SA`, `AE`, … |
-| monthly transaction CSV | `marketplace` | `amazon.sa`, `amazon.ae`, … (case varies between exports) |
+Both remaining rules read the same two things off a file, so one command
+covers them. It takes the paths as arguments, finds the header row by shape
+(the first row with more than five fields — these exports carry preamble
+lines), then reads the marketplace column **by name**, and streams both the
+hash and the rows so a large export costs no memory:
 
 ```bash
-# storage.csv
-awk -F'","' 'NR>1{print $5}' storage.csv | sort -u   # one value, the expected marketplace
-
-# transaction CSV — its header is the first row with >5 fields, so find it
-python3 - "$FILE" <<'PY'
-import csv, sys
-rows = list(csv.reader(open(sys.argv[1], encoding='utf-8-sig')))
-hi = next(i for i, r in enumerate(rows) if len(r) > 5)
-hdr = [h.strip().lower() for h in rows[hi]]
-mi = hdr.index('marketplace')
-print(sorted({r[mi].strip().lower() for r in rows[hi+1:] if len(r) > mi and r[mi].strip()}))
+python3 - reports_07_<cc1>_<slug>/2026JulMonthlyTransaction.csv \
+          reports_07_<cc2>_<slug>/2026JulMonthlyTransaction.csv <<'PY'
+import csv, hashlib, sys
+for path in sys.argv[1:]:
+    digest = hashlib.md5()
+    with open(path, 'rb') as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b''):
+            digest.update(chunk)
+    with open(path, newline='', encoding='utf-8-sig') as fh:
+        rows = csv.reader(fh)
+        header = next(r for r in rows if len(r) > 5)
+        cols = [c.strip().lower() for c in header]
+        name = 'marketplace' if 'marketplace' in cols else 'country_code'
+        i = cols.index(name)
+        seen = {r[i].strip().lower() for r in rows if len(r) > i and r[i].strip()}
+    print(f'{path}\n  md5={digest.hexdigest()}\n  {name}={sorted(seen)}')
 PY
 ```
 
-Anything other than the marketplace you intended means you are holding the
-other one's export — treat it exactly like Rule 2's hash match: redo the
-export, never rename the file and hope.
+`hashlib` rather than a shell tool on purpose: `md5sum` is coreutils, `md5`
+is macOS/BSD, and these skills run on both.
 
-Rules 1 and 2 still apply. This rule proves which marketplace a file is;
-Rules 1 and 2 catch the case where the second export never happened at all,
-which is what actually went wrong in production.
+### Rule 3 — the file names its own marketplace, so assert it
+
+This is the **decisive** check and the one to run on every file, because it
+proves *which* marketplace a file holds:
+
+| file | column | per-marketplace? |
+|---|---|---|
+| monthly transaction CSV | `marketplace` | **yes** — exactly one value, always |
+| `storage.csv` | `country_code` | **not necessarily** — see Rule 2 |
+
+The failure is a file whose values **do not include the marketplace you are
+writing it into**. That means you are holding the other one's export: redo
+it, never rename the file and hope.
+
+### Rule 2 — for the transaction CSV, identical hashes are a HARD FAILURE
+
+The transaction export is strictly per-marketplace, so two marketplaces can
+never legitimately produce the same bytes. Equal digests mean one export
+never happened and you are looking at one file twice. Redo that
+marketplace — reopen the picker, confirm the header shows the intended
+marketplace, download again.
+
+**`storage.csv` is the exception, and it is a real one.** On a seller
+account spanning several marketplaces this export can be account-level:
+observed in the wild as a single file, byte-identical in both marketplace
+folders, whose `country_code` column contains **both** codes. That is
+legitimate — consumers filter it by `country_code` — so do not treat a hash
+match on `storage.csv` as a failure by itself. Judge it by Rule 3: both
+codes present is fine; only the wrong code present is not.
+
+> What is never acceptable is skipping the check. A past run compared two
+> storage files, found the same MD5, concluded "the report is account-level,
+> that's fine for downstream use", and shipped **transaction** data twice on
+> the strength of that reasoning. Account-level exports do exist — that
+> intuition was not the error. Applying it to a per-marketplace file, and
+> using it as a reason not to verify, was.
+
+Rules 2 and 3 answer different questions and you want both: Rule 3 proves
+which marketplace a file is, Rule 2 catches the case where a second
+transaction export never happened at all — which is what actually reached
+production.
 
 ### Rule 4 — report what is missing, never substitute
 

--- a/app/skills_v2/amazon-reports/SKILL.md
+++ b/app/skills_v2/amazon-reports/SKILL.md
@@ -266,6 +266,105 @@ print(info)
 PY
 ```
 
+## Critical: One Account, Two Marketplaces — Never Reuse a Download
+
+A seller account can span several marketplaces (a MENA account serves both
+SA and AE). Seller Central then **ignores the URL subdomain and serves the
+session's last active marketplace**, and the reports come down under names
+that carry no marketplace at all:
+
+    2026JulMonthlyTransaction.csv     <- same name for SA and for AE
+    storage.csv                       <- same name for SA and for AE
+
+Both land in the one store downloads dir, so the second marketplace's
+download **silently overwrites the first**. And if that second download
+then fails, is slow, or is never actually triggered, `ls -lt` still
+returns a file under the expected name — the *first* marketplace's — and
+the agent copies one marketplace's money into both marketplaces' folders.
+
+This is not hypothetical. It reached production: a month's report set had
+one marketplace carrying a second copy of its sibling's revenue, because
+the same CSV was copied into both target directories.
+
+### Rule 1 — rename before switching marketplace
+
+Download → **immediately** move the file to its target directory under its
+final name → only then switch marketplace and download the next. Never
+download both marketplaces and sort it out afterwards.
+
+```bash
+DL=~/.vibe-seller/downloads/<slug>
+# marketplace 1: download, then move it out at once
+mv "$DL/2026JulMonthlyTransaction.csv" reports_07_<cc1>_<slug>/2026JulMonthlyTransaction.csv
+# only now switch the marketplace picker and download the second
+mv "$DL/2026JulMonthlyTransaction.csv" reports_07_<cc2>_<slug>/2026JulMonthlyTransaction.csv
+```
+
+`mv`, not `cp`: it leaves nothing behind in the downloads dir for the next
+step to pick up by mistake.
+
+### Rule 2 — identical bytes across two marketplaces is a HARD FAILURE
+
+Once both are in place, compare them. **Never reason your way past a
+match.**
+
+```bash
+md5 reports_07_<cc1>_<slug>/2026JulMonthlyTransaction.csv \
+    reports_07_<cc2>_<slug>/2026JulMonthlyTransaction.csv
+```
+
+Equal hashes mean one marketplace was never exported. Redo that
+marketplace: reopen the picker, confirm the header shows the intended
+marketplace, download again.
+
+> Transaction and storage reports are **per-marketplace**. They are NOT
+> account-level. A past run compared two storage files, found the same
+> MD5, concluded "the report is account-level, that's fine for downstream
+> use", and shipped one marketplace's numbers twice. If two marketplaces
+> produce byte-identical financial reports, the export did not happen —
+> report it and retry rather than explaining it away.
+
+### Rule 3 — verify the marketplace from the file itself (decisive)
+
+**Both files self-identify.** This is the strongest check available and the
+one that proves *which* marketplace a file holds. Run it on every file
+before it goes into a marketplace directory:
+
+| file | column | values |
+|---|---|---|
+| `storage.csv` | `country_code` | `SA`, `AE`, … |
+| monthly transaction CSV | `marketplace` | `amazon.sa`, `amazon.ae`, … (case varies between exports) |
+
+```bash
+# storage.csv
+awk -F'","' 'NR>1{print $5}' storage.csv | sort -u   # one value, the expected marketplace
+
+# transaction CSV — its header is the first row with >5 fields, so find it
+python3 - "$FILE" <<'PY'
+import csv, sys
+rows = list(csv.reader(open(sys.argv[1], encoding='utf-8-sig')))
+hi = next(i for i, r in enumerate(rows) if len(r) > 5)
+hdr = [h.strip().lower() for h in rows[hi]]
+mi = hdr.index('marketplace')
+print(sorted({r[mi].strip().lower() for r in rows[hi+1:] if len(r) > mi and r[mi].strip()}))
+PY
+```
+
+Anything other than the marketplace you intended means you are holding the
+other one's export — treat it exactly like Rule 2's hash match: redo the
+export, never rename the file and hope.
+
+Rules 1 and 2 still apply. This rule proves which marketplace a file is;
+Rules 1 and 2 catch the case where the second export never happened at all,
+which is what actually went wrong in production.
+
+### Rule 4 — report what is missing, never substitute
+
+If a marketplace's export cannot be produced, leave its directory empty and
+say so in the task result. An empty directory is recoverable. A directory
+holding another marketplace's numbers is silently wrong and reaches
+downstream consumers looking like real data.
+
 ## Report Types Overview
 
 ### A. Seller Central Reports (via hamburger menu → Reports)


### PR DESCRIPTION
A seller account can span several marketplaces. Seller Central then **ignores the URL subdomain and serves the session's last active marketplace**, and the monthly transaction and storage reports come down under names that carry no marketplace at all:

```
2026JulMonthlyTransaction.csv     same name for both marketplaces
storage.csv                       same name for both marketplaces
```

Both land in the one store downloads dir, so the second marketplace's download **silently overwrites the first**. When that second download then fails, is slow, or is never triggered, `ls -lt` still returns a file under the expected name — the *first* marketplace's — and the agent copies one marketplace's money into both target directories.

**This reached production.** A month's report set had one marketplace carrying a second copy of its sibling's revenue.

## The agent had the evidence and talked itself out of it

From the run that produced the bad data — it compared two storage files, saw the same MD5, and reasoned:

> Both files are identical (same MD5). The report is account-level. That's fine for downstream use.

Then shipped it. Nothing in this skill said otherwise, so four rules now do:

1. **Move each file to its target directory under its final name BEFORE switching marketplace** — `mv`, not `cp`, so nothing is left behind for the next step to pick up by mistake.
2. **For the transaction CSV, identical hashes across two marketplaces are a HARD FAILURE** — it is strictly per-marketplace, so that means one export never happened. `storage.csv` is a genuine exception (below).
3. **Assert the marketplace from the file itself** — the decisive check. The transaction CSV carries a `marketplace` column, `storage.csv` a `country_code` column.
4. **Leave a directory empty and say so rather than substituting.** An empty directory is recoverable; one holding another marketplace's numbers is silently wrong and looks like real data downstream.

## The rule I got wrong, and how

The first draft made *any* identical hash a hard failure. Fixing the review comment about the positional `awk` meant parsing `country_code` by name — and running that against two real `storage.csv` files returned the same digest for both **and** `country_code` holding *both* marketplace codes.

That export is **account-level**: one file covering both marketplaces, which consumers filter by `country_code`. My rule would have flagged it as a failure and sent agents into a re-download loop chasing a non-problem. Rule 2 is now scoped to the transaction CSV and `storage.csv` is judged by Rule 3 instead — both codes present is fine, only the wrong code is not.

Which also means the reasoning quoted above was **half right**, and the doc now says so. Account-level exports do exist; that belief was not the error. Applying it to a per-marketplace file, and using it as grounds not to verify, was.

## Review comments

All five addressed:

| comment | fix |
|---|---|
| PR body carried live metrics (policy § *No real customer data*) | body rewritten with illustrative values only — this revision |
| `storage.csv` check was positional `awk -F'","' '{print $5}'` | parse by column name; this is what surfaced the rule bug above |
| transaction check read the whole file into memory | streams rows; hash streams in 1 MiB chunks |
| `$FILE` undefined, so the "decisive" step failed on copy/paste | paths passed as arguments |
| `md5` is not on most Linux hosts | `hashlib`, no external tool |

The snippet was verified by extracting it from the committed file and running it against real exports of both kinds — a transaction CSV pair (distinct digests, one `marketplace` value each) and a `storage.csv` pair (identical digest, both `country_code` values), which is exactly the pair of outcomes the rules now distinguish.

## Relationship to `app/browser/downloads.py`

That module archives the store downloads dir at browser start, so stale same-named files from a previous month cannot be picked up — collisions **across** sessions. This fixes collisions **within** one session, which is the case its docstring defers to ("Within one session the skills already require renaming each file immediately after download"). That requirement was not actually written down anywhere; now it is.

Docs only — no code paths change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
