### PR TITLE
fix(tasks): a task with no store still has to launch

### DIFF
--- a/app/routers/schedule_planning.py
+++ b/app/routers/schedule_planning.py
@@ -28,7 +28,7 @@ from app.models.schedule_constants import PhaseMode
 from app.models.task import Task
 from app.models.user import User
 from app.plan_states import PlanStatus
-from app.routers.tasks import schedule_or_run
+from app.task_launch import schedule_or_run
 from app.task_states import TaskStatus, can_transition
 
 logger = logging.getLogger(__name__)

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -1,5 +1,3 @@
-import asyncio
-from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 import json
 import logging
@@ -45,6 +43,7 @@ from app.scheduler.task_queue import task_queue_scheduler
 from app.schemas.task import TaskCreate, TaskResponse, TaskStepResponse
 from app.schemas.user import TaskModeToggle
 from app.task_delete import delete_task as delete_task_record
+from app.task_launch import schedule_or_run
 from app.task_outcome import apply_outcome, resolve_outcome
 from app.task_runner import (
     TaskHeader,
@@ -54,7 +53,6 @@ from app.task_runner import (
     get_store_emails,
     reopen_parent_if_child_active,
 )
-from app.task_runner_auto import auto_run_task
 from app.task_runner_exec import execute_planned_task
 from app.task_states import (
     DESIGNABLE,
@@ -215,33 +213,6 @@ async def create_task(
     return task
 
 
-async def schedule_or_run(
-    task_id: str,
-    store: Store | None,
-    launcher: Callable | None = None,
-):
-    """Route store tasks through the queue scheduler.
-
-    No-store tasks launch immediately (no browser conflict
-    possible).  Store tasks go through the queue so the
-    same-platform/different-country QUEUE rule is enforced.
-
-    Falls back to direct launch if the scheduler hasn't
-    started (e.g. in tests without full app lifespan).
-
-    *launcher* defaults to ``auto_run_task``; pass
-    ``execute_planned_task`` for tasks that already have
-    a plan.  Note: when routing through the queue the
-    launcher is ignored — _dispatch() picks the right
-    handler from task state.
-    """
-    fn = launcher or auto_run_task
-    if store and task_queue_scheduler.is_running:
-        await task_queue_scheduler.submit(task_id, store.id)
-    else:
-        asyncio.create_task(fn(task_id, store))
-
-
 @router.get('/{task_id}', response_model=TaskResponse)
 async def get_task(
     task_id: str,
@@ -284,6 +255,22 @@ async def start_task(
     db: AsyncSession = Depends(get_db),
     _user: User = Depends(get_current_user),
 ):
+    """Launch a task that isn't running yet.
+
+    Two callers, one meaning — "launch this task": the manual Run
+    button, and the resume half of the deferred create flow
+    (``defer_start``: the client uploads attachments into the workspace
+    first, then POSTs here so the agent's prompt sees them).  It must
+    therefore accept every task shape ``create_task`` accepts.
+
+    Routing is delegated to ``schedule_or_run``.  This endpoint used to
+    re-derive it inline — queue-submit, and 400 unless the task had a
+    store — which predated ``defer_start``, back when /start meant only
+    "start a browser task".  Once create started deferring, that guard
+    became a dead end: a no-store task with an attachment was never
+    launched by create, was refused by /start, and sat at PENDING with
+    no error for the user to see.
+    """
     task = await db.get(Task, task_id)
     if not task:
         raise HTTPException(status_code=404, detail='Task not found')
@@ -293,23 +280,20 @@ async def start_task(
             detail=f'Cannot start task in status {task.status}',
         )
 
-    if not task.store_id:
-        raise HTTPException(
-            status_code=400,
-            detail='Cannot start browser task without a store. Assign a store first.',
-        )
+    store = None
+    if task.store_id:
+        store = await db.get(Store, task.store_id)
+        if not store:
+            raise HTTPException(status_code=404, detail='Store not found')
 
-    store = await db.get(Store, task.store_id)
-    if not store:
-        raise HTTPException(status_code=404, detail='Store not found')
-
-    # Submit to task queue scheduler (handles browser sessions + concurrency)
-    await task_queue_scheduler.submit(task_id, store.id)
+    queued = await schedule_or_run(task_id, store)
 
     return {
         'ok': True,
         'task_id': task_id,
-        'status': TaskStatus.QUEUED,
+        # Only the queue parks the task at QUEUED; a direct launch
+        # leaves it where it was until the launcher moves it.
+        'status': TaskStatus.QUEUED if queued else task.status,
     }
 
 

--- a/app/routers/tasks_conversation.py
+++ b/app/routers/tasks_conversation.py
@@ -13,7 +13,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import vision
 from app.ai.claude_backend_manager import agent_manager
-from app.ai.compaction import build_history_prompt, dump_history_file
 from app.ai.profiles import DEFAULT_PROFILE_ID
 from app.auth import get_current_user
 from app.browser.manager import browser_manager
@@ -28,9 +27,10 @@ from app.models.task_step import TaskStep
 from app.models.user import User
 from app.plan_states import PlanStatus
 from app.routers.dida365_oauth import refresh_token_if_needed
-from app.routers.tasks import schedule_or_run
 from app.routers.tasks_files import promote_staged_attachments
 from app.scheduler.task_queue import task_queue_scheduler
+from app.task_chat_context import build_chat_context
+from app.task_launch import schedule_or_run
 from app.task_outcome import clear_run_state
 from app.task_runner import (
     TaskHeader,
@@ -331,86 +331,13 @@ async def send_task_message(
         )
     )
 
-    # When resuming, skip conversation reconstruction — the CLI
-    # session already has all prior context. Only inject mode
-    # switch instructions and the plan feedback instruction.
-    conversation_context = ''
-    if has_resumable_session:
-        if is_plan_feedback:
-            conversation_context = (
-                '\n\nIMPORTANT: Your final output MUST be the '
-                'COMPLETE revised plan — not just the changes '
-                'or a summary. Include all original sections '
-                '(updated as needed) so the plan can fully '
-                'replace the previous version. '
-                'If the user asks questions, use '
-                'AskUserQuestion to ask them interactively, '
-                'then revise the plan after receiving answers.'
-            )
-    else:
-        # No resumable session — build full context from DB
-        result = await db.execute(
-            select(TaskMessage)
-            .where(TaskMessage.task_id == task_id)
-            .order_by(TaskMessage.seq)
-        )
-        messages = result.scalars().all()
-
-        # Always dump history file so the agent can read
-        # prior conversation on demand (even when a plan
-        # is shown inline).
-        prior_msgs = [
-            m
-            for m in messages
-            if m.role in ('user', 'assistant') and m.id != user_message.id
-        ]
-        history_file = None
-        if prior_msgs:
-            history_dicts = [
-                {
-                    'role': m.role,
-                    'content': m.content,
-                    'seq': m.seq,
-                }
-                for m in prior_msgs
-            ]
-            history_file = dump_history_file(task_id, history_dicts)
-
-        if is_plan_feedback and task.plan:
-            conversation_context = (
-                '\n\n## Current Plan (draft, not yet confirmed)\n'
-                'The following plan was designed in a previous '
-                'session. The user is providing feedback to '
-                'revise or extend it.\n\n'
-                'IMPORTANT: Your final output MUST be the '
-                'COMPLETE revised plan — not just the changes '
-                'or a summary. Include all original sections '
-                '(updated as needed) so the plan can fully '
-                'replace the previous version. '
-                'If the user asks questions, use '
-                'AskUserQuestion to ask them interactively, '
-                'then revise the plan after receiving '
-                'answers.\n\n' + task.plan
-            )
-        elif task.plan:
-            conversation_context = '\n\n## Task Plan\n' + task.plan
-        else:
-            if prior_msgs and history_file:
-                conversation_context = (
-                    '\n\n## Prior Conversation\n'
-                    + build_history_prompt(history_dicts, history_file)
-                )
-
-        # Add history file reference to system prompt when
-        # a plan was shown inline (agent can read full
-        # conversation from the file if needed).
-        if history_file and task.plan:
-            conversation_context += (
-                f'\n\nNote: Full conversation history '
-                f'({len(prior_msgs)} messages) is saved '
-                f'at {history_file}. Read it if you need '
-                f'context from prior discussion.'
-            )
+    conversation_context = await build_chat_context(
+        task,
+        db,
+        exclude_message_id=user_message.id,
+        is_plan_feedback=is_plan_feedback,
+        has_resumable_session=has_resumable_session,
+    )
 
     # Build full system prompt with all context
     store = await db.get(Store, task.store_id) if task.store_id else None

--- a/app/scheduler/task_queue.py
+++ b/app/scheduler/task_queue.py
@@ -413,10 +413,13 @@ class TaskQueueScheduler:
                 .order_by(Task.created_at)
             )
             for task in result.scalars().all():
-                if task.store_id:
-                    if task.store_id not in self._queues:
-                        self._queues[task.store_id] = []
-                    self._queues[task.store_id].append(task.id)
+                # store_id may be None — same reasoning as the PLANNED
+                # recovery below: None is a valid lane key and _dispatch
+                # handles a store-less task. Gating on store_id here
+                # meant a no-store PENDING task had NO recovery path,
+                # the third place (with create's defer_start and
+                # /start) where "no store" silently meant "never runs".
+                self._queues.setdefault(task.store_id, []).append(task.id)
 
             # Scheduled plan-mode tasks left in PLANNED (frozen plan
             # copied by the fanout/cron fire, awaiting a concurrency

--- a/app/task_chat_context.py
+++ b/app/task_chat_context.py
@@ -11,16 +11,12 @@ Extracted from ``app.routers.tasks_conversation`` so the message handler
 reads as routing rather than prompt-assembly.
 """
 
-import logging
-
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.compaction import build_history_prompt, dump_history_file
 from app.models.task import Task
 from app.models.task_message import TaskMessage
-
-logger = logging.getLogger(__name__)
 
 _REVISED_PLAN_INSTRUCTION = (
     'IMPORTANT: Your final output MUST be the '

--- a/app/task_chat_context.py
+++ b/app/task_chat_context.py
@@ -1,0 +1,122 @@
+"""What a chat turn has to tell the agent beyond the message itself.
+
+``POST /messages`` delivers the user's message as the prompt, replacing
+the ``bundle.prompt`` that ``_format_header`` builds from the task's own
+title and description. That is right for a follow-up — by then the task
+is already in the resumed CLI session or in the prior conversation — but
+it means everything else the turn needs (the draft plan, prior history,
+and on the first turn the task itself) has to be assembled here.
+
+Extracted from ``app.routers.tasks_conversation`` so the message handler
+reads as routing rather than prompt-assembly.
+"""
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.ai.compaction import build_history_prompt, dump_history_file
+from app.models.task import Task
+from app.models.task_message import TaskMessage
+
+logger = logging.getLogger(__name__)
+
+_REVISED_PLAN_INSTRUCTION = (
+    'IMPORTANT: Your final output MUST be the '
+    'COMPLETE revised plan — not just the changes '
+    'or a summary. Include all original sections '
+    '(updated as needed) so the plan can fully '
+    'replace the previous version. '
+    'If the user asks questions, use '
+    'AskUserQuestion to ask them interactively, '
+    'then revise the plan after receiving answers.'
+)
+
+
+async def build_chat_context(
+    task: Task,
+    db: AsyncSession,
+    *,
+    exclude_message_id: str,
+    is_plan_feedback: bool,
+    has_resumable_session: bool,
+) -> str:
+    """Assemble the ``extra_context`` for one chat turn.
+
+    ``exclude_message_id`` is the message being delivered right now — it
+    is already the prompt, so it must not also appear as history.
+    """
+    # When resuming, skip conversation reconstruction — the CLI
+    # session already has all prior context. Only inject mode
+    # switch instructions and the plan feedback instruction.
+    if has_resumable_session:
+        return f'\n\n{_REVISED_PLAN_INSTRUCTION}' if is_plan_feedback else ''
+
+    # No resumable session — build full context from DB
+    result = await db.execute(
+        select(TaskMessage)
+        .where(TaskMessage.task_id == task.id)
+        .order_by(TaskMessage.seq)
+    )
+    messages = result.scalars().all()
+
+    # Always dump history file so the agent can read
+    # prior conversation on demand (even when a plan
+    # is shown inline).
+    prior_msgs = [
+        m
+        for m in messages
+        if m.role in ('user', 'assistant') and m.id != exclude_message_id
+    ]
+    history_file = None
+    history_dicts: list[dict] = []
+    if prior_msgs:
+        history_dicts = [
+            {'role': m.role, 'content': m.content, 'seq': m.seq}
+            for m in prior_msgs
+        ]
+        history_file = dump_history_file(task.id, history_dicts)
+
+    if is_plan_feedback and task.plan:
+        context = (
+            '\n\n## Current Plan (draft, not yet confirmed)\n'
+            'The following plan was designed in a previous '
+            'session. The user is providing feedback to '
+            'revise or extend it.\n\n'
+            f'{_REVISED_PLAN_INSTRUCTION}\n\n' + task.plan
+        )
+    elif task.plan:
+        context = '\n\n## Task Plan\n' + task.plan
+    elif not prior_msgs and task.description:
+        # FIRST turn of a task that has never run. Every other entry
+        # point delivers the task's own description via bundle.prompt
+        # (_format_header); this one replaces that prompt with the chat
+        # message, and normally the description is already in the
+        # resumed session or the prior conversation. With neither — a
+        # PENDING task the user messages before it has ever started —
+        # the description reaches the agent NOWHERE: nothing in
+        # system_extra carries it. Observed live on a task carrying a
+        # description plus image attachments: the agent got a bare
+        # "please start", read the images, found no instructions, and
+        # stopped to ask the user what the task was, with the answer
+        # sitting unread in its own ``description`` column.
+        context = f'\n\n## Task\n{task.title}\n\n{task.description}'
+    elif prior_msgs and history_file:
+        context = '\n\n## Prior Conversation\n' + build_history_prompt(
+            history_dicts, history_file
+        )
+    else:
+        context = ''
+
+    # Add history file reference to system prompt when
+    # a plan was shown inline (agent can read full
+    # conversation from the file if needed).
+    if history_file and task.plan:
+        context += (
+            f'\n\nNote: Full conversation history '
+            f'({len(prior_msgs)} messages) is saved '
+            f'at {history_file}. Read it if you need '
+            f'context from prior discussion.'
+        )
+    return context

--- a/app/task_launch.py
+++ b/app/task_launch.py
@@ -1,0 +1,52 @@
+"""The single owner of "how does a task start running".
+
+Extracted from ``app.routers.tasks`` because two other routers already
+imported it from there — a router reaching into another router for the
+rule is the shape that lets the rule drift. It has drifted once:
+``/start`` re-derived a narrower, store-only version of this routing and
+so refused every no-store task, which stranded any task created with an
+attachment (create defers the launch, /start was the only way to resume
+it). Keep the rule here, and let callers ask rather than re-decide.
+"""
+
+import asyncio
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from app.scheduler.task_queue import task_queue_scheduler
+from app.task_runner_auto import auto_run_task
+
+if TYPE_CHECKING:
+    from app.models.store import Store
+
+
+async def schedule_or_run(
+    task_id: str,
+    store: 'Store | None',
+    launcher: Callable | None = None,
+) -> bool:
+    """Route store tasks through the queue scheduler.
+
+    No-store tasks launch immediately (no browser conflict
+    possible).  Store tasks go through the queue so the
+    same-platform/different-country QUEUE rule is enforced.
+
+    Falls back to direct launch if the scheduler hasn't
+    started (e.g. in tests without full app lifespan).
+
+    *launcher* defaults to ``auto_run_task``; pass
+    ``execute_planned_task`` for tasks that already have
+    a plan.  Note: when routing through the queue the
+    launcher is ignored — _dispatch() picks the right
+    handler from task state.
+
+    Returns True when the task went to the queue (so it is now QUEUED),
+    False when it was launched directly (status unchanged for now — the
+    launcher moves it).
+    """
+    fn = launcher or auto_run_task
+    if store and task_queue_scheduler.is_running:
+        await task_queue_scheduler.submit(task_id, store.id)
+        return True
+    asyncio.create_task(fn(task_id, store))
+    return False

--- a/app/workspace/manager.py
+++ b/app/workspace/manager.py
@@ -26,6 +26,15 @@ from app.workspace.templates import WORKSPACE_CLAUDE_MD
 
 logger = logging.getLogger(__name__)
 
+# Kept when a retry wipes a task workspace (``clean=True``). ``uploads/``
+# holds files the USER supplied — create-time attachments and chat
+# uploads — not run output. They are referenced by ``task_attachments``
+# rows that a retry does not delete, and ``uploaded_files_note()`` reads
+# them off disk to build every run's prompt. Wiping them turned a retry
+# of an image task back into the "where is the image?" bug that putting
+# attachments in the workspace was meant to fix.
+PRESERVED_ON_CLEAN = ('uploads',)
+
 
 class WorkspaceManager(SkillsMixin):
     """File operations + git auto-commit for ~/.vibe-seller/."""
@@ -560,11 +569,16 @@ browser: {backend}
         no-store (orchestrator) tasks — they now have the store-less
         ``web`` browser for neutral public web work, so they need the
         skill's CLI reference too.
+
+        ``clean=True`` (retry) wipes the run's residue but KEEPS
+        ``PRESERVED_ON_CLEAN`` — see the constant.
         """
         await self.ensure_init()
         task_dir = self.root / 'tasks' / task_id
         if clean and task_dir.exists():
-            task_links.remove_task_workspace(task_dir)
+            task_links.remove_task_workspace(
+                task_dir, preserve=PRESERVED_ON_CLEAN
+            )
         task_dir.mkdir(parents=True, exist_ok=True)
 
         links: dict[str, Path] = {
@@ -610,8 +624,12 @@ def reset_task_runtime_state(task_id: str) -> None:
     like a brand-new task. Clearing the DB rows is not enough: two stores
     outlive it and leak prior-run context into the fresh session.
 
-    1. The task workspace ``tasks/{id}/`` (uploads, generated_images, the
-       copied .claude skills, symlinks) — rebuilt by prepare_task_workspace.
+    1. The task workspace ``tasks/{id}/`` (generated_images, the copied
+       .claude skills, symlinks) — rebuilt by prepare_task_workspace.
+       ``PRESERVED_ON_CLEAN`` survives: prior-run *residue* is what must
+       not leak, and the user's own attachments are neither residue nor
+       reproducible — the retry keeps their ``task_attachments`` rows,
+       and nothing re-uploads the files.
     2. Claude Code's per-task Task/todo store. We pin a STABLE
        ``CLAUDE_CODE_TASK_LIST_ID='vibe-<id8>'`` (claude_backend.py) so a
        task's todos survive its own follow-ups/resumes — but that means a
@@ -621,7 +639,10 @@ def reset_task_runtime_state(task_id: str) -> None:
        (each ``/`` and ``.`` → ``-``), under ``.../projects/<cwd>/``.
     """
     task_dir = VIBE_SELLER_DIR / 'tasks' / task_id
-    shutil.rmtree(task_dir, ignore_errors=True)
+    try:
+        task_links.remove_task_workspace(task_dir, preserve=PRESERVED_ON_CLEAN)
+    except OSError:
+        logger.exception('Failed to reset workspace for task %s', task_id)
 
     claude_home = Path(
         os.environ.get('CLAUDE_CONFIG_DIR') or (Path.home() / '.claude')

--- a/app/workspace/task_links.py
+++ b/app/workspace/task_links.py
@@ -108,13 +108,10 @@ def remove_task_workspace(
         return
     keep = set(preserve)
     for child in task_dir.iterdir():
-        if child.name in keep:
-            continue
-        if (
-            child.is_dir()
-            and not child.is_symlink()
-            and not _is_junction(child)
-        ):
-            shutil.rmtree(child)
-        else:
-            child.unlink()
+        if child.name not in keep:
+            # Same four cases the shared links need — symlink, Windows
+            # junction, real dir, plain file — so reuse that helper
+            # rather than re-deciding. Hand-rolling it here got the
+            # junction wrong: a reparse point is a *directory*, so
+            # ``unlink()`` raises IsADirectoryError and the retry fails.
+            _clear_workspace_link(child)

--- a/app/workspace/task_links.py
+++ b/app/workspace/task_links.py
@@ -10,6 +10,7 @@ does NOT hold, which raised ``WinError 1314`` on task creation.
 Junctions and copies need no privilege, so the app runs as a plain user.
 """
 
+from collections.abc import Sequence
 import os
 from pathlib import Path
 import shutil
@@ -77,12 +78,21 @@ def _link_shared_into_task(link_path: Path, target: Path) -> None:
         shutil.copy2(target, link_path)
 
 
-def remove_task_workspace(task_dir: Path) -> None:
+def remove_task_workspace(
+    task_dir: Path,
+    preserve: Sequence[str] = (),
+) -> None:
     """Delete a task workspace dir without touching shared resources.
 
     Clears the shared-resource links first so the final ``rmtree`` can
     never descend a junction into shared knowledge/stores, then removes
     the task-local files. Safe to call on POSIX (symlinks) too.
+
+    *preserve* names top-level entries to keep, emptying the dir around
+    them instead of removing it. Used by the retry path to keep
+    user-supplied inputs (``uploads/``) that outlive a run — deleting
+    them leaves the surviving ``task_attachments`` rows pointing at
+    nothing. Teardown callers pass nothing and get the full wipe.
 
     Raises on failure (e.g. a locked file) rather than swallowing it, so
     ``clean=True`` callers surface the error as they did before this
@@ -93,4 +103,18 @@ def remove_task_workspace(task_dir: Path) -> None:
         return
     for name in _SHARED_LINK_NAMES:
         _clear_workspace_link(task_dir / name)
-    shutil.rmtree(task_dir)
+    if not preserve or task_dir.is_symlink():
+        shutil.rmtree(task_dir)
+        return
+    keep = set(preserve)
+    for child in task_dir.iterdir():
+        if child.name in keep:
+            continue
+        if (
+            child.is_dir()
+            and not child.is_symlink()
+            and not _is_junction(child)
+        ):
+            shutil.rmtree(child)
+        else:
+            child.unlink()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,7 @@ import { SettingsView, type SettingsTab } from './views/SettingsView'
 import { useSSE } from './hooks/useSSE'
 import { parseNav, settingsTabToSlug } from './lib/route'
 import { loadTaskById as loadTaskByIdHandler } from './handlers/loadTaskById'
-import { api, AUTH_EXPIRED_EVENT } from './api'
+import { api, AUTH_EXPIRED_EVENT, uploadTaskAttachment } from './api'
 import { triggerSchedule as triggerScheduleHandler } from './handlers/triggerSchedule'
 import { replanSchedule as replanScheduleHandler } from './handlers/replanSchedule'
 import { selectSchedule as selectScheduleHandler } from './handlers/selectSchedule'
@@ -576,12 +576,12 @@ export default function App() {
         planMode: selectedStore ? (currentUser?.plan_mode_default ?? false) : true,
         setTasks,
         setSelectedTask,
-        uploadAttachment: async (taskId, pf) => {
-          const form = new FormData()
-          form.append('file', pf.file)
-          await fetch(`/api/attachments/${taskId}`, { method: 'POST', body: form, credentials: 'include' })
-        },
+        uploadAttachment: (taskId, pf) => uploadTaskAttachment(taskId, pf.file),
         startTask: async (taskId) => { await api.post(`/api/tasks/${taskId}/start`, {}) },
+        // A deferred task that never launches stays PENDING with no
+        // error and emits no SSE — this alert is the only thing that
+        // tells the user their task is not going to run.
+        onStartError: (err) => alert(`${t('tasks.startFailed')}\n\n${err instanceof Error ? err.message : String(err)}`),
         onCreated: () => {
           setSteps([]); setScreenshots({}); setLogs([]); setConversationItems([]); setAgentMessages([]); setTodoItems([]); setPendingQuestions(null); setSelectedAnswers({}); setOtherInputs({}); setShowOtherInput({}); setChatInput(''); setChatAttachments([])
         },

--- a/frontend/src/__tests__/submitCreateTaskAttachments.test.ts
+++ b/frontend/src/__tests__/submitCreateTaskAttachments.test.ts
@@ -21,6 +21,7 @@ function deps(over: Record<string, unknown> = {}) {
       setTasks: vi.fn(), setSelectedTask: vi.fn(), onCreated: vi.fn(),
       uploadAttachment: vi.fn(async () => {}),
       startTask: vi.fn(async () => {}),
+      onStartError: vi.fn(),
       ...over,
     },
   }
@@ -58,6 +59,41 @@ describe('submitCreateTask with attachments', () => {
     await flush()
     expect(post).toHaveBeenCalledWith('/api/tasks', expect.objectContaining({ defer_start: false }))
     expect(d.uploadAttachment).not.toHaveBeenCalled()
+    expect(d.startTask).not.toHaveBeenCalled()
+  })
+
+  // The background upload→launch chain is the ONLY thing that moves a
+  // deferred task off PENDING. It used to `catch(() => {})` on the theory
+  // that "SSE / status will reflect any failure" — which cannot happen for
+  // a task that never launched: no status change, no task_update, no
+  // `error` column. A no-store task with an image hit exactly this (the
+  // /start 400) and sat at PENDING with the user shown nothing at all.
+  it('reports a failed start instead of swallowing it', async () => {
+    const boom = new Error('Cannot start browser task without a store.')
+    const { d } = deps({
+      startTask: vi.fn(async () => { throw boom }),
+      onStartError: vi.fn(),
+    })
+    await submitCreateTask({ title: 't', description: '', files: [file('a.png')] },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      d as any)
+    await flush(); await flush()
+    expect(d.onStartError).toHaveBeenCalledWith(boom)
+  })
+
+  it('reports a failed upload and never launches a task missing its files', async () => {
+    const boom = new Error('upload failed (500)')
+    const { d } = deps({
+      uploadAttachment: vi.fn(async () => { throw boom }),
+      onStartError: vi.fn(),
+    })
+    await submitCreateTask({ title: 't', description: '', files: [file('a.png')] },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      d as any)
+    await flush(); await flush()
+    expect(d.onStartError).toHaveBeenCalledWith(boom)
+    // Launching now would reproduce the original "where is the image?"
+    // bug: the agent starts with the file missing from its workspace.
     expect(d.startTask).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -46,3 +46,19 @@ export const api = {
   del: async (url: string) =>
     handleResponse(await fetch(url, { method: 'DELETE', credentials: 'include' })),
 }
+
+/**
+ * Upload one attachment into a task's workspace.
+ *
+ * Multipart, so it can't go through `api.post` (which sets a JSON
+ * content-type). It still has to REJECT on a non-2xx: a raw `fetch`
+ * resolves on 4xx/5xx, and an unchecked upload let the deferred launch
+ * proceed with the file missing from the workspace — the agent then asks
+ * for an image the user already attached.
+ */
+export const uploadTaskAttachment = async (taskId: string, file: File) => {
+  const form = new FormData()
+  form.append('file', file)
+  const r = await fetch(`/api/attachments/${taskId}`, { method: 'POST', body: form, credentials: 'include' })
+  if (!r.ok) throw new Error(`upload failed (${r.status})`)
+}

--- a/frontend/src/handlers/submitCreateTask.ts
+++ b/frontend/src/handlers/submitCreateTask.ts
@@ -43,6 +43,14 @@ export interface SubmitCreateTaskDeps {
   uploadAttachment?: (taskId: string, pf: PendingFile) => Promise<void>
   /** Launch a deferred task after its attachments are uploaded. */
   startTask?: (taskId: string) => Promise<void>
+  /**
+   * Called when the upload→launch chain fails. REQUIRED destination for
+   * that failure: a deferred task that never launches stays PENDING with
+   * no error column and emits no SSE, so there is nothing for the user to
+   * notice. This callback is the only thing standing between them and a
+   * task that silently never runs.
+   */
+  onStartError?: (err: unknown) => void
 }
 
 export interface SubmitCreateTaskInput {
@@ -89,7 +97,15 @@ export async function submitCreateTask(
         for (const pf of input.files) await deps.uploadAttachment(task.id, pf)
       }
       await deps.startTask?.(task.id)
-    })().catch(() => { /* SSE / status will reflect any failure */ })
+    })().catch(err => {
+      // Do NOT swallow. This used to `catch(() => {})` on the theory
+      // that "SSE / status will reflect any failure" — it cannot: the
+      // task never moved off PENDING, so no task_update is emitted and
+      // no `error` is stored. A no-store task created with an image hit
+      // exactly this and sat at PENDING indefinitely with the 400 from
+      // /start discarded here.
+      deps.onStartError?.(err)
+    })
   }
 
   // Race-guard refetch — see header comment.

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -200,7 +200,8 @@
     "wakeMessagePlaceholder": "Send a message to resume...",
     "followupPlaceholder": "Send a follow-up message...",
     "attachImage": "Attach image/file",
-    "attachedImage": "Image"
+    "attachedImage": "Image",
+    "startFailed": "Task created, but it could not be started. Its attachments may not have uploaded — open the task and retry."
   },
   "events": {
     "title": "Events",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -202,7 +202,8 @@
     "wakeMessagePlaceholder": "发送消息以恢复任务...",
     "followupPlaceholder": "发送后续消息...",
     "attachImage": "上传图片/文件",
-    "attachedImage": "图片"
+    "attachedImage": "图片",
+    "startFailed": "任务已创建，但未能启动。附件可能未上传成功——请打开任务后重试。"
   },
   "events": {
     "title": "事件",

--- a/tests/unit/test_followup_gate.py
+++ b/tests/unit/test_followup_gate.py
@@ -1,9 +1,10 @@
 """Unit tests for follow-up gate consistency:
 
-- ``reset_task_runtime_state`` wipes ALL on-disk state so a retry is a
+- ``reset_task_runtime_state`` wipes on-disk RUN RESIDUE so a retry is a
   true fresh start (workspace + Claude Code's per-task Task/todo store +
   project transcripts) — the fix for stale todos/refs leaking across a
-  retried task via the stable CLAUDE_CODE_TASK_LIST_ID.
+  retried task via the stable CLAUDE_CODE_TASK_LIST_ID — while keeping
+  ``uploads/``, which is the user's own input rather than residue.
 - ``interrupt_pending_question`` retires a pending AskUserQuestion with a
   NOTE (not the user's message, not recorded as answers) + emits
   ``task_question_interrupted`` — so a composer follow-up interrupts the
@@ -27,7 +28,18 @@ from app.workspace import manager as mgr
 pytestmark = pytest.mark.unit
 
 
-def test_reset_task_runtime_state_wipes_everything(tmp_path, monkeypatch):
+def test_reset_task_runtime_state_wipes_residue_keeps_uploads(
+    tmp_path, monkeypatch
+):
+    """Residue goes; the user's attachments stay.
+
+    This used to rmtree the whole workspace. ``uploads/`` is not run
+    residue — it holds files the USER attached, the retry keeps their
+    ``task_attachments`` rows, nothing re-uploads them, and every run's
+    prompt is built by reading them off disk. Wiping them turned a retry
+    of an image task back into "where is the image?" with the surviving
+    DB rows pointing at deleted files.
+    """
     vibe = tmp_path / 'vibe'
     claude = tmp_path / 'claude'
     monkeypatch.setattr(mgr, 'VIBE_SELLER_DIR', vibe)
@@ -37,6 +49,9 @@ def test_reset_task_runtime_state_wipes_everything(tmp_path, monkeypatch):
     ws = vibe / 'tasks' / tid
     (ws / 'uploads').mkdir(parents=True)
     (ws / 'uploads' / 'ref.jpg').write_text('img')
+    (ws / 'reviews').mkdir(parents=True)
+    (ws / 'reviews' / 'stale.json').write_text('{}')
+    (ws / 'notes.md').write_text('prior run scratch')
     store = claude / 'tasks' / f'vibe-{tid[:8]}'
     store.mkdir(parents=True)
     (store / '1.json').write_text('{"subject": "为产品图1生成白底主图"}')
@@ -47,7 +62,11 @@ def test_reset_task_runtime_state_wipes_everything(tmp_path, monkeypatch):
 
     mgr.reset_task_runtime_state(tid)
 
-    assert not ws.exists(), 'workspace (uploads etc.) must be wiped'
+    assert not (ws / 'reviews').exists(), 'run residue must be wiped'
+    assert not (ws / 'notes.md').exists(), 'run residue must be wiped'
+    assert (ws / 'uploads' / 'ref.jpg').read_text() == 'img', (
+        'user-supplied attachments must survive a retry'
+    )
     assert not store.exists(), 'Claude Code Task/todo store must be wiped'
     assert not proj.exists(), 'Claude Code project transcripts must be wiped'
 

--- a/tests/unit/test_task_queue.py
+++ b/tests/unit/test_task_queue.py
@@ -315,6 +315,27 @@ class TestRecovery:
 
         assert 'task-1' in scheduler._queues.get('store-1', [])
 
+    @pytest.mark.parametrize('status', [TaskStatus.PENDING, TaskStatus.QUEUED])
+    async def test_no_store_task_re_enqueued(
+        self, db_session, store_and_task, status
+    ):
+        """A store-less task must also survive a restart.
+
+        Recovery gated the re-queue on ``task.store_id``, so a no-store
+        PENDING task had no recovery path — the third place (with
+        create's ``defer_start`` and ``/start``) where "no store"
+        silently meant "never runs". ``None`` is a valid queue lane and
+        ``_dispatch`` already handles a store-less task, which is why the
+        PLANNED recovery right below it enqueues unconditionally.
+        """
+        await store_and_task(status=status, store_id=None)
+        scheduler = TaskQueueScheduler()
+
+        with patch('app.scheduler.task_queue.async_session', db_session):
+            await scheduler._recover_from_db()
+
+        assert 'task-1' in scheduler._queues.get(None, [])
+
     async def test_planned_scheduled_re_enqueued(
         self, db_session, store_and_task
     ):

--- a/tests/unit/test_workspace_symlinks.py
+++ b/tests/unit/test_workspace_symlinks.py
@@ -234,3 +234,37 @@ async def test_venv_not_copied_to_task(ws):
     assert not (
         task_dir / '.claude' / 'skills' / 'test-skill' / '__pycache__'
     ).exists()
+
+
+@pytest.mark.unit
+def test_preserve_clears_a_junction_child(tmp_path, monkeypatch):
+    """A non-preserved child that is a junction must be rmdir'd, not unlinked.
+
+    Preserve mode walks the task dir and removes each non-preserved
+    child. Hand-rolling that removal got the Windows case wrong: a
+    junction is a directory *reparse point*, so ``Path.unlink()`` raises
+    IsADirectoryError and the whole retry fails with the user's uploads
+    half-cleaned. ``_clear_workspace_link`` already distinguishes
+    symlink / junction / real dir / plain file, so preserve mode defers
+    to it.
+
+    An EMPTY REAL DIR is the faithful POSIX stand-in for a reparse
+    point: ``os.rmdir`` removes it, ``unlink`` raises on it, and the
+    junction branch is selected by monkeypatching ``_is_junction`` (the
+    same stand-in strategy the Windows-strategy test above uses). A
+    symlink would not reproduce the bug, because POSIX ``unlink``
+    happily removes a symlink-to-dir.
+    """
+    task_dir = tmp_path / 'tasks' / 'tid-junction'
+    (task_dir / 'uploads').mkdir(parents=True)
+    (task_dir / 'uploads' / 'ref.png').write_bytes(b'\x89PNG')
+    stray = task_dir / 'stray-junction'
+    stray.mkdir()
+    monkeypatch.setattr(task_links, '_is_junction', lambda p: p == stray)
+
+    task_links.remove_task_workspace(task_dir, preserve=('uploads',))
+
+    assert not stray.exists(), 'the junction child must be cleared'
+    assert (task_dir / 'uploads' / 'ref.png').read_bytes() == b'\x89PNG', (
+        'preserved uploads must survive'
+    )

--- a/tests/workflow/test_wf_create_attachments.py
+++ b/tests/workflow/test_wf_create_attachments.py
@@ -5,6 +5,14 @@ blob dir invisible to the agent, and the agent auto-started before the
 upload landed — so it asked "where is the image?". Now attachments write
 into the task workspace ``uploads/`` (agent-visible) and create can defer
 the start until the client has uploaded them.
+
+Second regression, from the fix itself: ``defer_start`` made ``/start``
+the resume half of create, but ``/start`` still refused tasks without a
+store — so a NO-STORE task created with an attachment was deferred by
+create, refused by /start, and stranded at PENDING with no error. Every
+test here passed a ``store_id``, which is exactly why that shipped. The
+no-store path is now covered, as is the retry that used to delete the
+attachments it left behind.
 """
 
 import shutil
@@ -13,9 +21,13 @@ import pytest
 
 from app.workspace.manager import VIBE_SELLER_DIR
 
+from .conftest import wait_for_task
+
 pytestmark = pytest.mark.workflow
 
 _TASKS_DIR = VIBE_SELLER_DIR / 'tasks'
+
+_PNG = b'\x89PNG\r\n\x1a\nx'
 
 
 async def _store(client):
@@ -68,5 +80,95 @@ async def test_attachment_lands_in_agent_workspace(admin_client):
         assert len(saved) == 1
         assert saved[0].suffix == '.png'
         assert saved[0].read_bytes().startswith(b'\x89PNG')
+    finally:
+        shutil.rmtree(task_dir, ignore_errors=True)
+
+
+async def test_deferred_no_store_task_starts(admin_client):
+    """The whole deferred create flow for a task with NO store.
+
+    create(defer_start) → upload → POST /start must LAUNCH it. /start
+    used to 400 here ('Cannot start browser task without a store'),
+    which had no destination in the client, so the task sat at PENDING
+    forever with a `pending` badge and no error anywhere.
+    """
+    r = await admin_client.post(
+        '/api/tasks',
+        json={
+            'title': 'widget report',
+            'description': 'read the attached reference image',
+            'store_id': None,
+            'defer_start': True,
+        },
+    )
+    assert r.status_code == 200
+    tid = r.json()['id']
+    task_dir = _TASKS_DIR / tid
+    try:
+        up = await admin_client.post(
+            f'/api/attachments/{tid}',
+            files={'file': ('shot.png', _PNG, 'image/png')},
+        )
+        assert up.status_code == 200
+
+        started = await admin_client.post(f'/api/tasks/{tid}/start')
+        assert started.status_code == 200, (
+            f'no-store deferred task must be startable; '
+            f'got {started.status_code}: {started.text[:200]}'
+        )
+
+        # And it must actually move — a 200 that launches nothing is the
+        # same stranded task with a nicer status code. No-store tasks are
+        # forced into plan mode, so the agent designs and parks at PLANNED.
+        got = await wait_for_task(admin_client, tid, target='planned')
+        assert got['status'] != 'pending', (
+            f'task never left PENDING after /start: {got["status"]}'
+        )
+    finally:
+        shutil.rmtree(task_dir, ignore_errors=True)
+
+
+async def test_retry_keeps_uploaded_attachments(admin_client):
+    """Retry wipes run residue but NOT the user's attachments.
+
+    ``reset_task_runtime_state`` rmtree'd the whole workspace, taking
+    ``uploads/`` with it while the ``task_attachments`` rows survived —
+    so retrying an image task re-created the "where is the image?" bug
+    the workspace uploads were introduced to fix, with the DB rows now
+    pointing at deleted files.
+    """
+    store_id = await _store(admin_client)
+    r = await admin_client.post(
+        '/api/tasks',
+        json={'title': 'retry me', 'store_id': store_id, 'defer_start': True},
+    )
+    tid = r.json()['id']
+    task_dir = _TASKS_DIR / tid
+    try:
+        await admin_client.post(
+            f'/api/attachments/{tid}',
+            files={'file': ('shot.png', _PNG, 'image/png')},
+        )
+        # Run residue that a retry MUST clear, alongside the upload.
+        (task_dir / 'reviews').mkdir(parents=True, exist_ok=True)
+        (task_dir / 'reviews' / 'stale.json').write_text('{}')
+
+        retried = await admin_client.post(f'/api/tasks/{tid}/retry')
+        assert retried.status_code == 200, retried.text[:200]
+
+        uploads = task_dir / 'uploads'
+        saved = [p for p in uploads.iterdir() if p.is_file()]
+        assert [p.name for p in saved] == ['shot.png'], (
+            'retry deleted the user-supplied attachment'
+        )
+        assert saved[0].read_bytes() == _PNG
+        assert not (task_dir / 'reviews').exists(), (
+            'retry must still clear prior-run residue'
+        )
+        # The rows that point at the file survive a retry — so must the
+        # file, or they dangle.
+        rows = await admin_client.get(f'/api/attachments/{tid}')
+        assert rows.status_code == 200
+        assert len(rows.json()) == 1
     finally:
         shutil.rmtree(task_dir, ignore_errors=True)

--- a/tests/workflow/test_wf_followup_mode.py
+++ b/tests/workflow/test_wf_followup_mode.py
@@ -20,6 +20,7 @@ from sqlalchemy import select
 import app.database as _db
 from app.models.schedule import Schedule
 from app.models.task import Task
+from app.models.task_message import TaskMessage
 from app.models.user import User
 from tests.workflow.fake_agent import FakeAgentScenario
 
@@ -70,6 +71,68 @@ async def _seed_task(
         )
         await db.commit()
     return task_id
+
+
+class TestFirstTurnCarriesTheTask:
+    """A chat message to a task that has NEVER run still delivers the
+    task's own description.
+
+    Every other entry point puts title+description in ``bundle.prompt``
+    (``_format_header``). ``/messages`` deliberately replaces that prompt
+    with the chat message, which is right for a follow-up — the
+    description is already in the resumed session or the prior
+    conversation. With neither, it is delivered nowhere: nothing in
+    ``system_extra`` carries it. Live consequence on a PENDING task
+    carrying a description plus image attachments: the agent received a
+    bare "please start", read the images, found no instructions, and
+    stopped to ask the user what the task was — with the answer sitting
+    unread in its own ``description`` column.
+    """
+
+    async def test_first_turn_includes_description(
+        self, admin_client, install_fake_agent
+    ):
+        install_fake_agent.default_scenario = FakeAgentScenario(plan='## p')
+        task_id = await _seed_task(status='pending', plan_mode=True)
+        r = await admin_client.post(
+            f'/api/tasks/{task_id}/messages',
+            json={'content': 'please start this task'},
+        )
+        assert r.status_code == 200
+        run_calls = install_fake_agent.get_calls(task_id=task_id, action='run')
+        assert run_calls, 'FakeAgent.run was not invoked'
+        delivered = run_calls[-1].prompt + run_calls[-1].system_extra
+        assert 'design something' in delivered, (
+            'first-turn chat dropped the task description; the agent has '
+            'no way to learn what the task is'
+        )
+
+    async def test_followup_does_not_repeat_description(
+        self, admin_client, install_fake_agent
+    ):
+        """Once there IS a conversation, prior history carries the task —
+        re-injecting the description would duplicate it every turn."""
+        install_fake_agent.default_scenario = FakeAgentScenario(plan='## p')
+        task_id = await _seed_task(status='designing', plan_mode=True)
+        async with _db.async_session() as db:
+            db.add(
+                TaskMessage(
+                    task_id=task_id,
+                    role='user',
+                    content='an earlier turn',
+                    seq=0,
+                )
+            )
+            await db.commit()
+
+        r = await admin_client.post(
+            f'/api/tasks/{task_id}/messages', json={'content': 'next turn'}
+        )
+        assert r.status_code == 200
+        run_calls = install_fake_agent.get_calls(task_id=task_id, action='run')
+        assert run_calls, 'FakeAgent.run was not invoked'
+        assert '## Task\n' not in run_calls[-1].system_extra
+        assert '## Prior Conversation' in run_calls[-1].system_extra
 
 
 class TestFollowUpMode:

--- a/tests/workflow/test_wf_status_gating.py
+++ b/tests/workflow/test_wf_status_gating.py
@@ -140,19 +140,27 @@ class TestStopGate:
 
 
 class TestStartGate:
-    """POST /start accepts STARTABLE (store required), rejects rest."""
+    """POST /start accepts STARTABLE, rejects rest — store or not.
+
+    /start used to add a second gate rejecting any task without a store.
+    That predated ``defer_start``, which made /start the resume half of
+    create for ANY task carrying an attachment — so the extra gate
+    stranded no-store tasks at PENDING. Status is now the only gate;
+    launch routing belongs to ``schedule_or_run``.
+    """
 
     @pytest.mark.parametrize('status', list(TaskStatus))
     async def test_start_gate_without_store(
         self, admin_client, override_async_session, status
     ):
-        """No store_id — /start always rejects with 400 (require store)."""
+        """No store_id — STARTABLE launches, everything else 400s."""
         task_id = await _seed_task(override_async_session, status=status)
         r = await admin_client.post(f'/api/tasks/{task_id}/start')
         if status in STARTABLE:
-            # Gate passes but then rejects on missing store.
-            assert r.status_code == 400
-            assert 'store' in r.json().get('detail', '').lower()
+            assert r.status_code == 200, (
+                f'STARTABLE no-store task must launch; '
+                f'got {r.status_code}: {r.text[:200]}'
+            )
         else:
             assert r.status_code == 400
 


### PR DESCRIPTION
## What broke

A task created with an image attachment sat at `PENDING` forever. No error, no `started_at`, no agent — its workspace held only `uploads/`.

Create defers the launch when attachments are present (`defer_start`, #105), because the files must land before the agent reads its prompt; the client then POSTs `/start`. But `/start` re-derived launch routing inline — queue-submit, and 400 unless the task had a store. That guard was written for v0.0.1, when `/start` meant only "start a browser task". Once create started deferring, a no-store task with an attachment was deferred by create and refused by `/start`. The client's `.catch(() => {})` discarded the 400 on the theory that "SSE / status will reflect any failure" — which cannot happen for a task that never moved off `PENDING`: no status change, no `task_update`, no `error` column.

The same "no store means this path doesn't apply to you" assumption sat in three more places, so every recovery route was a dead end too:

| Site | Effect |
|---|---|
| boot recovery (`task_queue.py`) | gated its `PENDING`/`QUEUED` re-queue on `store_id`, so a no-store task was orphaned across a restart — while the `PLANNED` recovery ten lines below already enqueues unconditionally |
| retry (`reset_task_runtime_state`) | `rmtree`'d the whole workspace, naming `uploads/` in its own docstring, while the `task_attachments` rows survived — so retrying an image task re-created the "where is the image?" bug #105 fixed, now with DB rows pointing at deleted files |
| `POST /messages` on a task that never ran | dropped the task's own description; it replaces `bundle.prompt` with the message, and with no resumable session and no prior conversation the description reaches the agent nowhere — nothing in `system_extra` carries it |

That last one was observed live: the agent read its attachments, found no instructions, and stopped to ask the user what the task was — with the answer sitting unread in its own `description` column.

## The fix

One owner for launch routing, and stop discarding failures.

- **`/start` delegates to `schedule_or_run`** (store → queue, no-store → direct) instead of re-deriving a narrower rule. `schedule_or_run` now returns whether it queued, so the response reports the real status rather than always claiming `queued`.
- **Boot recovery** enqueues on the `None` lane, matching `PLANNED`.
- **`remove_task_workspace` takes `preserve=`.** Retry keeps `uploads/` — user input, not run residue — and still clears everything else. It also clears the shared links first, so it can no longer descend a Windows junction into shared knowledge.
- **First-turn chat** seeds `## Task` with title + description when the message is the task's first turn, and only then.
- **The client reports the failure** through `onStartError`, and `uploadTaskAttachment` checks `res.ok` — a raw `fetch` that never rejected on 4xx/5xx, so an unchecked upload let the launch proceed with the file missing.

## Refactor

The 800-line limit tripped on all three files this touches (they sat at 781/799/799 on `main`). Split rather than trimmed, along the seams this change argues for:

- `schedule_or_run` → `app/task_launch.py`. Two other routers already imported it *out of a router*, which is how a rule drifts in the first place.
- The chat turn's context assembly → `app/task_chat_context.py`, so the message handler reads as routing rather than prompt-assembly.

## Tests

No-store defer → upload → `/start` launches; retry keeps attachments and still clears residue; boot recovery re-queues a no-store task; first-turn chat carries the description and a later follow-up does not repeat it; two frontend tests for the swallowed failures. **Each was confirmed to fail without its fix** — the retry one with `FileNotFoundError: .../uploads`. Two tests that pinned the old behaviour are rewritten, not deleted.

2506 backend passing, 499 frontend passing. Two pre-existing `ziniao` failures are unrelated and fail identically on a clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
