### PR TITLE
fix(profiles): a system schedule inherits from the admin, not from the bot that owns it

### DIFF
--- a/app/ai/profiles.py
+++ b/app/ai/profiles.py
@@ -3,6 +3,7 @@
 import json
 import os
 
+from app.config import AI_BOT_ROLE, DEFAULT_USER_ID
 from app.models.user import User
 from app.workspace.manager import VIBE_SELLER_DIR
 
@@ -666,6 +667,18 @@ async def resolve_schedule_profile(sched, db) -> str:
     schedule row); in that case there is no owner to resolve, so this
     returns ``DEFAULT_PROFILE_ID`` (the global inherit sentinel) and the
     caller applies its own default.
+
+    **System schedules have no human owner.** They are seeded with
+    ``created_by=AI_BOT_USER_ID`` — a login-less account whose
+    ``default_profile_id`` is the placeholder ``'default'`` and which no
+    Settings page can ever change. Inheriting from it therefore resolved
+    right back to ``'default'``, i.e. plain Claude on
+    api.anthropic.com. On an install driven entirely by third-party
+    profiles that is not a configuration, it is a guaranteed failure:
+    the nightly catalog sync died with "Not logged in · Please run
+    /login" every night for weeks while the admin's default was set to
+    a working provider the whole time. A bot owner means "no preference
+    expressed", so fall through to the human admin who did express one.
     """
     if (
         sched
@@ -675,6 +688,8 @@ async def resolve_schedule_profile(sched, db) -> str:
         return sched.ai_profile_id
     if sched and sched.created_by:
         owner = await db.get(User, sched.created_by)
+        if owner and owner.role == AI_BOT_ROLE:
+            owner = await db.get(User, DEFAULT_USER_ID)
         if owner and owner.default_profile_id:
             return owner.default_profile_id
     return DEFAULT_PROFILE_ID

--- a/app/config.py
+++ b/app/config.py
@@ -86,6 +86,11 @@ def _resolve_jwt_secret() -> str:
 
 JWT_SECRET = _resolve_jwt_secret()
 AI_BOT_USER_ID = '00000000-0000-0000-0000-000000000002'
+# ``User.role`` of the seeded bot account. It cannot log in and no
+# Settings page can edit it, so any preference read off this user is a
+# placeholder, never a choice someone made — see
+# ``resolve_schedule_profile``.
+AI_BOT_ROLE = 'ai_bot'
 
 DEFAULT_USER_ID = '00000000-0000-0000-0000-000000000001'
 

--- a/tests/workflow/test_wf_schedule_profile_inherit.py
+++ b/tests/workflow/test_wf_schedule_profile_inherit.py
@@ -22,6 +22,7 @@ import pytest
 from sqlalchemy import select
 
 from app.ai.profiles import resolve_schedule_profile
+from app.config import AI_BOT_ROLE, AI_BOT_USER_ID, DEFAULT_USER_ID
 from app.models.schedule import Schedule
 from app.models.schedule_constants import PhaseMode
 from app.models.task import Task
@@ -111,6 +112,77 @@ class TestResolveScheduleProfile:
     async def test_none_schedule_returns_default(self, override_async_session):
         async with override_async_session() as db:
             assert await resolve_schedule_profile(None, db) == 'default'
+
+    async def test_system_schedule_inherits_human_admin_not_bot(
+        self, override_async_session
+    ):
+        """A bot-owned schedule follows the ADMIN's default.
+
+        System schedules (the nightly catalog sync) are seeded with
+        ``created_by=AI_BOT_USER_ID``. That account cannot log in and no
+        Settings page can edit it, so its ``default_profile_id`` is
+        forever the placeholder ``'default'`` — inheriting from it
+        resolved straight back to plain Claude on api.anthropic.com.
+        On an install running entirely on third-party profiles that is
+        a guaranteed nightly failure ("Not logged in · Please run
+        /login") while the admin's default pointed at a working
+        provider the whole time.
+        """
+        async with override_async_session() as db:
+            db.add(
+                User(
+                    id=AI_BOT_USER_ID,
+                    username='ai_bot',
+                    email='ai@vibe-seller.local',
+                    password_hash='disabled',
+                    role=AI_BOT_ROLE,
+                    default_profile_id='default',
+                )
+            )
+            db.add(
+                User(
+                    id=DEFAULT_USER_ID,
+                    username='human-admin',
+                    email='admin@example.com',
+                    password_hash='x',
+                    role='admin',
+                    default_profile_id='minimax',
+                )
+            )
+            await db.commit()
+
+            sched = await _make_schedule(db, AI_BOT_USER_ID, 'default')
+            assert await resolve_schedule_profile(sched, db) == 'minimax'
+
+    async def test_system_schedule_still_honors_an_explicit_pin(
+        self, override_async_session
+    ):
+        """Falling through to the admin must not override a real pin."""
+        async with override_async_session() as db:
+            db.add(
+                User(
+                    id=AI_BOT_USER_ID,
+                    username='ai_bot',
+                    email='ai@vibe-seller.local',
+                    password_hash='disabled',
+                    role=AI_BOT_ROLE,
+                    default_profile_id='default',
+                )
+            )
+            db.add(
+                User(
+                    id=DEFAULT_USER_ID,
+                    username='human-admin',
+                    email='admin@example.com',
+                    password_hash='x',
+                    role='admin',
+                    default_profile_id='minimax',
+                )
+            )
+            await db.commit()
+
+            sched = await _make_schedule(db, AI_BOT_USER_ID, 'kimi')
+            assert await resolve_schedule_profile(sched, db) == 'kimi'
 
 
 class TestSingleJobInheritsProfile:


### PR DESCRIPTION
## What broke

The nightly `Update Knowledge Catalogs` run had failed **every night for weeks** with `Not logged in · Please run /login`, on an install whose admin default profile pointed at a working third-party provider the entire time.

The inheritance machinery was working. It was reading the wrong user.

`resolve_schedule_profile` treats both `NULL` and the literal `'default'` as "inherit" and falls through to the schedule's owner. System schedules are seeded with `created_by=AI_BOT_USER_ID` (`app/database.py`) — a seeded, login-less account that no Settings page can edit, and whose `default_profile_id` is therefore forever the placeholder `'default'`. So "inherit" resolved straight back to `'default'`: plain Claude on `api.anthropic.com`.

On an install driven entirely by third-party profiles that isn't a configuration, it's a guaranteed nightly failure — and nothing ever revisits it. The schedule has no human owner, so there is no preference for it to follow and no page on which to correct it.

## The fix

A bot owner means "no preference was expressed", so fall through to the human admin (`DEFAULT_USER_ID`) who did express one.

```python
if owner and owner.role == AI_BOT_ROLE:
    owner = await db.get(User, DEFAULT_USER_ID)
```

One place; repairs existing installs with no data migration or backfill; preserves the follow-the-live-default property the resolver is built around (the whole point of the resolver, per its docstring: switching providers during an outage must move existing schedules too). An explicit per-schedule pin still wins over both, and a missing admin row still falls back to `DEFAULT_PROFILE_ID`.

The seed's hardcoded `ai_profile_id='default'` is left alone — it's the correct value now that `'default'` means inherit. `AI_BOT_ROLE` joins `AI_BOT_USER_ID` in `config.py` rather than being another `'ai_bot'` string literal.

## Tests

- A bot-owned schedule resolves to the admin's default — **confirmed to fail without the fix**, resolving to `'default'`, reproducing the reported symptom exactly.
- An explicit pin on a bot-owned schedule is still honored, so the fallback can't override a real choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
