### PR TITLE
fix(review-gate): the re-drive budget belongs to the turn, not to the session

### DIFF
--- a/app/ai/claude_backend_review_gate.py
+++ b/app/ai/claude_backend_review_gate.py
@@ -34,7 +34,7 @@ from app.ai.claude_backend_utils import (
     check_exec_review_status_for_stop,
     check_review_status_for_stop,
 )
-from app.ai.review_redrive import RedriveClock
+from app.ai.review_redrive import ledger_for
 from app.env_options import Options
 
 logger = logging.getLogger(__name__)
@@ -58,19 +58,33 @@ class _ReviewGateMixin:
     """Owns the re-drive budget and the fail-open decision."""
 
     def _init_review_gate_state(self):
-        """Per-session gate state.
+        """Gate state for this session, on the TURN's budget.
 
-        ``_review_redrive_count`` — attempts spent.
-        ``_review_redrive_clock`` — the wall clock those attempts cost.
+        ``_review_redrive_clock`` — attempts AND the wall clock they
+        cost, both read off a ledger keyed by task rather than built
+        fresh here. A session is not the unit being bounded: the gate's
+        own re-drives each spawn one, and a circuit-breaker kill is
+        picked back up in another. Building fresh state per session
+        refunded the budget on exactly the respawn the gate provoked, so
+        the gate was bounded at every point and the turn was bounded
+        nowhere — see ``review_redrive._ledgers``. ``reset_ledger`` at
+        the orchestrator entry points is what makes a NEW turn start
+        over.
+
         ``_review_gate_failed_open`` — the gate has given up and the
         banner has shipped; from then on nothing it was waiting for may
-        keep the turn alive.
+        keep the turn alive. Stays per-session: it describes what THIS
+        session already shipped.
         """
-        self._review_redrive_count: int = 0
-        self._review_redrive_clock = RedriveClock(
-            Options.REVIEW_REDRIVE_BUDGET_S.get_float()
+        self._review_redrive_clock = ledger_for(
+            self.task_id, Options.REVIEW_REDRIVE_BUDGET_S.get_float()
         )
         self._review_gate_failed_open: bool = False
+
+    @property
+    def _review_redrive_count(self) -> int:
+        """Attempts spent on this turn — the ledger is the only tally."""
+        return self._review_redrive_clock.turns
 
     def _review_gate_deny_reason(self) -> str | None:
         """Why the review/exec gates say this turn may not end yet.
@@ -109,8 +123,12 @@ class _ReviewGateMixin:
         self._review_redrive_clock.note_turn_end()
 
     def _note_review_redrive(self) -> None:
-        """Record (and log) that another re-drive is being issued."""
-        self._review_redrive_count += 1
+        """Record (and log) that another re-drive is being issued.
+
+        One increment, on the ledger — the attempt tally reads back off
+        it. Keeping a second counter beside the clock is what let the
+        two denominators disagree about what a re-drive was.
+        """
         self._review_redrive_clock.note_redrive()
         logger.warning(
             'Review gate unsatisfied at result for %s — re-driving agent '

--- a/app/ai/review_redrive.py
+++ b/app/ai/review_redrive.py
@@ -184,8 +184,13 @@ def reset_ledger(task_id: str) -> None:
     post-circuit-breaker respawn does NOT re-enter one, which is why
     they keep the spend.
 
-    Also keeps the dict bounded: without a reset per turn it would grow
-    one entry per task for the life of the process.
+    Called at BOTH ends, which is what keeps ``_ledgers`` bounded:
+    turn entry alone does not, because a task that runs one turn and
+    never runs again leaves its entry behind for the life of the
+    process. So the terminal points drop it too — the same two places
+    ``stop_gates.reset_attempts`` is called from (result persisted, task
+    deleted). Idempotent, so a task that reaches neither (or reaches
+    both) costs nothing.
     """
     _ledgers.pop(task_id, None)
 

--- a/app/ai/review_redrive.py
+++ b/app/ai/review_redrive.py
@@ -68,6 +68,16 @@ class RedriveClock:
     def longest_turn_s(self) -> float:
         return self._longest_turn_s
 
+    @property
+    def turns(self) -> int:
+        """Re-drives issued against this clock.
+
+        The attempt bound reads this rather than keeping its own tally:
+        the two denominators must agree on what a re-drive is, and they
+        cannot if each counts separately on a different lifetime.
+        """
+        return self._turns
+
     def note_redrive(self) -> None:
         """A re-drive was just sent: start the budget, time the turn."""
         now = self._now()
@@ -123,3 +133,64 @@ class RedriveClock:
             f'a {self._budget_s:.0f}s gate budget, and the longest re-driven '
             f'turn took {self._longest_turn_s:.0f}s'
         )
+
+
+# ── Turn-scoped ledger ────────────────────────────────────────────────
+#
+# A RedriveClock bounds ONE session. That was enough while a turn was
+# one session, and it is not: the gate's own re-drives each spawn a
+# session, and when the agent wanders into a degenerate tool loop the
+# circuit breaker kills the session and the turn is picked back up in a
+# fresh one. A fresh session built fresh gate state, so the bound reset
+# — observed in CI as a turn that spent 5/5 re-drives with "225s left of
+# a 300s gate budget", got broken by the circuit breaker, and came back
+# announcing "1/5, 300s left of a 300s gate budget". The gate was bounded
+# at every point and the turn was bounded nowhere; the caller's deadline
+# was what finally stopped it.
+#
+# So the ledger is keyed by TASK and outlives the session. This is not
+# the run-relative budget the module docstring above rejects — it is the
+# same gate-relative budget, simply not refunded by a respawn the gate
+# itself provoked. A genuinely new turn resets it (see reset_ledger and
+# its orchestrator call sites); a respawn within one turn inherits the
+# spend, which is the whole point.
+#
+# Same shape and lifetime as ``stop_gates._attempts``: in-memory, keyed
+# by task, dropped at the turn boundaries. Lost on server restart, which
+# is fine — the agent session would also be torn down.
+_ledgers: dict[str, RedriveClock] = {}
+
+
+def ledger_for(task_id: str, budget_s: float) -> RedriveClock:
+    """The clock for this task's CURRENT turn, created on first use.
+
+    Sessions ask for it instead of constructing their own, so a second
+    session serving the same turn continues the first one's spend.
+    """
+    clock = _ledgers.get(task_id)
+    if clock is None:
+        clock = RedriveClock(budget_s)
+        _ledgers[task_id] = clock
+    return clock
+
+
+def reset_ledger(task_id: str) -> None:
+    """Start this task's gate budget over — a NEW turn is beginning.
+
+    Called from the orchestrator entry points (``auto_run_task``,
+    ``execute_planned_task``, ``execute_woken_task``,
+    ``spawn_followup_agent``), because entering an orchestrator is
+    exactly what "a new user-initiated turn" means. A re-drive or a
+    post-circuit-breaker respawn does NOT re-enter one, which is why
+    they keep the spend.
+
+    Also keeps the dict bounded: without a reset per turn it would grow
+    one entry per task for the life of the process.
+    """
+    _ledgers.pop(task_id, None)
+
+
+def redrive_count(task_id: str) -> int:
+    """Re-drives spent on this task's current turn (0 if none)."""
+    clock = _ledgers.get(task_id)
+    return clock.turns if clock else 0

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -11,6 +11,7 @@ from app import telemetry
 from app.ai.bash_safety import check_exec_review_status
 from app.ai.claude_backend_manager import agent_manager
 from app.ai.profiles import DEFAULT_PROFILE_ID, profile_kind_for_id
+from app.ai.review_redrive import reset_ledger
 from app.ai.stop_gates import (
     CONTRADICTION_MAX_DENIALS,
     clear_skill_bindings,
@@ -242,9 +243,11 @@ async def delete_task(
         await delete_task_record(db, task_id)
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    # Drop the gate-attempt counters and the durable skill→gate
-    # binding file with the task (bounded server state).
+    # Drop the gate-attempt counters, the review gate's re-drive
+    # ledger, and the durable skill→gate binding file with the task
+    # (bounded server state).
     reset_attempts(task_id)
+    reset_ledger(task_id)
     clear_skill_bindings(task_id)
     return {'ok': True}
 
@@ -694,10 +697,12 @@ async def set_task_result(
     task.updated_at = datetime.now(UTC).isoformat()
     await db.commit()
 
-    # Result persisted — drop the per-task gate-attempt counters and
-    # any gate-owned progress state so a long-running server doesn't
-    # accumulate stale entries (and a later retry starts fresh).
+    # Result persisted — drop the per-task gate-attempt counters, the
+    # review gate's re-drive ledger, and any gate-owned progress state
+    # so a long-running server doesn't accumulate stale entries (and a
+    # later retry starts fresh).
     reset_attempts(task_id)
+    reset_ledger(task_id)
     for _name, gate in skill_gates:
         reset = getattr(gate, 'reset_progress', None)
         if reset is not None:

--- a/app/task_runner_auto.py
+++ b/app/task_runner_auto.py
@@ -9,6 +9,7 @@ from app.ai.external_config import (
     assert_profile_compatible,
 )
 from app.ai.profiles import DEFAULT_PROFILE_ID
+from app.ai.review_redrive import reset_ledger
 from app.browser.manager import browser_manager, store_slug as _store_slug
 from app.database import async_session
 from app.events.bus import event_bus
@@ -55,6 +56,9 @@ async def auto_run_task(task_id: str, store: Store | None):
     Multiple tasks for the same store can run concurrently
     with CDP-level isolation via CDPMuxProxy.
     """
+    # A new turn — the review gate's budget starts over here and
+    # nowhere else. See reset_ledger.
+    reset_ledger(task_id)
     catalog_backups: dict = {}
     schedule: Schedule | None = None
     try:

--- a/app/task_runner_exec.py
+++ b/app/task_runner_exec.py
@@ -12,6 +12,7 @@ from app.ai.external_config import (
     assert_profile_compatible,
 )
 from app.ai.profiles import DEFAULT_PROFILE_ID, profile_kind_for_id
+from app.ai.review_redrive import reset_ledger
 from app.browser.manager import browser_manager, store_slug as _store_slug
 from app.database import async_session
 from app.errors import categorize_ziniao_error
@@ -113,6 +114,7 @@ async def execute_planned_task(task_id: str, store: Store | None):
     (native plan mode). If the session died, starts a new execute
     session. Either way, the agent session is held during execution.
     """
+    reset_ledger(task_id)  # new turn — see reset_ledger
     try:
         # Write browser config (needed for retry — server may have
         # restarted since the task was created; no-store tasks get the
@@ -484,6 +486,7 @@ async def execute_planned_task(task_id: str, store: Store | None):
 
 async def execute_woken_task(task_id: str, store: Store | None):
     """Resume a woken waiting task with trigger context."""
+    reset_ledger(task_id)  # new turn — see reset_ledger
     try:
         async with async_session() as db:
             task = await db.get(Task, task_id)

--- a/app/task_runner_followup.py
+++ b/app/task_runner_followup.py
@@ -17,6 +17,7 @@ from app.ai.external_config import (
     ExternalConfigOverrideError,
     assert_profile_compatible,
 )
+from app.ai.review_redrive import reset_ledger
 from app.browser.manager import store_slug as _store_slug
 from app.database import async_session
 from app.events.bus import event_bus
@@ -55,6 +56,9 @@ async def spawn_followup_agent(
     task back to its prior terminal state via a fresh DB session
     so the UI doesn't get stuck mid-transition.
     """
+    # A new turn — the review gate's budget starts over here and
+    # nowhere else. See reset_ledger.
+    reset_ledger(task_id)
     started = False
     try:
         # cc-switch / external override may have appeared since the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ from sqlalchemy.orm import sessionmaker  # noqa: E402
 # Event, ...) silently aren't created and a test that touches them
 # fails later with "no such table: <name>".
 from app import models  # noqa: F401, E402
+from app.ai.review_redrive import _ledgers  # noqa: E402, PLC2701
 from app.auth import create_token  # noqa: E402
 from app.database import get_db  # noqa: E402
 from app.main import app  # noqa: E402
@@ -316,3 +317,19 @@ def sample_browser_config():
         'headless': True,
         'args': ['--no-sandbox', '--disable-dev-shm-usage'],
     }
+
+
+@pytest.fixture(autouse=True)
+def _isolate_review_redrive_ledger():
+    """Keep one test's review-gate spend out of the next test's turn.
+
+    The re-drive budget is keyed by task so a respawn inside a turn
+    inherits it (``app/ai/review_redrive.py``). In production a turn ends
+    and an orchestrator resets it; unit tests build ``AgentSession``
+    directly, never enter an orchestrator, and reuse the same
+    ``task_id='test-task'`` — so without this a test that spends the
+    budget hands the next one a session that is already exhausted.
+    """
+    _ledgers.clear()
+    yield
+    _ledgers.clear()

--- a/tests/e2e/test_llm_browser.py
+++ b/tests/e2e/test_llm_browser.py
@@ -341,6 +341,27 @@ class TestLLMWebBrowserNoStore:
         assert result['status'] in ('completed', 'waiting'), (
             f'Task failed: {result.get("error")}'
         )
+        # WAITING is accepted by the polls above only so this returns
+        # promptly instead of burning the full timeout — it is NOT done.
+        # A parked task never executed, so every caller's content
+        # assertion is guaranteed to fail, and it fails by reporting the
+        # agent's planning preamble rather than the reason. Say the
+        # reason here instead. (Observed: the agent stalled waiting on an
+        # Explore subagent, then asked for direction.)
+        if result['status'] == 'waiting':
+            msgs = get_messages(api_client, data['id'])
+            last = next(
+                (
+                    m['content']
+                    for m in reversed(msgs)
+                    if m['role'] in ('assistant', 'result')
+                ),
+                '',
+            )
+            raise AssertionError(
+                'Agent parked in WAITING without executing the plan, so '
+                'nothing was extracted. It last said: ' + last[:300]
+            )
         return data
 
     def test_web_browser_reads_homepage(self, api_client, test_site):
@@ -349,7 +370,8 @@ class TestLLMWebBrowserNoStore:
             api_client,
             f'Use the browser-use CLI (your general web browser) to '
             f'navigate to {test_site}. Read the page and report the '
-            f'company name. Include the company name in your result.',
+            f'company name. Include the company name in your result. '
+            f'Do not ask questions — just do it and report.',
         )
         msgs = get_messages(api_client, data['id'])
         all_text = ' '.join(
@@ -367,7 +389,8 @@ class TestLLMWebBrowserNoStore:
             f'Use the browser-use CLI (your general web browser) to '
             f'navigate to {test_site} and find the contact page. '
             f'Extract the contact details (email, phone, address) '
-            f'and report them.',
+            f'and report them. Do not ask questions — just do it '
+            f'and report.',
         )
         msgs = get_messages(api_client, data['id'])
         all_text = ' '.join(

--- a/tests/unit/test_handle_event_result.py
+++ b/tests/unit/test_handle_event_result.py
@@ -396,7 +396,8 @@ class TestReviewGateRedrive:
         so an unsatisfiable gate can't wedge the session forever."""
         session = _make_session('auto')
         session.task_dir = '/tmp/fake-task'
-        session._review_redrive_count = REVIEW_REDRIVE_MAX
+        for _ in range(REVIEW_REDRIVE_MAX):
+            session._note_review_redrive()
         emitted: list[tuple[str, str]] = []
 
         async def _mock_emit(role, content):
@@ -448,7 +449,6 @@ class TestReviewGateRedrive:
         """
         session = _make_session('auto')
         session.task_dir = '/tmp/fake-task'
-        session._review_redrive_count = 1
         clock = _FakeClock()
         session._review_redrive_clock = RedriveClock(300, now=clock)
         session._review_redrive_clock.note_redrive()

--- a/tests/unit/test_review_redrive_budget.py
+++ b/tests/unit/test_review_redrive_budget.py
@@ -293,3 +293,40 @@ class TestASessionPicksUpTheTurnsBudget:
         first._note_review_gate_failed_open()
         assert first._review_gate_failed_open
         assert not self._session()._review_gate_failed_open
+
+
+class TestTheLedgerIsBounded:
+    """``_ledgers`` must not grow one entry per task, forever.
+
+    Review catch on #140: the first version reset only at turn ENTRY,
+    which cannot bound the dict — a task that runs one turn and never
+    runs again leaves its entry behind for the life of the process, and
+    ``_init_review_gate_state`` allocates one for EVERY session whether
+    or not a gate ever bites. The terminal points drop it too, which is
+    what ``stop_gates.reset_attempts`` has always done and what this was
+    supposed to be modelled on.
+    """
+
+    def setup_method(self):
+        reset_ledger('task-bounded')
+
+    teardown_method = setup_method
+
+    def test_a_turn_that_never_redrives_still_gets_collected(self):
+        # Allocation is unconditional: a session asks for its budget
+        # before it knows whether a gate will bite.
+        ledger_for('task-bounded', 300.0)
+        assert 'task-bounded' in _ledgers
+
+        # Whatever ends the task — result persisted or task deleted —
+        # must take the entry with it.
+        reset_ledger('task-bounded')
+        assert 'task-bounded' not in _ledgers
+
+    def test_terminal_cleanup_is_idempotent(self):
+        # A task can reach both terminal points (result then delete), or
+        # neither (server restart). Both must be free.
+        ledger_for('task-bounded', 300.0)
+        reset_ledger('task-bounded')
+        reset_ledger('task-bounded')
+        assert 'task-bounded' not in _ledgers

--- a/tests/unit/test_review_redrive_budget.py
+++ b/tests/unit/test_review_redrive_budget.py
@@ -14,7 +14,17 @@ over, instead of by running out of clock.
 
 import pytest
 
-from app.ai.review_redrive import RedriveClock
+from app.ai.claude_backend_review_gate import (
+    _ReviewGateMixin,  # noqa: PLC2701 — the unit under test
+)
+from app.ai.claude_backend_utils import REVIEW_REDRIVE_MAX
+from app.ai.review_redrive import (
+    RedriveClock,
+    _ledgers,  # noqa: PLC2701
+    ledger_for,
+    redrive_count,
+    reset_ledger,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -140,3 +150,146 @@ class TestDisabling:
         assert '150s' in text
         off, _ = _budget(0)
         assert 'disabled' in off.describe()
+
+
+class TestTheBudgetBelongsToTheTurnNotTheSession:
+    """A respawn inside one turn inherits the spend.
+
+    The bound above is real per session, and a turn is not one session:
+    each re-drive spawns a session, and when the agent falls into a
+    degenerate tool loop the circuit breaker kills the session and the
+    turn is picked back up in a fresh one. Building fresh gate state per
+    session refunded the budget on exactly the respawn the gate had
+    provoked — so the gate was bounded at every point and the turn was
+    bounded nowhere.
+
+    Seen in CI: a follow-up spent 5/5 re-drives down to "225s left of a
+    300s gate budget", the breaker fired, and the next session announced
+    "1/5, 300s left of a 300s gate budget". It was still looping 15
+    minutes later when the caller's 600s deadline had long passed.
+    """
+
+    def setup_method(self):
+        reset_ledger('task-1')
+        reset_ledger('task-2')
+
+    teardown_method = setup_method
+
+    def test_a_second_session_continues_the_first_ones_spend(self):
+        first = ledger_for('task-1', 300.0)
+        for _ in range(3):
+            first.note_redrive()
+            first.note_turn_end()
+        assert redrive_count('task-1') == 3
+
+        # The circuit breaker kills that session; the turn is picked up
+        # by a new one, which asks for its budget the same way.
+        second = ledger_for('task-1', 300.0)
+        assert second is first, 'a respawn must not get a fresh budget'
+        assert redrive_count('task-1') == 3, 'the spend was refunded'
+
+        second.note_redrive()
+        assert redrive_count('task-1') == 4
+
+    def test_the_clock_is_not_rewound_by_a_respawn(self):
+        clock = _Clock()
+        ledger = ledger_for('task-1', 300.0)
+        ledger._now = clock  # noqa: SLF001 — injecting time, as _budget does
+        ledger.note_redrive()
+        clock.advance(200)
+        ledger.note_turn_end()
+
+        again = ledger_for('task-1', 300.0)
+        assert again.remaining_s() == pytest.approx(100), (
+            'the respawn refunded the wall clock too'
+        )
+        # 100s left and the longest turn cost 200s — no room for another.
+        assert again.out_of_time()
+
+    def test_a_new_turn_starts_over(self):
+        ledger = ledger_for('task-1', 300.0)
+        for _ in range(5):
+            ledger.note_redrive()
+            ledger.note_turn_end()
+        assert redrive_count('task-1') == 5
+
+        # An orchestrator entry — auto_run_task, execute_planned_task,
+        # execute_woken_task, spawn_followup_agent — IS a new turn.
+        reset_ledger('task-1')
+        assert redrive_count('task-1') == 0
+        assert ledger_for('task-1', 300.0) is not ledger
+
+    def test_tasks_do_not_share_a_budget(self):
+        a = ledger_for('task-1', 300.0)
+        a.note_redrive()
+        assert redrive_count('task-1') == 1
+        assert redrive_count('task-2') == 0
+        assert ledger_for('task-2', 300.0) is not a
+
+    def test_reset_drops_the_entry_so_the_dict_stays_bounded(self):
+        ledger_for('task-1', 300.0)
+        assert 'task-1' in _ledgers
+        reset_ledger('task-1')
+        assert 'task-1' not in _ledgers
+        # Idempotent: an orchestrator may reset a task that never ran.
+        reset_ledger('task-1')
+
+
+class TestASessionPicksUpTheTurnsBudget:
+    """The session-level pin: ``_init_review_gate_state`` must not
+    hand a respawn a clean slate.
+
+    This is the regression the CI failure was. The old implementation
+    built ``RedriveClock(...)`` fresh here and zeroed a session-local
+    ``_review_redrive_count``, so every session for a turn started at
+    0/5 with the full wall clock — the refund that made the loop
+    unbounded.
+    """
+
+    def setup_method(self):
+        reset_ledger('task-session')
+
+    teardown_method = setup_method
+
+    def _session(self):
+        class _S(_ReviewGateMixin):
+            task_id = 'task-session'
+
+        s = _S()
+        s._init_review_gate_state()
+        return s
+
+    def test_a_respawned_session_is_already_out_of_attempts(self):
+        first = self._session()
+        for _ in range(REVIEW_REDRIVE_MAX):
+            first._note_review_redrive()
+            first._note_review_turn_end()
+        assert first._review_redrive_exhausted()
+
+        # Circuit breaker kills that session; the turn continues in a
+        # new one. It must NOT be allowed another full budget.
+        second = self._session()
+        assert second._review_redrive_count == REVIEW_REDRIVE_MAX
+        assert second._review_redrive_exhausted(), (
+            'a respawn got a fresh budget — the turn is unbounded again'
+        )
+
+    def test_a_new_turn_gives_the_next_session_a_full_budget(self):
+        first = self._session()
+        for _ in range(REVIEW_REDRIVE_MAX):
+            first._note_review_redrive()
+            first._note_review_turn_end()
+        assert first._review_redrive_exhausted()
+
+        reset_ledger('task-session')  # an orchestrator entry
+        fresh = self._session()
+        assert fresh._review_redrive_count == 0
+        assert not fresh._review_redrive_exhausted()
+
+    def test_failed_open_is_still_per_session(self):
+        # It records what THIS session already shipped, so it must not
+        # ride the ledger into the next one.
+        first = self._session()
+        first._note_review_gate_failed_open()
+        assert first._review_gate_failed_open
+        assert not self._session()._review_gate_failed_open

--- a/tests/unit/test_turn_linger.py
+++ b/tests/unit/test_turn_linger.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from app.ai.claude_backend import AgentSession
+from app.ai.claude_backend_utils import REVIEW_REDRIVE_MAX
 from app.env_options import Options
 
 pytestmark = pytest.mark.unit
@@ -112,7 +113,10 @@ class TestCloseGuards:
         # the gate stands down so an unsatisfiable gate can't wedge
         # the process forever.
         s = self._closable(_session())
-        s._review_redrive_count = 99
+        # Spend the budget the way the gate does — the tally lives on
+        # the turn's ledger, so there is nothing to assign here.
+        for _ in range(REVIEW_REDRIVE_MAX):
+            s._note_review_redrive()
         with patch(
             'app.ai.claude_backend_review_gate.check_review_status_for_stop',
             return_value='Reviewer never ran.',

--- a/tests/workflow/test_wf_reviewer_set_result.py
+++ b/tests/workflow/test_wf_reviewer_set_result.py
@@ -19,6 +19,7 @@ from datetime import UTC, datetime
 import pytest
 from sqlalchemy import select
 
+from app.ai.review_redrive import _ledgers, ledger_for  # noqa: PLC2701
 import app.ai.stop_gates as sg
 from app.ai.stop_gates import record_skill_load, report_reviewer, reset_attempts
 from app.models.task import Task
@@ -266,3 +267,33 @@ class TestFollowUpTurnRollover:
         )
         assert r.status_code == 400
         assert 'ads-report-review' in r.json()['detail']
+
+
+async def test_set_result_and_delete_drop_the_redrive_ledger(
+    admin_client, override_async_session
+):
+    """The terminal points that drop gate-attempt counters must drop the
+    review gate's re-drive ledger too.
+
+    Unit tests can pin ``reset_ledger`` itself; only this catches a
+    missing CALL SITE. Review catch on #140: resetting at turn entry
+    alone left ``_ledgers`` growing one entry per task forever.
+    """
+    store = (
+        await admin_client.post('/api/stores', json={'name': 'Ledger Store'})
+    ).json()
+    made = await admin_client.post(
+        '/api/tasks',
+        json={'title': 'ledger', 'store_id': store['id'], 'defer_start': True},
+    )
+    task_id = made.json()['id']
+
+    # A session would allocate this when it starts; do it directly so
+    # the test does not depend on an agent run.
+    ledger_for(task_id, 300.0)
+    assert task_id in _ledgers
+
+    await admin_client.delete(f'/api/tasks/{task_id}')
+    assert task_id not in _ledgers, (
+        'deleting a task must drop its re-drive ledger'
+    )


### PR DESCRIPTION
## How this was found

Debugging #139's `e2e-test` failure. The failing test (`test_followup_review_scoping`) has nothing to do with that PR — #139 changes only `resolve_schedule_profile`, and the test creates tasks with no schedule. The real cause is in `main`.

A follow-up turn ran **unbounded** until the caller's 600s deadline killed it, and was still looping 15 minutes in.

## The bug

`RedriveClock` bounds **one session** — attempts and wall clock. A turn is not one session. The gate's own re-drives each spawn a session, and when the agent falls into a degenerate tool loop the circuit breaker kills the session and the turn is picked back up in a fresh one. `_init_review_gate_state` built fresh state per session, so the budget was refunded on exactly the respawn the gate had provoked:

```
03:43:41  re-driving (1/5, 300s left of a 300s gate budget)
   …
03:44:56  re-driving (5/5, 225s left of a 300s gate budget)   ← budget gone
03:47:01  Circuit breaker: stuck in loop (set_task_result), stopping
03:47:33  re-driving (1/5, 300s left of a 300s gate budget)   ← refunded
```

A loop with no exit: 5 re-drives → breaker → respawn → 5 more. The gate was bounded at every point and the turn was bounded nowhere.

It only trips when the breaker fires first — whether the model wanders into a degenerate loop is chance — which is why it reads as a flaky e2e rather than a broken one. **The same test passed on #138.** `e2e-test` has failed 3 of the last 6 CI runs, each on a different model-behaviour-dependent test.

## The fix

The ledger is keyed by **task** and outlives the session.

This is *not* the run-relative budget `review_redrive`'s docstring rejects as "inventing a number" — that reasoning still stands. It is the same gate-relative budget, simply not refunded by a respawn the gate itself provoked. A genuinely new turn resets it, and entering an orchestrator (`auto_run_task`, `execute_planned_task`, `execute_woken_task`, `spawn_followup_agent`) is exactly what "a new turn" means; a re-drive or a post-breaker respawn does not come through one, which is why they keep the spend.

Same shape and lifetime as `stop_gates._attempts` — in-memory, keyed by task, dropped at the turn boundary.

**Also collapses the two tallies into one.** The attempt count was a session-local `int` sitting beside the clock's own turn counter, so the gate's two denominators could disagree about what a re-drive was. The count now reads off the ledger.

## Tests

- A respawn inherits attempts **and** wall clock; a new turn starts over; tasks don't share a budget.
- The fail-open flag stays per-session — it describes what *this* session shipped, so it must not ride the ledger forward.
- Session-level pins on `_init_review_gate_state`, which is where the refund actually happened.
- An autouse fixture clears the ledger between tests: unit tests build `AgentSession` directly, never enter an orchestrator, and share `task_id='test-task'` — so without it one test's spend exhausts the next one's session. Same reasoning as the existing `_isolate_wrapper_bin_dir` fixture.

2506 passing; the only failures are the two pre-existing `ziniao` ones that fail identically on a clean `main`.

## Note on scope

`task_runner_exec.py` sat at 795/800 on `main`, so the call-site comment there is one line pointing at `reset_ledger` rather than a second copy of its reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
