### PR TITLE
fix(noon): the barcode is an FNSKU, and Add Barcode auto-saves — eight silent failures

### DIFF
--- a/.claude/skills/debug-store/SKILL.md
+++ b/.claude/skills/debug-store/SKILL.md
@@ -132,6 +132,24 @@ echo "export VIBE_TASK_ID='$NEW'" > /tmp/vs_session_env.sh
 ~/.vibe-seller/bin/<slug>/browser-use open <some-url>
 ```
 
+> **A rotated `VIBE_TASK_ID` gets REAPED within 5 minutes — do not use
+> one for manual driving.** `VIBE_TASK_ID=<uuid>` resolves the session to
+> `<slug>-<8hex>`, which is exactly the shape
+> `daemon_reaper.task_prefix_for_bu_name()` reads as *"owned by a task"*.
+> There is no task row for a hand-made UUID, so the 5-minute sweep
+> classifies the daemon as orphaned and kills it. The next `js()` in your
+> heredoc then dies with a bare, undiagnosable traceback —
+> `FileNotFoundError: [Errno 2] No such file or directory` out of
+> `_ipc.connect` — because `ensure_daemon()` runs **once** before
+> `exec(code)` and nothing re-checks the socket mid-script. Confirm with:
+> `grep -i reaped logs/backend_7777.log`
+> → `Reaped 1 orphaned browser-use daemon(s): [(<pid>, '<8hex>')]`.
+>
+> For manual driving use a session the reaper **skips** — one with no
+> task suffix: unset `VIBE_TASK_ID` entirely (session `<slug>`, the
+> global one) or pass `--session <slug>-aux`. Rotation advice above
+> applies to a *wedged* daemon inside a real task, not to your shell.
+
 ## Reviving a wedged daemon
 
 ```bash

--- a/app/skills_v2/amazon-shared/SKILL.md
+++ b/app/skills_v2/amazon-shared/SKILL.md
@@ -37,6 +37,34 @@ byte-identical across the marketplaces' subdomains (account-level). Stranded Inv
 a specific listing, always specify which marketplace; "the inventory
 for store X" is ambiguous.
 
+> **To reach another marketplace, SWITCH the account — do not navigate to
+> that marketplace's domain.** Hitting `sellercentral.amazon.{other-tld}`
+> directly lands on a *fresh* `/ap/signin` that Ziniao pre-fills with the
+> **current** marketplace's email. That looks exactly like "this is a
+> separate account I have no credentials for", and signing in anyway
+> would authenticate the wrong account. Instead:
+>
+> ```
+> https://sellercentral.amazon.{current-tld}/account-switcher/default/merchantMarketplace
+> ```
+>
+> Entries read `<Country>` when available and `<Country> (pending
+> registration)` when not — only the former can be selected. Selection is
+> two steps: click the country row (it ticks), **then** the "Select
+> account" button that appears; a single click looks like a no-op. Success
+> shows `?mons_sel_mkid=amzn1.mp.o.…` on the URL and the new country in
+> the header. Every subsequent page on the SAME domain then serves that
+> marketplace's data — so per-marketplace reports are pulled from the
+> original domain after switching, not from the other country's domain.
+>
+> **Confirm the switch changed the data, not just the chrome.** These
+> report pages cache aggressively; compare something content-bearing
+> (e.g. the newest report row's date differed — 09/08 on one marketplace
+> vs 10/08 on the other) or a row count, before trusting a second export.
+> A store's `notes.md` email-to-platform map can imply separate accounts
+> per marketplace when one unified account actually holds several — check
+> the switcher before concluding a marketplace is unreachable.
+
 ## 2. Sign-in flow (browser-side)
 
 The first hit per session typically redirects through Amazon sign-in

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -9,7 +9,8 @@ allowed-tools: Bash(browser-use:*)
      from upstream, re-apply: (1) the Store/No-store task banners, (2) the
      wrapper env-injection contract (BU_NAME/BU_CDP_WS auto-injected, agent
      overrides blocked), (3) removal of cloud/remote-daemon and local-profile
-     sections we don't use, (4) the "js() does NOT parse JSON" bullet.
+     sections we don't use, (4) the "js() does NOT parse JSON" bullet,
+     (5) the "a screenshot is not a data source" rule.
      See docs/browser-use-0.13-migration.md. -->
 
 > **browser-use 0.13 changed everything.** There are **no subcommands**. You
@@ -96,6 +97,21 @@ start of the next invocation instead of assuming where you left off.
    overwritten each call); `print()` it and **Read that PNG** to view it.
    Use it only to disambiguate a crowded layout — never *depend* on it. If
    your model can't view images, skip screenshots entirely and use step 2.
+
+   **A screenshot is not a data source.** Never take a value you will act
+   on or report — an ID, a number, a row, a column that exists, a count —
+   from an image. Read it from the DOM with `js(...)`. A screenshot
+   answers "where is it on screen", nothing else.
+
+   This is not caution about edge cases; it is the observed default. On
+   a page holding exactly two rows, models on two different providers
+   each described a table that did not exist — invented columns
+   (`ACOS`, `CPC`, `Bid`), invented campaigns, invented statuses — then
+   spent a dozen turns hunting for the data they had "seen", and one
+   named a nonexistent campaign in its final report to the user. Nothing
+   was wrong with the PNG. **When the DOM and the picture disagree, the
+   DOM is right and the picture is a hallucination** — do not go looking
+   for the difference, and never reconcile by trusting the image.
 4. **Interact**: get an element's centre coords from step 2, then
    `click_at_xy(x, y)`; set input values with `js(...)`. Re-read with
    `page_info()` / `js(...)` after to confirm.
@@ -109,7 +125,7 @@ Helpers are pre-imported into the heredoc namespace:
 ```python
 new_tab(url)  # open a new tab and navigate (use for EVERY navigation)
 page_info()  # structured summary of the current page
-capture_screenshot()  # → PNG path (~/.vibe-seller/bh-tmp/shot.png); Read it to VIEW
+capture_screenshot()  # → PNG path (~/.vibe-seller/bh-tmp/shot.png); LAYOUT only, never data
 click_at_xy(x, y)  # click at pixel coordinates
 wait_for_load()  # wait for navigation/network to settle
 ensure_real_tab()  # switch off a stale/internal (chrome://) tab
@@ -182,6 +198,15 @@ els = js("""
 print(els)          # pick the one whose text matches, then click_at_xy(it.x, it.y)
 PY
 ```
+
+**A plain `<a href>` is a navigation, not a click.** Read the href and
+`new_tab(href)`. Clicking one means landing inside the *anchor's* own
+rect, and an anchor is usually a small target inside a much larger
+parent: the centre of the table row or cell holding it is typically not
+on the anchor at all, so `click_at_xy` hits dead space and silently does
+nothing — no error, no navigation, and `page_info()` still shows the old
+page. Reserve clicking for controls that have no href (buttons, `kat-*`,
+JS handlers).
 
 ### A control BELOW the fold that won't scroll into view
 

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -9,7 +9,8 @@ allowed-tools: Bash(browser-use:*)
      from upstream, re-apply: (1) the Store/No-store task banners, (2) the
      wrapper env-injection contract (BU_NAME/BU_CDP_WS auto-injected, agent
      overrides blocked), (3) removal of cloud/remote-daemon and local-profile
-     sections we don't use. See docs/browser-use-0.13-migration.md. -->
+     sections we don't use, (4) the "js() does NOT parse JSON" bullet.
+     See docs/browser-use-0.13-migration.md. -->
 
 > **browser-use 0.13 changed everything.** There are **no subcommands**. You
 > no longer run `browser-use open <url>`. Instead you pipe Python helper code
@@ -99,6 +100,22 @@ cdp('Domain.method', **params)  # raw CDP — params are KEYWORDS, not a dict
   `cdp('Runtime.evaluate', expression=..., returnByValue=False)` → `objectId`
   (note: `cdp()` params are **keyword args**, never a positional dict —
   see "Uploading a file").
+- **`js()` does NOT parse JSON — so do not `JSON.stringify` your result.**
+  The value comes straight from CDP `returnByValue`, so the JS type maps
+  to the Python type: `return [{a:1}]` gives you a **list of dicts**
+  already, while `return JSON.stringify([{a:1}])` gives you a **`str`**
+  that you must then `json.loads` yourself. Both directions bite:
+  stringifying and *not* parsing makes `for row in data` iterate
+  **characters**; not stringifying and *then* parsing raises
+  `TypeError: the JSON object must be str, bytes or bytearray, not list`.
+  Return the object directly and use it as-is. If you inherit code whose
+  shape you can't be sure of, normalise once rather than guessing:
+
+  ```python
+  def jsjson(expr):
+      d = js(expr)
+      return json.loads(d) if isinstance(d, str) else d
+  ```
 
 ## Locate & click an element WITHOUT vision (the preferred path)
 

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -138,10 +138,18 @@ cdp('Domain.method', **params)  # raw CDP — params are KEYWORDS, not a dict
   shape you can't be sure of, normalise once rather than guessing:
 
   ```python
+  import json          # stdlib modules: import them, don't rely on the namespace
+
   def jsjson(expr):
       d = js(expr)
       return json.loads(d) if isinstance(d, str) else d
   ```
+
+  Only the **helpers** above are guaranteed pre-imported. `json`, `time` and
+  friends do happen to be reachable in the heredoc namespace today (they leak
+  in through the harness's own `import *`), but that is an implementation
+  detail of the wheel, not a contract — one `__all__` upstream and it stops.
+  Import the stdlib you use.
 
 ## Locate & click an element WITHOUT vision (the preferred path)
 

--- a/app/skills_v2/browser-harness/SKILL.md
+++ b/app/skills_v2/browser-harness/SKILL.md
@@ -53,6 +53,32 @@ The wrapper takes the heredoc form **only** — there is no `-c` flag
 browser-use --doctor    # verify installation / CDP connectivity
 ```
 
+## Budget every invocation: the wrapper kills it at 120 s
+
+The store wrapper runs the real `browser-use` under a **120-second
+alarm**, and a timeout is treated as evidence the *browser* is wedged:
+the wrapper bumps a strike counter, force-`--reload`s the daemon, and on
+the **second consecutive** timeout prints `UNRECOVERABLE`, exits 75, and
+tells you to stop retrying and report a gap. Any other outcome — even an
+ordinary Python error — resets the counter.
+
+**A slow-but-healthy call is indistinguishable from a wedged browser.**
+So a legitimately long heredoc does not merely get cut off: two of them
+in a row will convince the wrapper (and then you) that a perfectly good
+browser is dead, and the honest-reporting rule then makes you abandon
+real work. Keep each invocation comfortably under the limit:
+
+- **One unit of work per invocation** — one page, one SKU, one export.
+  Drive the loop from the **shell**, not inside the heredoc, and append
+  results to a file under `/tmp/<task>/` so progress survives.
+- **Count your polls.** A render-wait of `range(15)` with `sleep(3)` is
+  45 s on its own; two of those plus navigation overruns 120 s.
+- If you genuinely need a long single operation (a slow export), poll it
+  across **separate** invocations rather than sleeping inside one.
+
+A timeout also leaves the tab mid-operation, so re-read state at the
+start of the next invocation instead of assuming where you left off.
+
 ## Core Workflow
 
 1. **Navigate**: `new_tab(url)` — for the first page **and every later

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -447,19 +447,62 @@ The modal "Your changes have been saved" with a green check confirms success.
 
 ### 3.2 Offer Tab — Barcode
 
-Labeled "Common across marketplaces". Multiple barcodes can be added.
+Labeled "Common across marketplaces". Multiple barcodes can be added;
+each added barcode shows as a removable chip.
+
+> **The barcode is the Amazon FNSKU — NOT the ASIN.** The value the
+> seller wants here is the code printed on the FBA label, shape `X00` +
+> 7 chars (10 total, digits + caps), e.g. `X00EXAMPL1`. An **ASIN**
+> (`B0…`, e.g. `B0EXAMPLE1`) is a *different identifier* and is the
+> wrong value — the physical unit in the warehouse carries the FNSKU,
+> so a scan against an ASIN never matches. Do not infer the value from
+> the field's shape ("10 chars, caps+digits" fits both); read it from
+> an FNSKU source below.
+
+**Where to get the FNSKU** (per Amazon marketplace, per seller-SKU):
+
+| Source | How |
+|---|---|
+| Manage FBA Inventory report (best — all SKUs at once) | `sellercentral.amazon.{tld}/reportcentral/FBA_MYI_UNSUPPRESSED_INVENTORY/1` → Download the newest row. TSV columns `sku`, `fnsku`, `asin`. Amazon regenerates it daily, so a fresh row is usually already there — no request/wait needed. |
+| Amazon Fulfilled Inventory report | `/reportcentral/AFNInventoryReport/1` — same `fnsku` column, but only SKUs with stock. |
+| FBA Inventory UI | per-SKU `FNSKU` column, one SKU at a time. |
+
+The noon PSKU and the Amazon seller-SKU are normally the **same
+string** for a store that lists the same catalogue on both platforms,
+so joining the two is a plain SKU-to-SKU match. Verify that assumption
+on one known-good SKU before trusting it across the batch — compare a
+**Live** noon SKU that already has a barcode against the report.
+
+> **Amazon SA and AE issue DIFFERENT FNSKUs for the same SKU, and noon
+> wants BOTH on the one SKU.** noon's barcode field is "Common across
+> marketplaces" — it does not split by country — while Amazon mints a
+> per-marketplace FNSKU. So pull the report from **each** Amazon
+> marketplace the store sells on and add every FNSKU for that SKU as a
+> separate chip. A noon SKU carrying only one barcode when the store
+> has two Amazon marketplaces is an incomplete job, not a finished one.
+> Note the marketplaces can be **separate Amazon accounts** with
+> separate logins (see the store's `notes.md` email-to-platform map) —
+> if you cannot reach one, fill what you can and report the gap
+> explicitly rather than silently shipping half.
 
 ```bash
 browser-use <<'PY'
-fill_input("input[placeholder*='Barcode']", "TEST1234567890")   # "Enter Barcode" input
+fill_input("input[placeholder*='Barcode']", "X00EXAMPL1")   # "Enter Barcode" input
 # "Add Barcode" button becomes enabled — click it by text:
 js("Array.from(document.querySelectorAll('button')).find(b=>/add barcode/i.test(b.textContent))?.click()")
-# Barcode appears as a blue chip; input clears
+# Barcode appears as a blue chip; input clears — repeat per marketplace FNSKU
 PY
 ```
 
-Each added barcode shows as a removable chip (Amazon-ASIN-style
-strings like `XNNNXXXNNN` are typical — 10 chars, digits + caps).
+Then click **Save Changes** and re-verify per the persistence rule
+below. Adding the chip alone does **not** persist it.
+
+> **`fill_input` APPENDS to a non-empty field.** It types via key
+> events without clearing, so a second `fill_input` on the same box
+> yields `oldvalue||newvalue`. Clear first — click the field's native
+> clear (✕) control, or use the native-setter route — before typing a
+> replacement. This bites hardest on reused boxes (the catalog search
+> box, date inputs); see also `noon-exports` § date-range inputs.
 
 ### 3.3 Offer Tab — Stock
 

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -489,17 +489,68 @@ on one known-good SKU before trusting it across the batch — compare a
 > what you can and report the gap explicitly rather than silently
 > shipping half.
 
+**The card is `div#barcode-card`.** Its input has **no `name` and no
+`placeholder`** — a `input[placeholder*='Barcode']` selector matches
+nothing and silently does nothing. Scope to the card instead, and tag the
+input so `fill_input` has a stable selector:
+
 ```bash
 browser-use <<'PY'
-fill_input("input[placeholder*='Barcode']", "X00EXAMPL1")   # "Enter Barcode" input
-# "Add Barcode" button becomes enabled — click it by text:
-js("Array.from(document.querySelectorAll('button')).find(b=>/add barcode/i.test(b.textContent))?.click()")
-# Barcode appears as a blue chip; input clears — repeat per marketplace FNSKU
+import time
+# The card sits ~y=1500 on a 839px-tall viewport. Grow the viewport for
+# headroom rather than clicking near the bottom edge (see browser-harness
+# "A control BELOW the fold").
+cdp("Emulation.setDeviceMetricsOverride", width=1920, height=1600,
+    deviceScaleFactor=1, mobile=False)
+js("document.getElementById('barcode-card').scrollIntoView({block:'center'})")
+
+def add_one(code):
+    js("var c=document.getElementById('barcode-card');"
+       "c.querySelector('input').setAttribute('data-bc','1');")
+    fill_input('#barcode-card input[data-bc="1"]', code)   # enables the button
+    box = js("""
+      var c=document.getElementById('barcode-card');
+      var b=[].slice.call(c.querySelectorAll('button'))
+              .find(function(x){return /add barcode/i.test(x.innerText||'');});
+      var r=b.getBoundingClientRect();
+      return {x:Math.round(r.x+r.width/2), y:Math.round(r.y+r.height/2)};
+    """)
+    click_at_xy(box["x"], box["y"])
+    # WAIT for the chip to appear before doing ANYTHING else (see below).
+    for _ in range(20):
+        chips = js("var c=document.getElementById('barcode-card');"
+                   "return c ? [].slice.call(c.querySelectorAll('.ant-tag-blue'))"
+                   ".map(function(e){return e.innerText.trim();}) : null;")
+        if chips and code in chips:
+            return chips
+        time.sleep(3)
+    raise SystemExit("barcode %s never committed" % code)
+
+add_one("X00EXAMPL1")      # SA FNSKU
+add_one("X00EXAMPL2")      # AE FNSKU — only after the first chip is visible
 PY
 ```
 
-Then click **Save Changes** and re-verify per the persistence rule
-below. Adding the chip alone does **not** persist it.
+> **"Add Barcode" AUTO-SAVES, and the card re-renders — this is the trap
+> that silently loses barcodes.** There is **no** Save Changes step for a
+> barcode: each add fires its own save (toast: *"All changes have been
+> saved successfully"*) and **unmounts and remounts `#barcode-card`**.
+> Two consequences, both of which look like "the barcode didn't stick":
+>
+> 1. **Reading right after the click returns an EMPTY card** — you are
+>    reading mid-render. That is not a failed add. Poll until the chip
+>    appears (above) instead of concluding failure and retrying.
+> 2. **Adding the second barcode too soon is silently dropped** — the
+>    click lands while the previous auto-save is in flight; the input
+>    clears and the button disables, so it *looks* accepted, but the code
+>    never joins the list and no error is shown. Always confirm chip *n*
+>    is present before typing chip *n+1*.
+>
+> Chips carry class `.ant-tag-blue` (the card header's "Common across
+> marketplaces" label is a plain `.ant-tag` — don't count it).
+
+Then **reload the detail page** and confirm the chips are still there.
+That reload is the only real proof; a toast is not.
 
 > **`fill_input` APPENDS to a non-empty field.** It types via key
 > events without clearing, so a second `fill_input` on the same box

--- a/app/skills_v2/noon-listing/SKILL.md
+++ b/app/skills_v2/noon-listing/SKILL.md
@@ -480,10 +480,14 @@ on one known-good SKU before trusting it across the batch — compare a
 > marketplace the store sells on and add every FNSKU for that SKU as a
 > separate chip. A noon SKU carrying only one barcode when the store
 > has two Amazon marketplaces is an incomplete job, not a finished one.
-> Note the marketplaces can be **separate Amazon accounts** with
-> separate logins (see the store's `notes.md` email-to-platform map) —
-> if you cannot reach one, fill what you can and report the gap
-> explicitly rather than silently shipping half.
+>
+> To get the second marketplace's report, **switch marketplace via the
+> account switcher — do not browse to the other country's domain**, which
+> presents a fresh sign-in pre-filled with the wrong account and reads as
+> "separate account, no credentials". See `amazon-shared` § 1. Only if the
+> switcher genuinely lacks that marketplace is it unreachable; then fill
+> what you can and report the gap explicitly rather than silently
+> shipping half.
 
 ```bash
 browser-use <<'PY'

--- a/app/skills_v2/noon-shared/SKILL.md
+++ b/app/skills_v2/noon-shared/SKILL.md
@@ -277,6 +277,13 @@ Read `N items` first, then walk `page=1…⌈N/20⌉`. **Anchor `href`s carry
 the `code=` param you need** for each row's detail page — collect
 `(PSKU, href)` while you page, don't reconstruct URLs later (§ below).
 
+> **One page per `browser-use` invocation.** The store wrapper kills any
+> single invocation at **120 s** and counts it as a wedge strike (see
+> browser-harness § "Budget every invocation"). A render poll can burn
+> ~45 s on one page, so three pages in one heredoc overruns the limit and
+> gets read as a broken browser. Loop pages in the **shell**, one
+> invocation each, appending to a file.
+
 > **Do not decide "Not Live" by reading a per-row badge after a search.**
 > The `Search for SKU here…` box is a *substring* filter whose result set
 > is easy to misread: it silently keeps the previous term when refilled

--- a/app/skills_v2/noon-shared/SKILL.md
+++ b/app/skills_v2/noon-shared/SKILL.md
@@ -225,6 +225,68 @@ Each row has:
 Click the product title anchor to open the edit page (see
 `noon-listing` skill).
 
+### `wait_for_load()` is NOT enough — poll until the rows render
+
+noon's portal is a React/Next app that reaches `readyState:'interactive'`
+with `document.body.innerText === ''` and paints seconds later. Right
+after `wait_for_load()` you will read an **empty page**: `js(...)` returns
+`''`, a row count returns `0`, and a `print()` of it makes the heredoc
+emit *nothing at all* (`Bash completed with no output`). None of that
+means "no results" — it means "not painted yet". Concluding `0 items`
+from it is a silent wrong answer.
+
+Always poll for a content marker before reading anything:
+
+```bash
+browser-use <<'PY'
+import time
+new_tab("https://noon-catalog.noon.partners/en/catalog?project=PRJ{pid}&tab=noon")
+wait_for_load()
+t = ""
+for _ in range(15):                     # ~45 s worst case
+    t = js("return document.body.innerText") or ""
+    if "PSKU" in t:                     # the marker for THIS page
+        break
+    time.sleep(3)
+else:
+    raise SystemExit("catalog never rendered — do not treat as empty")
+print(len(t))
+PY
+```
+
+Pick the marker per page: `PSKU` on My Catalog, `Barcode` on the Offer
+tab, `Total`/`items` for a count. Never `time.sleep(n)` once and hope.
+
+### Enumerate a subset via URL params — do NOT fight the search box
+
+The list page's filters and pagination are **URL state**. Set them in
+the URL and read the rows; that is exact, resumable, and avoids the
+search box entirely:
+
+```
+…/en/catalog?project=PRJ{project_id}&tab=noon&live_status=false&page=1
+```
+
+| Param | Values | Notes |
+|---|---|---|
+| `tab` | `noon` / `supermall` / `global` | marketplace, not country |
+| `live_status` | `false` / `true` | `false` = Not Live only |
+| `page` | 1-based | 20 rows/page; the header reads `N items`, so pages = ⌈N/20⌉ |
+
+Read `N items` first, then walk `page=1…⌈N/20⌉`. **Anchor `href`s carry
+the `code=` param you need** for each row's detail page — collect
+`(PSKU, href)` while you page, don't reconstruct URLs later (§ below).
+
+> **Do not decide "Not Live" by reading a per-row badge after a search.**
+> The `Search for SKU here…` box is a *substring* filter whose result set
+> is easy to misread: it silently keeps the previous term when refilled
+> (`fill_input` appends — clear via the ✕ first), a partial term matches
+> a different family than you intended, and a row whose badge is
+> off-screen reads as absent. Deciding a set is "all Live" from that view
+> and skipping it produces a **silent under-fill** — the failure looks
+> like success. Take the set from `live_status=false` and treat that as
+> authoritative; use the search box only to jump to one known SKU.
+
 For ad-tuning audits, this catalog read is the prerequisite step
 that establishes "what the SKU actually is" before reading any
 campaign — see `noon-ads/references/ads-tuning.md`.

--- a/install.sh
+++ b/install.sh
@@ -128,9 +128,11 @@ _warn()    { printf "%s[!]%s %s\n" "$_Y" "$_Z" "$*" >&2; }
 _error()   { printf "%s[error]%s %s\n" "$_R" "$_Z" "$*" >&2; }
 _check()   { command -v "$1" > /dev/null 2>&1; }
 
-# Canonical set of user-local bin dirs where our installers drop
-# binaries: uv → ~/.local/bin or ~/.cargo/bin; node/pnpm → the npm
-# prefix's bin. Prints a PATH value with these prepended.
+# Canonical set of bin dirs where our installers drop binaries:
+# uv → ~/.local/bin or ~/.cargo/bin; node/pnpm → Homebrew's bin on
+# macOS (`install_node` runs `brew install node`, and pnpm then lands in
+# that node's npm prefix) or the npm prefix's bin elsewhere. Prints a
+# PATH value with these prepended.
 #
 # SINGLE SOURCE OF TRUTH: main()'s dependency checks AND start.sh (via
 # `install.sh --print-path`) prepend the *same* dirs. Without this, a
@@ -138,12 +140,38 @@ _check()   { command -v "$1" > /dev/null 2>&1; }
 # where they are used — install.sh finds uv only because it bootstraps
 # this PATH internally, and that export dies with the subprocess, so a
 # login shell (or start.sh) that lacks ~/.local/bin can't run uv.
+#
+# Homebrew's bin is load-bearing, not belt-and-braces. A non-interactive
+# `ssh host './restart.sh'` gets a minimal PATH with no /opt/homebrew/bin,
+# so on the project's own documented macOS deployment target the check
+# reported uv/node/pnpm "missing" while the server was at that moment
+# running under /opt/homebrew/bin/uv. restart.sh stops before start.sh
+# checks, so that false negative took the service DOWN and left it down.
+# Resolve it from `brew` when available (honours a custom prefix) and
+# fall back to the two canonical locations: /opt/homebrew (Apple
+# Silicon) and /usr/local (Intel).
 _compute_bootstrap_path() {
     local p="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+
+    # Homebrew bin dirs first — see the note above. `brew --prefix` is
+    # only consulted if brew already resolves; a bare command
+    # substitution of a missing command exits 127, which `2>/dev/null`
+    # silences but does NOT neutralize under `set -e`.
+    local brew_bins=() brew_prefix=''
+    if command -v brew >/dev/null 2>&1; then
+        brew_prefix="$(brew --prefix 2>/dev/null || true)"
+        [[ -n "$brew_prefix" ]] && brew_bins+=("$brew_prefix/bin")
+    fi
+    brew_bins+=(/opt/homebrew/bin /usr/local/bin)
+    local d
+    for d in "${brew_bins[@]}"; do
+        if [[ -d "$d" && ":$p:" != *":$d:"* ]]; then
+            p="$d:$p"
+        fi
+    done
+
     # Only probe npm's prefix if npm resolves under the augmented PATH.
-    # A command substitution of a missing command exits 127, which
-    # `2>/dev/null` silences but does NOT neutralize under `set -e`;
-    # guarding with the `if` keeps a missing npm a no-op.
+    # Same 127-under-`set -e` reasoning as above.
     local npm_bin=''
     if PATH="$p" command -v npm >/dev/null 2>&1; then
         npm_bin="$(PATH="$p" npm config get prefix 2>/dev/null || true)/bin"

--- a/restart.sh
+++ b/restart.sh
@@ -19,6 +19,25 @@ for arg in "$@"; do
 done
 PORT="${PORT:-7777}"
 
+# Pre-flight the SAME prerequisite check start.sh runs, BEFORE stopping.
+# start.sh aborts on a missing tool, and stopping first meant a failed
+# check took the server down and left it down — a restart that cannot
+# start must not be a restart that stops. Observed on macOS over a
+# non-interactive `ssh host './restart.sh --dev'`: PATH lacked
+# /opt/homebrew/bin, uv/node/pnpm read as missing, and the running
+# server was killed before anything noticed. Bail out here with the old
+# process still serving.
+if ! "$SCRIPT_DIR/install.sh" --check-only >/dev/null 2>&1; then
+    echo "======================================" >&2
+    echo "Prerequisite check FAILED — server left running, nothing stopped." >&2
+    echo "======================================" >&2
+    # Re-run visibly so the user sees which tool is missing.
+    "$SCRIPT_DIR/install.sh" --check-only || true
+    echo "" >&2
+    echo "Error: fix the above, then re-run $0" >&2
+    exit 1
+fi
+
 # Stop the server
 echo "======================================"
 echo "Step 1: Stopping server..."

--- a/tests/e2e/test_ad_declaration_scoping.py
+++ b/tests/e2e/test_ad_declaration_scoping.py
@@ -16,6 +16,9 @@ The journey mirrors the one that produced the design:
 the console's own access log: the excluded campaign's detail page must
 never be fetched. That is ground truth — a report can claim restraint it
 did not exercise, but the server records what it was actually asked for.
+An access-log assertion only carries meaning if the request *entails* the
+fetch, so both tests ask for keyword bids, which exist nowhere but on a
+campaign's own page. ``tests/unit/test_fake_ads_console.py`` pins that.
 
 The ``vibe_seller_declare_ad_task`` call is checked only *if the agent
 made one*, because the design does not promise one here. The declaration
@@ -247,14 +250,31 @@ class TestAnUnscopedRequestStaysWide:
     ):
         ts = int(time.time())
         store = create_store(api_client, f'e2e-adwide-{ts}')
+        # Ask for what only the campaign PAGES hold. The assertion below
+        # is the console access log — "was each campaign's detail page
+        # opened?" — so the request has to be one that cannot be answered
+        # without opening them, or the test measures browsing habits
+        # instead of scope.
+        #
+        # It did, once. "Look at every campaign and give me bid
+        # recommendations" is answerable straight off /campaigns, which
+        # already carries per-campaign spend/revenue/orders/ROAS. Opening
+        # a campaign was then optional work, and whether the agent
+        # bothered was a coin flip: the same model passed one CI run and
+        # failed the next, both times having read BOTH campaigns off the
+        # list — never the subset-clip this test exists to catch. Bids
+        # live ONLY in each campaign's keyword table, so asking for them
+        # makes the click load-bearing, exactly as the scoped test above
+        # does with its one campaign. Keep it that way: if you reword
+        # this, check the new wording is unanswerable from the list.
         task = create_task(
             api_client,
             'Review all our ad campaigns and tell me what to change',
             store_id=store['id'],
             description=(
                 f'Our ad console is at {ads_console.base} — open it with '
-                'the browser-use CLI, look at every campaign, and give me '
-                'bid recommendations.'
+                'the browser-use CLI, go through every campaign, and give '
+                'me a keyword-by-keyword bid recommendation for each one.'
             ),
         )
         # An unscoped audit is inherently the slower job — it drills

--- a/tests/unit/test_fake_ads_console.py
+++ b/tests/unit/test_fake_ads_console.py
@@ -1,0 +1,91 @@
+"""The e2e ad console must not answer a bid question off the LIST page.
+
+``tests/e2e/test_ad_declaration_scoping.py`` proves scope held by reading
+the console's access log: campaign X's detail page was opened, campaign
+Y's never was. That instrument is wired up to something only if answering
+the request *requires* opening a campaign. If the list page ever grows a
+bid column, both tests keep passing while asserting nothing — an agent
+could answer from the list, touch no campaign page, and the wide test
+would fail for having browsed shallowly rather than for having clipped
+the account down to a subset.
+
+That is not hypothetical: it is how the wide test failed twice in CI. It
+asked for "bid recommendations", the list already carried per-campaign
+spend/revenue/orders/ROAS, and so opening a campaign was optional work
+the agent skipped — while reading BOTH campaigns off the list, which is
+the opposite of the narrowing this test guards against.
+
+So: bids — the thing the request asks for — live on the detail pages and
+nowhere else. That is a fixture invariant, not a preference. It is
+checked here rather than in the e2e tier so a regression surfaces in
+seconds without a live model, and checked over HTTP rather than against
+the page constants so it covers what the handler actually serves.
+"""
+
+import re
+import urllib.request
+
+import pytest
+
+from tests.e2e.fake_ads_console import CAMPAIGN_A, CAMPAIGN_B, serve
+
+pytestmark = pytest.mark.unit
+
+# Reachable WITHOUT opening a campaign: everything the agent can read
+# before the click that the e2e assertion is watching for.
+PRE_CLICK_PATHS = ('/', '/campaigns')
+DETAIL_PATHS = (f'/campaign/{CAMPAIGN_A}', f'/campaign/{CAMPAIGN_B}')
+
+
+@pytest.fixture(scope='module')
+def console():
+    server = serve()
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+def _cells(console, path: str) -> list[str]:
+    """Header + data cell text — where a bid column would show up."""
+    with urllib.request.urlopen(f'{console.base}{path}', timeout=5) as r:
+        assert r.status == 200, f'{path} returned {r.status}'
+        html = r.read().decode()
+    return [
+        re.sub(r'<[^>]+>', '', c).strip()
+        for c in re.findall(r'<t[hd][^>]*>(.*?)</t[hd]>', html, re.S)
+    ]
+
+
+@pytest.mark.parametrize('path', PRE_CLICK_PATHS)
+def test_no_bid_data_before_the_click(console, path):
+    """A bid column on a pre-click page would void the e2e assertion."""
+    offenders = [
+        c for c in _cells(console, path) if re.search(r'\bbids?\b', c, re.I)
+    ]
+    assert not offenders, (
+        f'{path} exposes bid data ({offenders}), so a keyword-bid request '
+        f'no longer requires opening a campaign — the access-log assertion '
+        f'in tests/e2e/test_ad_declaration_scoping.py stops meaning '
+        f'anything. Keep bids on the detail pages only.'
+    )
+
+
+@pytest.mark.parametrize('path', DETAIL_PATHS)
+def test_the_detail_page_is_the_only_source_of_bids(console, path):
+    """...and it must carry them, or the request is unanswerable."""
+    assert 'Bid' in _cells(console, path), (
+        f'{path} carries no bid column, so the wide e2e request cannot be '
+        f'answered from anywhere and the agent can only fabricate one'
+    )
+
+
+def test_both_campaigns_are_listed_but_not_detailed(console):
+    """The list names both — reading it is not a scope breach.
+
+    The e2e contract draws its line at the detail page precisely because
+    the list names every campaign. If a campaign stopped appearing on the
+    list, a scoped review could not find it in order to exclude it.
+    """
+    listed = _cells(console, '/campaigns')
+    for cid in (CAMPAIGN_A, CAMPAIGN_B):
+        assert cid in listed, f'{cid} vanished from the campaign list'


### PR DESCRIPTION
A task asked an agent to backfill the Amazon barcode onto the noon SKUs that
had none. It filled nothing and reported success. Root-causing that on the
live store turned up eight defects; every one of them fails **silently**,
which is why the run looked like it worked.

## The barcode was the wrong identifier, and never sourced

`noon-listing` § 3.2 described the value as *"Amazon-ASIN-style strings like
`XNNNXXXNNN`"*. It is an Amazon **FNSKU** (`X00` + 7), not an ASIN (`B0…`) —
a different identifier for the same product. The shape hint fits both, so an
agent reasoning from the field's shape picks the ASIN, and a barcode holding
an ASIN never matches the code on the physical unit. § 3.2 now names the
FNSKU, points at the `FBA_MYI_UNSUPPRESSED_INVENTORY` report's `fnsku`
column (regenerated daily, so no request/wait), and states the rule that
makes this a *pair* of values: Amazon mints a per-marketplace FNSKU while
noon's field is "common across marketplaces", so **every** marketplace's
FNSKU goes on the one noon SKU. One barcode on a two-marketplace store is a
half-done job.

## `Add Barcode` auto-saves and remounts the card

This is the defect that actually dropped the barcodes, and the skill
documented the opposite: it said to click **Save Changes** afterwards and
warned that "adding the chip alone does not persist it". In fact each add
fires its own save (toast: *"All changes have been saved successfully"*) and
**unmounts and remounts `#barcode-card`**. Three silent failures follow:

- Reading the card right after the click returns it **empty** — a mid-render
  read, not a failed add. Retrying re-enters the race.
- Typing the second barcode before the first chip appears puts the click in
  flight during the previous auto-save: the input clears and the button
  disables, so it looks accepted, but the code is dropped with no error.
- The save is **async**, so even a reload done immediately afterwards can
  read empty on a SKU that did commit. Observed live: a SKU recorded as
  "nothing landed" held both codes a minute later.

So a same-moment empty read is *inconclusive*, never proof of failure. The
documented loop is now add → poll for that chip → add the next → reload and
confirm.

## The documented selector could never match

`input[placeholder*='Barcode']` matches nothing: the live input has no
`placeholder` and no `name`. Replaced with the stable `div#barcode-card`
container (plus a `data-bc` tag so `fill_input` has a selector), and recorded
that chips are `.ant-tag-blue` while the card header's "Common across
marketplaces" label is a plain `.ant-tag` that must not be counted as a
barcode. Also noted the card sits below an 839 px viewport — grow the
viewport rather than clicking near the bottom edge.

## "No rows" was usually "not painted yet"

noon reaches `readyState:'interactive'` with an empty `body.innerText` and
paints seconds after `wait_for_load()` returns. The observed run counted
**0 not-live SKUs out of 42** twice this way, once emitting no output at all.
Added a poll-until-marker loop and the rule that empty output is never
evidence of an empty result.

## "Not Live" was decided from the wrong surface

The skill only offered the `Search for SKU here…` box — a substring filter
that keeps its previous term when refilled (`fill_input` **appends** rather
than clears; the same bug `noon-exports` hit on date inputs, now documented).
The run searched one family, read a stale result set, concluded a set was
"all Live", and skipped it. `noon-shared` § 3 now documents `live_status` /
`page` / `tab` as the authoritative enumeration and says to collect each
row's `href` while paging — because a detail page without its `code=` param
renders an **empty** barcode field on a SKU that has one.

## Reaching the second marketplace looked impossible

Browsing to `sellercentral.amazon.{other-tld}` lands on a fresh `/ap/signin`
that Ziniao pre-fills with the *current* marketplace's email — indistinguishable
from "a separate account I have no credentials for", and signing in anyway
would authenticate the wrong account. A store's `notes.md` email-to-platform
map reinforces the wrong conclusion. The real route is the account switcher
on the **current** domain; `amazon-shared` § 1 now documents it, including
that selection takes two clicks (the row ticks, *then* a "Select account"
button appears, so one click reads as a no-op) and that you must confirm the
switch changed the **data**, not just the header — these report pages cache
hard, and comparing the newest report row's date is what caught it.

## Budget every `browser-use` invocation

The store wrapper runs each call under a **120 s alarm** and treats a timeout
as evidence the *browser* is wedged: strike counter, forced daemon reload,
and on the second consecutive timeout it prints `UNRECOVERABLE`, exits 75,
and instructs the agent to stop and report a gap. A slow-but-healthy call is
indistinguishable from a wedged one, so two long heredocs in a row retire a
perfectly good browser and abandon real work. Documented the budget and the
one-unit-of-work-per-invocation rule (this repo's own pagination guidance
needed it too: a 45 s render poll across three pages overruns the limit).

## `js()` never parses JSON, in either direction

The value comes straight from CDP `returnByValue`, so the JS type is the
Python type: `return [{a:1}]` is already a list, `return JSON.stringify(…)`
is a `str` you must parse. Only one direction raises — parsing a native value
gives a loud `TypeError`, while failing to parse a stringified one silently
iterates **characters** (observed: `PAGE 1 rows: 3747` for a 20-row page).
That loud `TypeError` is also how a store note came to assert the exact
opposite. Documented the real rule with a `jsjson()` normaliser.

## A restart that cannot start must not be a restart that stops

Separately, `ssh mac './restart.sh --dev'` killed the server and then refused
to start it, reporting `uv`/`node`/`pnpm` missing — while the server it had
just killed was running under `/opt/homebrew/bin/uv`. Two defects:
`_compute_bootstrap_path` never included Homebrew's bin even though
`install_node` runs `brew install node`, so the check fails over
non-interactive SSH — the documented way to reach the documented macOS
target; and `restart.sh` stopped **before** `start.sh` validated, so a false
negative became an outage. Homebrew's bin is now resolved from `brew --prefix`
with `/opt/homebrew/bin` and `/usr/local/bin` fallbacks (fixing it in the
shared helper fixes `--check-only` and `--print-path` together), and
`restart.sh` pre-flights the same check before stopping anything.

## Verification

Skill guidance was validated by re-running the real task against the fixed
skills: the agent's *plan* named `live_status=false` and the FBA report
before touching a browser, got `Total 42 items` on the first attempt, and
pulled both marketplaces' FNSKUs — all of which matched an independently
derived baseline (live Amazon SA/AE `Manage FBA Inventory` reports
cross-checked against a separate internal barcode table).

The two shell fixes were verified in the exact environment that failed:
`--check-only` now exits 0 over non-interactive SSH, and the new
`restart.sh` guard was exercised with stubs to confirm it leaves the server
running (and that the normal path still stops-then-starts).

Per-SKU fill results are appended below once the live backfill run completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
