### PR TITLE
fix(noon-ads): correct the skill against the live console

### DIFF
--- a/app/skills_v2/noon-ads/SKILL.md
+++ b/app/skills_v2/noon-ads/SKILL.md
@@ -824,6 +824,40 @@ dynamic-bid noise.
 - **Auto Targeting** (default): noon matches ads automatically.
 - **Manual Targeting**: pick keywords / categories / products.
 
+> **Negative Targeting is available under Auto too** (§ 4 renders with
+> Auto selected). This is the only lever you get on an Auto campaign —
+> use it. Observed live: an Auto campaign matched a store's socks
+> listing to unrelated categories (`beauty/…`, `luggage-and-bags/…`) and
+> to opposite-audience queries that drew clicks and **zero** orders.
+> Seed the negative list at creation rather than waiting to harvest.
+
+### Categories tab — use the search box, not the tree
+
+The `Categories` tab renders a top-level category tree with a `Refine`
+control per row. **`Refine` does not expand** via `click_at_xy` or JS
+`.click()` in the current build — do not burn time on it.
+
+Instead use the tab's **`Search by Category name`** input: typing a
+product word returns matching categories at every depth, each as a full
+path plus its display name, e.g.
+
+```
+fashion/<gender>/clothing/<mid-category>            Mid Category
+fashion/<gender>/clothing/<mid-category>/<leaf>     Leaf Category
+```
+
+Each result row carries its own add control — **`img[alt="addButton"]`**
+(note: NOT `alt="add"`, which is the *product* picker's control; the two
+tabs use different alt text). Once added, the category appears in the
+selected-target table with its own editable bid, and the Targets tab
+(§ 4) shows it as `<path> Category Match`.
+
+> **Depth is the decision, and it is not obvious.** A bare top-level
+> category (`fashion/<gender>`) is the whole department; the leaf is a
+> single product type. Both are one click apart in this list. Pick
+> deliberately and record which depth you chose, because performance
+> between depths is not comparable.
+
 > **ant radios ignore `click_at_xy`.** Both the strategy and targeting
 > groups are ant-design radios whose real `<input>` is visually
 > replaced; coordinate clicks land on the skin and silently do

--- a/app/skills_v2/noon-ads/SKILL.md
+++ b/app/skills_v2/noon-ads/SKILL.md
@@ -391,20 +391,62 @@ concluding failure at 10 s.)
 `aria-selected` state can lag for a second after click and isn't a
 reliable activation signal.
 
-**Recommended-Bid cell suffix.** The Recommended Bid column
-extracts as e.g. `0.75 0.60-0.90 Apply` — the literal "Apply"
-button label is concatenated into the cell innerText. Strip
-the trailing `Apply` before formatting in the report.
+**Columns** (verified live 2026-08-10) — read them positionally, the
+header row extracts with two blank spacer cells:
 
-Columns: Target (keyword text), Bid, eCPC, Recommended Bid,
-Verticals, Engagement (Views/Clicks/Orders/CTR/CvR), Status.
+```
+Targets | Status | Bid | (blank) | Revenue | ROAS | Spends | eCPC |
+Orders | Views | Clicks | ATC | CTR | CVR | SOI | (blank) | Actions
+```
 
-**Match types** observed: `exact Match`, `phrase Match` (and likely
-`broad Match`).
+There is **no `Recommended Bid` column, no `Verticals`, and no
+combined `Engagement` column** in the current build — an earlier
+revision of this skill listed all three, plus a "strip the trailing
+`Apply`" workaround for a cell that no longer exists. Don't look for
+them.
+
+The **Target cell carries the match type inline**: it extracts as
+`<keyword> Keyword Exact Match`, `<keyword> Keyword Phrase Match`, or
+`<path> Category Match`. Split it off before using the keyword text —
+and note the **keyword is truncated** in this cell when long
+(`women's socks c...`). To recover full keyword text, read the
+campaign **editor** (§ 9), whose selected-target list is untruncated.
+
+### SOI — the column that tells you what you are LEAVING on the table
+
+`SOI` is **Share of Impressions**: the fraction of the available
+impressions for that target which your ad actually won.
+
+```
+available impression pool ≈ views ÷ SOI
+```
+
+This is the single most useful number on the page and has no
+equivalent in `searches/month` (§ 9): `searches/month` sizes the
+*market*, SOI tells you **how much of it you are winning**, already
+net of bid, relevance and competition. A target sitting on a large
+`searches/month` bucket with a 1% SOI is not a keyword problem — it is
+a bid-or-relevance problem, and adding more keywords will not fix it.
+
+Compute it per target and sum across the campaign to get a single
+"capture rate". Observed live on a real store: a manual campaign whose
+targets summed to ~11% capture — i.e. ~8× headroom on keywords it
+already owned, before adding a single new one. Its daily-budget
+utilisation was ~11% too; the two numbers corroborate each other and
+together separate "no reach" from "no demand".
+
+**Diagnosing a low SOI — bid vs relevance.** Raising the bid only
+helps when the platform already considers the listing a valid answer
+for that query. Compare the SOI of head terms against modified terms
+(`<category>` vs `<category> <audience>`) on the SAME campaign: if the
+modified terms hold a healthy SOI while the bare head term sits near
+zero at a comparable bid, the auction is telling you the listing is
+not relevant for the broad query, and bidding up burns money for
+impressions that will not convert. See
+`references/ads-tuning.md § Head terms vs modified terms`.
 
 Per-keyword actions:
-- **Bid input**: edit target bid directly
-- **Apply** button: applies recommended bid
+- **Bid input**: edit target bid directly (`step=0.01`)
 - **Status toggle**: enable/disable the keyword
 
 ## 5. Change Target / Keyword Price
@@ -495,8 +537,14 @@ full table on most campaigns; if you see fewer than ~15 rows on
 a 14d+ campaign, scroll the inner table container and re-eval.
 
 Shows the actual search terms customers used that triggered your ads.
-Columns: Customer Query Term, Target, Match Type, Target Bid, eCPC,
-Spends, Verticals, Engagement.
+Columns (from an earlier build): Customer Query Term, Target, Match
+Type, Target Bid, eCPC, Spends, Verticals, Engagement.
+
+> ⚠️ **Not re-verified.** The Targets tab's column list was written in
+> this same vocabulary (`Verticals`, `Engagement`) and turned out to
+> be stale — those columns no longer exist there (§ 4). Treat this
+> list as a hint, read the live header row before parsing positionally,
+> and prefer the **Export** (§ 7) which is the complete source anyway.
 
 **Auto campaign query routing per-product.** On Auto campaigns,
 the Customer Queries tab shows queries scoped to the product
@@ -727,26 +775,114 @@ Click Continue.
 - Search by SKU name input
 - Selected products shown in right panel
 
-**2. Bidding Strategy** (choose one):
+> ⚠️ **noon PRE-SELECTS products you did not choose.** On entering
+> step 2 the right panel already reads `Selected Products (3)` — a
+> "Preselected Recommendations" block of `High Potential` SKUs. Adding
+> your own SKU makes it **4**, and launching ships ads for three
+> products you never picked. **Clear it first**: click
+> **`Remove all (N)`** at the top of that panel, THEN search and add
+> your SKU. Re-check the counter reads `Selected Products (1)` before
+> launching — the block **re-populates when the product search text
+> changes**, so clearing it once is not enough if you search again.
+
+**1. Product Selection** — `Manual Selection` / `Bulk Upload`.
+Type into the `Search products` box (SKU or title words). Each result
+row is a `div[class*="ProductCard_cardContent"]`; the control that
+adds it is an **`img[alt="add"]`** button at the RIGHT edge of the
+row, outside `cardContent` — locate it by nearest-y to the card, not
+by descending into the card. In the selected panel each row has an
+**`img[alt="removeIcon"]`** to drop it again.
+
+**Pick the variant that actually sells.** A variant family
+(`…Z-3/-4/-5`) usually has ONE variant carrying the traffic and the
+others near zero; the SKU that a title search surfaces first is not
+necessarily it. Check the existing campaign's Products tab (§ 3) or a
+prior Export `Sku` sheet before choosing. For a product with no noon
+history, noon's own `High Potential` badge on the card is a
+defensible tiebreak.
+
+**2. Bidding Strategy** (choose one) — verified live 2026-08-10, the
+radio group renders **three** options:
 
 | Strategy | Behavior |
 |----------|----------|
-| **Dynamic Bid Up & Down** (New) | Scale up for top placements, down during low conversion. Auto Targeting only. |
-| **Dynamic Bid Down Only** | Only lowers bid when conversion is low. Auto + Manual Targeting. |
-| **Fixed** | Set default bid amount; no dynamic adjustment. |
+| **Maximize ROAS** | Default selection. noon optimises toward return. |
+| **Maximize Orders** | noon optimises toward order count. |
+| **Fixed** | Your exact per-target bids are honoured; no dynamic adjustment. |
+
+Use **Fixed** for Manual Targeting — per-keyword bids are honoured
+as-is, which is the only way to read per-keyword performance without
+dynamic-bid noise.
+
+> The older `Dynamic Bid (Up & Down)` / `Dynamic Bid (Down Only)`
+> names are **not** what this form offers. They still appear in the
+> campaign LIST for previously-created Auto campaigns
+> (`Auto targeting - Dynamic down only`), so don't treat a list value
+> as a form option.
 
 **3. Targeting**:
-- **Auto Targeting**: noon automatically matches ads with relevant
-  parameters. Configure **Default Bid Amount** and **Minimum Bid**.
-- **Manual Targeting** (with supported strategies): pick keywords.
+- **Auto Targeting** (default): noon matches ads automatically.
+- **Manual Targeting**: pick keywords / categories / products.
 
-**4. Negative Targeting (Optional)**: Exclude specific keywords to
-prevent your ad from appearing in irrelevant searches. Limits:
-**30 Days negative targets** and **30 Phrase negative targets**.
+> **ant radios ignore `click_at_xy`.** Both the strategy and targeting
+> groups are ant-design radios whose real `<input>` is visually
+> replaced; coordinate clicks land on the skin and silently do
+> nothing (the group keeps its previous `checked`). Drive them with
+> JS `.click()` on the input, then READ BACK `checked` — same class of
+> gotcha as Amazon's `kat-dropdown`:
+> ```bash
+> browser-use <<'PY'
+> print(js("""var rs=[].slice.call(document.querySelectorAll('input[type=radio]'))
+>   .filter(function(e){return e.getBoundingClientRect().width>=5;});
+>   rs[2].click(); return JSON.stringify(rs.map(function(e){return e.checked;}));"""))
+> PY
+> ```
+> Indices shift once Manual Targeting expands its settings block, so
+> re-query the list before each click rather than caching positions.
 
-**5. Top Of Search Placement Bidding (Optional)**: Increase chances
-of appearing at top of search results. Bid Percentage boost up to
-**900%** to compete for premium placements.
+**4. Negative Targeting (Optional)**: Exclude keywords so your ad
+doesn't show on irrelevant searches. Limits are **100 Exact + 100
+Phrase** (the counter under each box reads `0/100 … Selected`); an
+earlier revision of this skill said 30/30.
+
+The two boxes are **`ant-select` in tags mode**, not plain inputs —
+their `<input>` is ~4px wide and is skipped by any
+`width > 60` filter. Add terms one at a time: set the inner input's
+value with the native setter, dispatch `input`, then dispatch
+`keydown`/`keypress`/`keyup` for `Enter` to commit the tag. Pasting a
+comma-separated list into the placeholder does **not** commit.
+
+### Adding keywords — the search box IS the keyword tool
+
+Under **Manual Targeting Settings** the `Keywords` tab has a
+`Search for keywords` box. Type a term and each result renders as a
+card carrying **`searches/month: <range>`** plus an `Exact` and a
+`Phrase` button — clicking one adds that keyword at that match type.
+The same box doubles as a free keyword-volume lookup; see § 9 and
+`references/ads-keyword-research.md`.
+
+> **Scroll the result row into view before clicking.** The card list
+> grows downward and rows quickly sit past the viewport bottom
+> (~839px). `click_at_xy` cannot reach an off-screen y and fails
+> **silently** — the run reports every keyword as added while the
+> selected-target table stays empty. Always: `scrollIntoView({block:
+> "center"})` on the button → re-read `getBoundingClientRect()` →
+> reject `y < 0 || y > 800` → click → and verify by counting the
+> per-target bid inputs afterwards.
+
+Each added target gets a bid input (`input[type=number]`,
+`step=0.01`, width < 60px) pre-filled with noon's suggested bid. To
+set them all, native-set every narrow number input on the page — but
+**scroll the targeting section into view first**, because the inputs
+are not in the DOM until that block renders (an off-screen read finds
+0 and silently sets nothing).
+
+**5. Top Of Search Placement Bidding (Optional)**: percentage boost
+on top-of-search placements, up to **900%**. Two `Increase bid by`
+fields (top-of-search, product-pages); blank = `0`. See
+`references/ads-creation.md` before setting this — the default of
+**0** is what the best-performing campaigns observed in this codebase
+actually run.
 
 **6. General Settings**:
 - Campaign Name (required)
@@ -759,6 +895,22 @@ of appearing at top of search results. Bid Percentage boost up to
 
 Action buttons at bottom: **Cancel & Go Back**, **Save As Draft**,
 **Launch Campaign**.
+
+> **`Launch Campaign` sits below the fold.** On a full form it lands
+> around y≈1378 in an 839px viewport, so `click_at_xy` on its
+> reported coordinates hits nothing and the page just stays on the
+> form — which reads as a silent validation failure. There is no error
+> banner because nothing was submitted. `scrollIntoView({block:
+> "center"})` the button, re-read its rect, then click. Success is
+> visible in the header, which switches to
+> `Edit - <campaign name> | Product Ad | Live`.
+
+### Post-launch verification (do this every time)
+
+Re-read the campaign list and confirm, per new campaign: status
+`Live`, the intended **daily budget**, `Manual targeting - Fixed`,
+and — most importantly — that the campaign carries **only the SKU you
+chose**. The preselect trap above is silent and only shows up here.
 
 ## 9. Edit an Existing Campaign — Add / Remove Keywords & Negatives
 
@@ -775,10 +927,34 @@ live campaign you re-enter the campaign editor:
    - **§ 5 Targeting → Manual Targeting Settings** — add positive
      keywords / category / product targets, or remove existing rows.
    - **§ 6 Negative Targeting (Optional)** — add or remove negative
-     keywords (limits: 30 day + 30 phrase negatives, § 8).
+     keywords (limits: **100 Exact + 100 Phrase**, § 8).
 3. **Save** to apply. Deleting a keyword/negative is the same flow:
    open the editor, remove the row, Save. (The Targets-tab Status
    toggle only *pauses* a keyword; it does not remove it.)
+
+### The editor is also a READ-ONLY research tool
+
+Opening the editor changes nothing until you Save, which makes it the
+cheapest way to get two things the Targets tab cannot give you:
+
+- **Untruncated keyword text.** The selected-target list shows each
+  target in full, where the Targets tab truncates (§ 4).
+- **`searches/month` per target**, plus noon's suggested bid range.
+  A target rendering **no `searches/month` line at all is below
+  noon's reporting threshold** — i.e. a dead keyword. Scanning for
+  missing lines is the fastest dead-weight audit available, and it
+  needs no export.
+
+Both are reachable by parsing `document.body.innerText`: a target
+block reads `<keyword>` → `searches/month` → `<range>` →
+`Keyword <Exact|Phrase>` → `Suggested` → `<low>` → `-` → `<high>`.
+
+For using the `Search for keywords` box as a keyword-volume lookup
+across a whole category, see
+`references/ads-keyword-research.md § Step 1`.
+
+> **Leave without saving.** Navigating away discards everything. Never
+> click Save during a read-only pass.
 
 > **State-changing — confirm first.** Adding/removing keywords or
 > negatives re-saves a live campaign (per the "surface, don't
@@ -807,7 +983,7 @@ one, how to research keywords — lives in three reference files:
 | [`../amazon-ads/references/format-anchor.md`](../amazon-ads/references/format-anchor.md) | _Legacy detail._ Exact per-campaign table layouts; load only if you need the precise column shape. Superseded as a contract by `output-spec.md`. |
 | [`references/ads-creation.md`](references/ads-creation.md) | Creating a new campaign. Covers targeting choice, bidding strategy, per-keyword bid heuristic, match-type strategy, negative scoping, TOS boost rules, budget choice, the Save-as-Draft → Launch UI quirk, naming convention, post-launch verification cadence. |
 | [`references/ads-tuning.md`](references/ads-tuning.md) | **Any task that reads existing campaigns and proposes changes** — phrasings like "review all ads", "audit the campaigns", "give me an improvement plan", "weekly ad review", "tune ads", "fix ACOS / ROAS". Defines the steps and noon-specific click paths (Customer Queries tab, Targets tab, etc.); the **output contract** lives in `output-spec.md` (shared with Amazon — same shape for both platforms). |
-| [`references/ads-keyword-research.md`](references/ads-keyword-research.md) | Building the initial keyword list for a Manual campaign. Covers buyer-vs-seller language, storefront autocomplete (English + Arabic), peer-listing reading, cross-checking against existing campaigns to avoid self-competition, parallel negative-list build, match-type assignment. |
+| [`references/ads-keyword-research.md`](references/ads-keyword-research.md) | Building the initial keyword list for a Manual campaign. **Step 1 is noon's built-in keyword-volume tool** (`searches/month` per term, via the editor's `Search for keywords` box) — every keyword you ship must carry its volume bucket, volume is per-country, and word order changes it. Then buyer-vs-seller language, storefront autocomplete (English + local language), peer-listing reading, cross-checking against existing campaigns to avoid self-competition, parallel negative-list build, match-type assignment. |
 
 Safety rails:
 

--- a/app/skills_v2/noon-ads/SKILL.md
+++ b/app/skills_v2/noon-ads/SKILL.md
@@ -417,8 +417,14 @@ campaign **editor** (§ 9), whose selected-target list is untruncated.
 `SOI` is **Share of Impressions**: the fraction of the available
 impressions for that target which your ad actually won.
 
+**The cell renders as a PERCENT** (`12.5%`), so convert before dividing
+— dividing by the displayed number is wrong by 100×:
+
 ```
-available impression pool ≈ views ÷ SOI
+available impression pool ≈ views ÷ (SOI_percent / 100)
+
+# illustrative: views 400, SOI 2.0%  →  400 / 0.02  = 20,000
+#               views 400, SOI 2.0   →  400 / 2     =    200   ← WRONG
 ```
 
 This is the single most useful number on the page and has no
@@ -429,11 +435,16 @@ net of bid, relevance and competition. A target sitting on a large
 a bid-or-relevance problem, and adding more keywords will not fix it.
 
 Compute it per target and sum across the campaign to get a single
-"capture rate". Observed live on a real store: a manual campaign whose
-targets summed to ~11% capture — i.e. ~8× headroom on keywords it
-already owned, before adding a single new one. Its daily-budget
-utilisation was ~11% too; the two numbers corroborate each other and
-together separate "no reach" from "no demand".
+**capture rate** — total views ÷ total available pool. A starved manual
+campaign can sit in the low single digits, meaning most of the reach it
+already owns is unclaimed *before* any new keyword is added.
+
+Cross-check it against **daily-budget utilisation** (actual spend ÷
+budget × days). When both land in the same low band they corroborate
+each other, and together they separate **"no reach"** (capture low,
+budget unspent → bid/relevance) from **"no demand"** (capture high,
+budget unspent → the keywords are simply small). Report both; either
+one alone is ambiguous.
 
 **Diagnosing a low SOI — bid vs relevance.** Raising the bid only
 helps when the platform already considers the listing a valid answer
@@ -465,7 +476,11 @@ PY
 > setter clear + read-back protocol; a naive `fill_input` on the
 > Ant Design shadow input can turn `1.30` into `11.3`.
 
-Or click "Apply" next to Recommended Bid to use noon's suggestion.
+There is no "Apply the suggested bid" shortcut on this tab in the
+current build — the Recommended Bid column it belonged to is gone
+(§ 4). Type the bid you want. noon's suggested range is still visible
+per target inside the campaign **editor** (§ 9), but treat it as a hint,
+not a target (`references/ads-creation.md § Per-keyword bid`).
 
 ## 6. Customer Queries Tab
 

--- a/app/skills_v2/noon-ads/references/ads-creation.md
+++ b/app/skills_v2/noon-ads/references/ads-creation.md
@@ -79,7 +79,7 @@ actually sits:
 
 | Keyword shape | Match | Why |
 |---|---|---|
-| Qualified / multi-word (`<category> <audience>`, `<attribute> <category>`) | **Phrase** | The variants (`… <material>`, `… <length>`) are real, same-intent demand. Observed on one account: the same term drew ~40× the impressions as Phrase vs Exact at an identical bid. |
+| Qualified / multi-word (`<category> <audience>`, `<attribute> <category>`) | **Phrase** | The variants (`… <material>`, `… <length>`) are real, same-intent demand. The same term at the same bid can draw **orders of magnitude** more impressions as Phrase than as Exact — measure it on your own account before assuming Exact is "tighter and therefore better". |
 | Bare category noun with real volume | **Exact** | Phrase on a bare noun is where wrong-audience traffic enters (opposite gender, kids, competitor brand). Exact matches only the query itself, so the leak is structurally impossible. |
 | Proven converter (has orders in your own data) | **Exact**, bid up | You already know the intent converts; buy the exact query specifically. |
 | Your own or a competitor brand | **Exact** | Defend / siphon precisely. |

--- a/app/skills_v2/noon-ads/references/ads-creation.md
+++ b/app/skills_v2/noon-ads/references/ads-creation.md
@@ -29,41 +29,75 @@ Three options, but practically:
 
 ## Per-keyword bid: heuristic for first launch
 
-The form suggests a low/high pair per keyword. For a *new* manual
-campaign, set bids via the bulk-apply flow at **the high end of
-noon's suggested range, or just above**. Reasoning:
-- noon's auction is rating- and conversion-weighted; a fresh listing
-  loses ties to peers. Bidding at suggestion midpoint usually
-  means losing ~half the auctions.
-- Per-keyword bids combine with §5 Top-of-Search boost. A 250%
-  boost on a too-low base bid is multiplying a small number.
-- Rule of thumb: target 1.0–1.5× the high end of the suggested
-  range for the first 2 weeks; reduce on keywords that converted
-  at the starting bid.
+The form pre-fills each target with noon's suggested bid, and offers
+a low/high suggested range.
 
-Use Manual Upload tab → bulk-paste keywords → Add Keywords →
-Select All → **Apply Bids to Targets** → **Set Custom bid** →
-enter value → Apply. Faster than per-row editing for >5 keywords.
+**Do not treat noon's suggested range as the ceiling.** Campaigns
+observed winning meaningful impression share in this codebase sit at
+or ABOVE the top of the suggested range, and campaigns pinned to the
+top of the range still show single-digit SOI. The suggestion is a
+floor-ish hint, not a calibrated target.
 
-**Custom-bid input quirk**: the field's `step` attribute is `1`,
-so typing `1.00` may render as `10` or `100`. Type the integer
-form (`1`) and the input accepts it; the per-keyword input fields
-themselves use `step=0.01` so decimals work there.
+**Prefer the store's own history over any rule of thumb.** Before
+picking a number, read what already works on this account:
 
-## Match type: Phrase > Exact for noon
+```bash
+# click-weighted bid distribution from prior Customer-Queries exports
+#   stores/<slug>/ads/noon/<cc>/*.searchterms.tsv  → target_bid, clicks
+# report P25 / P50 / P75 and the realised eCPC, then start at ~P75
+```
 
-Default to **Phrase** for most keywords on noon. Reasoning:
-- noon is a low-volume site. Exact-only locks out long-tail
-  variants that may be the only buyers searching that month.
-- Phrase still respects word order and intent; you don't get
-  Auto-style random matches.
-- Reserve **Exact** for: (a) defending your own brand name,
-  (b) siphoning a competitor brand, (c) ultra-high-intent generic
-  terms where you want to outbid specifically.
+That gives an empirically-supported opening bid instead of a guess.
+Absent any history, start at the high end of noon's range and treat
+the first 3 days as calibration.
+
+**Then verify with SOI, not with ROAS.** Three days in, the question
+is "did impression share move?" (`../SKILL.md § 4`). ROAS at that
+point is noise on a low-volume site. If SOI did not move, decide
+between bid and relevance using
+`ads-tuning.md § Head terms vs modified terms` **before** raising
+again — bidding into a relevance wall just burns budget.
+
+Set the per-target bids by native-setting every narrow
+`input[type=number]` (`step=0.01`) in the targeting block — scroll
+that block into view first, or the inputs are not yet in the DOM and
+the write silently no-ops. Read the values back to confirm. This is
+the path verified live 2026-08-10.
+
+> A bulk path (`Manual Upload` tab → Add Keywords → Select All →
+> **Apply Bids to Targets** → **Set Custom bid**) is documented from
+> an earlier build, along with a quirk where that field's `step="1"`
+> made `1.00` render as `10`/`100` (type the integer form instead).
+> **Not re-verified in the current build** — if you use it, confirm
+> the resulting per-target bids before launching.
+
+## Match type: choose per keyword, not per campaign
+
+An Exact-heavy campaign starves itself and a Phrase-everything
+campaign leaks. Decide per keyword, from where that keyword's volume
+actually sits:
+
+| Keyword shape | Match | Why |
+|---|---|---|
+| Qualified / multi-word (`<category> <audience>`, `<attribute> <category>`) | **Phrase** | The variants (`… <material>`, `… <length>`) are real, same-intent demand. Observed on one account: the same term drew ~40× the impressions as Phrase vs Exact at an identical bid. |
+| Bare category noun with real volume | **Exact** | Phrase on a bare noun is where wrong-audience traffic enters (opposite gender, kids, competitor brand). Exact matches only the query itself, so the leak is structurally impossible. |
+| Proven converter (has orders in your own data) | **Exact**, bid up | You already know the intent converts; buy the exact query specifically. |
+| Your own or a competitor brand | **Exact** | Defend / siphon precisely. |
+
+> Bidding a bare category noun at all is a separate decision from
+> the match type — for many listings it is not worth buying. See
+> `ads-tuning.md § Head terms vs modified terms` first, and verify
+> on the store's own data.
+
+Note that `searches/month` is measured per exact string: word order
+matters and `<noun> <modifier>` may be several times bigger than
+`<modifier> <noun>`. Size both before choosing which to bid
+(`ads-keyword-research.md § Step 1`).
 
 ## Negative keywords: scoping
 
-Cap is **20 Exact + 20 Phrase** per campaign. Spend them on:
+Cap is **100 Exact + 100 Phrase** per campaign (the counter under
+each box reads `N/100 … Selected`). Spend them on:
 
 | Negate | Match type | Why |
 |---|---|---|
@@ -79,18 +113,32 @@ list. Otherwise, harvest them from Customer Queries post-launch
 
 ## Top-of-Search bid boost
 
-`0%` to `900%` (integer field). Boosts effective bid for the
-top-of-search placement only.
+`0%` to `900%` (integer field, blank = `0`). Boosts the effective bid
+for the top-of-search placement only; PDP and category placements use
+the base bid.
+
+**Default to `0%`.** An earlier revision of this file recommended
+`150–250%` as the "typical starting point" for a new manual campaign
+and `400–900%` for a proven listing. That was not grounded in
+observed results, and the campaigns in this codebase with the
+strongest ROAS in their category run **`Top of Search 0%`** with
+ordinary per-keyword bids. Check the account's own winners
+(campaign detail header shows `Top of Search N%`) before assuming a
+boost is needed.
 
 | Setting | When |
 |---|---|
-| `0%` (default) | Only if listing is highly competitive on price+rating+title and the keyword is super high-intent. Otherwise you'll lose to anyone bidding the placement. |
-| `150–250%` | Typical starting point for a new manual campaign trying to gain visibility. Pairs with bids at the high end of the suggested range. |
-| `400–900%` | Only if (a) the listing is already proven on Amazon but starved of impressions on noon, AND (b) the daily budget can absorb high CPCs. Re-evaluate after 7 days. |
+| **`0%`** | **Default.** Start here. Establish base-bid performance first — you cannot tell whether a boost helped if you never measured without it. |
+| Small boost (`≤100%`) | Only after ≥14 days show the keyword converts at base bid but sits low in SOI *and* the low SOI is a price problem, not a relevance one (`ads-tuning.md § Head terms vs modified terms`). |
+| Large boost | Rarely justified. It multiplies the cost of the placement you understand least. If you reach for this, say why in the recommendation and set a review date. |
 
-The boost only fires for the top-of-search placement; PDP and
-category placements use the base bid. That's why a 250% boost
-doesn't 3.5× your daily spend — it's selective.
+**Budget interaction — the reason `0%` matters on a small budget.**
+The boost multiplies the bid, so top-of-search clicks cost
+`bid × (1 + boost)`. On a small daily budget a large boost concentrates
+the whole day's spend into a couple of clicks, which produces no
+readable signal: e.g. a `250%` boost on a `1.00` bid makes a
+top-of-search click `3.50`, so a `15/day` budget buys ~4 of them.
+Boost and budget must be chosen together.
 
 ## Budget: Campaign Budget vs Shared Budget
 
@@ -107,12 +155,27 @@ validates keyword performance
 within a week. Higher budgets just mean you waste money faster
 if the diagnosis was wrong.
 
-## Save as Draft → Launch — UI quirk
+## Launching
 
-After clicking **Save as Draft** on the create form, noon shows a
-success modal that *overlays* the page-level **Launch Campaign**
-button, making it un-clickable directly. Three-step recovery to
-launch a saved draft:
+**Prefer launching directly from the create form** — fill everything,
+then click **Launch Campaign** at the bottom. Verified live
+2026-08-10 across four consecutive campaigns; the header flips to
+`Edit - <name> | Product Ad | Live` on success. You do not need to
+save a draft first.
+
+> **The button is below the fold.** On a completed form it lands well
+> past the bottom of a standard viewport, and `click_at_xy` on its
+> reported coordinates silently hits nothing — the form just sits
+> there, which is easy to misread as a validation failure (there is
+> no error banner, because nothing was submitted).
+> `scrollIntoView({block: "center"})` first, re-read the rect, then
+> click. Same applies to the keyword `Exact`/`Phrase` add buttons.
+
+### Save as Draft → Launch — UI quirk (drafts only)
+
+If you do save a draft, noon shows a success modal that *overlays*
+the page-level **Launch Campaign** button, making it un-clickable
+directly. Three-step recovery to launch a saved draft:
 
 1. In the Save success modal, click **View Campaign**.
 2. On the campaign-detail page, click the **blue Edit pencil**

--- a/app/skills_v2/noon-ads/references/ads-keyword-research.md
+++ b/app/skills_v2/noon-ads/references/ads-keyword-research.md
@@ -3,8 +3,14 @@
 How to build a buyer-validated keyword list for a noon Manual
 campaign. The shortcut everyone makes is "ask the LLM for keywords"
 — that produces seller-side language (technical, spec-heavy) that
-real buyers don't type. This playbook avoids that trap by going
-through noon's actual storefront.
+real buyers don't type. This playbook avoids that trap by sizing
+every candidate in noon's own keyword tool (Step 1) and validating
+intent against noon's actual storefront (Steps 2–4).
+
+**Never ship a keyword you have not sized.** Every keyword you hand
+back must carry its `searches/month` bucket. A plausible-sounding
+term with no volume costs the same to add as a good one and quietly
+caps the campaign's reach.
 
 Pair with `ads-creation.md` (how to feed the resulting list into
 the create form) and `../SKILL.md § 6` (how to harvest from existing
@@ -24,7 +30,71 @@ The seller term carries SKU/spec language; buyers search the
 category + a use-case modifier. Always validate via the actual
 storefront search before adding a keyword.
 
-## Step 1 — Storefront autocomplete (English)
+## Step 1 — noon's own keyword-volume tool (do this FIRST)
+
+**The Ad Manager ships a keyword tool with search-volume estimates.**
+Earlier revisions of this playbook sent you straight to storefront
+autocomplete; that is now Step 2. Autocomplete tells you a term
+*exists*, this tells you **how big it is** — and it is the only way to
+satisfy "don't add a keyword you haven't sized".
+
+Open any campaign in the editor (`…&mode=edit`, `noon-ads` § 9 — a
+read-only pass, do NOT Save) and use the **`Search for keywords`** box
+under Manual Targeting Settings. One seed term returns ~100 related
+keywords, each with:
+
+- **`searches/month`** as a bucket — observed ladder:
+  `< 10` · `10-50` · `50-100` · `100-250` · `250-500` · `500-1000` ·
+  `1000-5000` · `5000-10000`
+- a **suggested bid range**
+
+Drive it without saving anything:
+
+```bash
+browser-use <<'PY'
+import re, time
+js("""var el=[].slice.call(document.querySelectorAll('input'))
+  .filter(function(e){return (e.placeholder||'').indexOf('Search for keywords')>=0;})[0];
+  var s=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set;
+  s.call(el,'<seed>'); el.dispatchEvent(new Event('input',{bubbles:true})); return 1;""")
+time.sleep(6)
+t = js("return (document.body.innerText||'')")
+lines=[l.strip() for l in t.split(chr(10))]
+for i,l in enumerate(lines):
+    m=re.match(r"^searches/month:\s*(.+)$", l)
+    if m and i>0 and lines[i-1].strip() not in ("Exact","Phrase"):
+        print(lines[i-1].strip(), "|", m.group(1).strip())
+PY
+```
+
+Run 8–15 seeds across the category and union the results — that is a
+sized vocabulary for the whole category in a few minutes. A term the
+tool does not return at all is below threshold: treat as **no volume**
+and do not bid it.
+
+Three rules that fall out of this data:
+
+1. **Size every keyword before it ships.** "It sounds right" is not a
+   reason to bid; the bucket is. Keep the bucket next to each keyword
+   in your deliverable so the user can audit the claim.
+2. **Volume is per COUNTRY — re-run per marketplace.** Local-language
+   head terms routinely differ by two orders of magnitude between two
+   countries that share a language, because the dialect differs. The
+   same seed can return `1000-5000` in one and `< 10` in its
+   neighbour. Never copy a sized list across countries; re-run it.
+3. **Word order is significant.** noon matches literally and does not
+   normalise word order, so `<noun> <modifier>` and
+   `<modifier> <noun>` are different keywords with different volumes —
+   observed differing by 4–20×. Check both orders of every
+   multi-word candidate and keep whichever is larger.
+
+Cross-check the result against the **SOI** column on the campaign's
+Targets tab (`noon-ads` § 4). `searches/month` sizes the market; SOI
+says how much of it you are winning. A big bucket with a low SOI is a
+bid/relevance problem, not a keyword gap — adding more keywords will
+not fix it.
+
+## Step 2 — Storefront autocomplete (English)
 
 Noon's storefront search has live autocomplete reflecting *actual
 recent searches by buyers in this country*. This is the gold-
@@ -50,7 +120,7 @@ Workflow:
 Manual campaign — Manual Targeting allows dozens of keywords but
 each one dilutes budget attention.
 
-## Step 2 — Storefront autocomplete (local language)
+## Step 3 — Storefront autocomplete (local language)
 
 In any marketplace whose buyers don't search primarily in English,
 **a substantial fraction of buyers search in the local language**
@@ -80,14 +150,14 @@ Validate each local-language candidate the same way as English:
 type into search, see if results match your category, record only
 if so.
 
-## Step 3 — Peer-listing reading
+## Step 4 — Peer-listing reading
 
 With a candidate list in hand, do a final filter pass against
 peer listings on noon (same category, same buyer intent, *that
 are selling well*).
 
 Workflow:
-1. Search a top-volume buyer term (from Step 1/2) on the storefront.
+1. Search a top-volume buyer term (from Steps 1–3) on the storefront.
 2. Open 3–5 of the top results that have visible review counts
    ≥50 (these are *selling*, not just listed).
 3. Read each peer's title carefully. Extract:
@@ -103,7 +173,7 @@ This catches false positives from your own seller-side bias.
 but if every selling peer says "soft" or "breathable" instead,
 the buyer doesn't search "cotton" — they search the use-case.
 
-## Step 4 — Cross-check against your existing campaigns
+## Step 5 — Cross-check against your existing campaigns
 
 Before adding a keyword to a NEW manual campaign, check whether
 it's already running in any of your existing campaigns:
@@ -124,7 +194,7 @@ auction inventory to noon. Always:
 - **Only in seller-suggested lists, not in any active campaign**:
   safe to add.
 
-## Step 5 — Build the negative list (in parallel)
+## Step 6 — Build the negative list (in parallel)
 
 While doing buyer-side keyword research, log everything that's
 *close to your category but wrong*:
@@ -139,7 +209,7 @@ While doing buyer-side keyword research, log everything that's
 Negatives are as important as positives. Every wasted Click on a
 wrong query is real money you could have spent on a relevant one.
 
-## Step 6 — Match-type assignment
+## Step 7 — Match-type assignment
 
 For each validated keyword:
 

--- a/app/skills_v2/noon-ads/references/ads-keyword-research.md
+++ b/app/skills_v2/noon-ads/references/ads-keyword-research.md
@@ -84,9 +84,10 @@ Three rules that fall out of this data:
    neighbour. Never copy a sized list across countries; re-run it.
 3. **Word order is significant.** noon matches literally and does not
    normalise word order, so `<noun> <modifier>` and
-   `<modifier> <noun>` are different keywords with different volumes —
-   observed differing by 4–20×. Check both orders of every
-   multi-word candidate and keep whichever is larger.
+   `<modifier> <noun>` are different keywords, and they can land in
+   **different volume buckets entirely** — not a rounding difference.
+   Check both orders of every multi-word candidate and keep whichever
+   bucket is larger.
 
 Cross-check the result against the **SOI** column on the campaign's
 Targets tab (`noon-ads` § 4). `searches/month` sizes the market; SOI

--- a/app/skills_v2/noon-ads/references/ads-tuning.md
+++ b/app/skills_v2/noon-ads/references/ads-tuning.md
@@ -246,6 +246,37 @@ on a bare noun creates.
 > tuning — its own SQP / Customer Queries / SOI — before adopting.
 > If the two disagree, the target store's data wins.
 
+## Category (Subcat) targets — check the AD TYPE before citing one
+
+Category targets show on the Targets tab as `<path> Category Match`.
+Before drawing a lesson from one — especially a cross-campaign or
+cross-store one — record **which ad type it ran on**.
+
+Observed across two stores sharing an account: every campaign carrying
+category targets was a **Brand Ad**. Aggregated across one store's
+Brand Ads the category legs looked excellent; the same store's *other*
+Brand Ad had a category leg that produced clicks and almost no orders.
+Neither store had ever put a category target on a **Product Ad**, so
+"category targeting works here" was not established for Product Ads at
+all — the UI permits it (Manual Targeting → Categories, § 8), it simply
+had no track record.
+
+Two traps this closes:
+
+1. **Do not aggregate category performance across ad types.** Brand and
+   Product ads buy different placements; a Brand-Ad category ROAS is not
+   a forecast for a Product-Ad category target.
+2. **Do not aggregate across campaigns of wildly different health.** One
+   store's category numbers were dominated by a single failing Brand Ad,
+   making category targeting look worthless store-wide; split by campaign
+   and the picture reversed.
+
+When you do propose one, state the **depth** explicitly — a top-level
+department and a leaf product type are one click apart in the picker
+(§ 8) and are not comparable. Start with a low bid relative to the
+campaign's keyword bids so the category cannot drain the keyword budget
+before you can read it.
+
 ## Notes
 
 - **Cover every active campaign — no silent skipping.** Every

--- a/app/skills_v2/noon-ads/references/ads-tuning.md
+++ b/app/skills_v2/noon-ads/references/ads-tuning.md
@@ -201,6 +201,51 @@ catch yourself writing one of those, go back and capture the
 data — then write the specific keyword names, current bids,
 and target bids in the recommendation.
 
+## Head terms vs modified terms — diagnosing a starved campaign
+
+When a campaign has good ROAS but almost no volume, the reflex is
+"add more keywords" or "raise bids". Before either, read the **SOI**
+column (`../SKILL.md § 4`) and split the targets two ways:
+
+- **Bare head term** — the category noun alone (`<category>`).
+- **Modified term** — category plus an audience/attribute qualifier
+  (`<category> <audience>`, `<attribute> <category>`).
+
+Then compare SOI *and* conversion between the two groups **within
+the same campaign**, at comparable bids.
+
+| Pattern | Reading | Action |
+|---|---|---|
+| Modified terms hold decent SOI; bare head term near 0% at a similar bid | The auction does not consider this listing a valid answer for the broad query. **Relevance, not price.** | Do NOT bid up the head term. Grow the modified terms. |
+| Both groups low SOI | Genuinely underbid or budget-capped | Raise bids / budget, re-read SOI in 3 days |
+| Head term has SOI but converts far below the modified terms | You are buying unqualified traffic | Move spend to modified terms; negate the qualifiers you don't serve |
+
+**Why this matters more on a niche listing than a category leader.**
+A bare category query carries mixed intent — different audiences,
+form factors, price tiers. A listing that serves one slice of that
+category will convert on it at a materially lower rate than on the
+qualified variant, *and* the platform will already be showing it
+less. Both effects point the same way, so bidding harder on the head
+term is the worst of both: you pay more for traffic you convert
+worse.
+
+**The reach is usually available without the head term.** Qualified
+variants frequently sit in the *same* `searches/month` bucket as the
+bare noun (see `ads-keyword-research.md § Step 1`). Check before
+concluding you must bid the broad term to get volume — normally you
+do not, and the qualified variant is both bigger-converting and
+structurally immune to the wrong-audience leakage that a broad match
+on a bare noun creates.
+
+> ⚠️ **Do not transfer a head-term result between stores.** Two
+> stores in the same category and country can have opposite results
+> on the identical keyword, because the bare query's dominant intent
+> matches one of them and not the other. A sibling store's winning
+> configuration is a hypothesis to TEST against the target store's
+> own numbers, never evidence for it. Verify on the store you are
+> tuning — its own SQP / Customer Queries / SOI — before adopting.
+> If the two disagree, the target store's data wins.
+
 ## Notes
 
 - **Cover every active campaign — no silent skipping.** Every
@@ -651,8 +696,10 @@ independently re-read live. Mechanisms:
   **Section 4 Negative Targeting**: two `<input type=search>`
   fields — Exact (`id=rc_select_0`) and Phrase (`id=rc_select_1`).
   Type each term + Enter (verify a `.ant-select-selection-item`
-  tag appears). **Limit is 20 Exact + 20 Phrase** (older docs say
-  30/30 — the live cap is 20). The edit page is a **single-page
+  tag appears). **Limit is 100 Exact + 100 Phrase** — read the
+  counter under each box (`N/100 … Selected`) rather than trusting
+  any number written here; it has changed twice (30 → 20 → 100).
+  The edit page is a **single-page
   form** (no per-section save); the bottom has three controls:
   `Cancel & Go Back`, `Save and Pause`, `Save and Launch`.
   **Click the one that MATCHES the campaign's current status** —

--- a/app/skills_v2/noon-shared/SKILL.md
+++ b/app/skills_v2/noon-shared/SKILL.md
@@ -189,6 +189,35 @@ like `STR{project_id}-N{CC}` reuses the same numeric value with
 `STR` prefix and country suffix. Direct URL navigation works for
 most pages; sidebar only for Support/Help.
 
+> ⚠️ **Two different country mechanisms — do not assume one from the
+> other.** Portals whose path carries `/en-{cc}/` (Ad Manager, FBN) are
+> country-scoped **by URL**: navigate and you are in that country.
+> Portals whose path is only `/en/` (**My Catalog, Imports, Exports,
+> Sales, Transaction View, Vantage**) are scoped by a **sidebar store
+> switcher** that persists across sessions — the URL is identical for
+> every country, so a page can silently show a DIFFERENT market than the
+> one you were just working in.
+>
+> **Read the flag before trusting any `/en/` page**, and say which
+> country the data is from when you report it:
+> ```bash
+> browser-use <<'PY'
+> print(js("""var f=document.querySelector('.ns-side-nav__store-flag');
+>   return f ? getComputedStyle(f).backgroundImage : 'no switcher';"""))
+> # → url("…/images/flags/<cc>.svg")
+> PY
+> ```
+> To switch, click the `.ns-store-list__item` whose `[class*=item-flag]`
+> background-image ends in the target `<cc>.svg` — the entries can share
+> an identical store NAME across countries, so match on the flag, never
+> on the label.
+>
+> Live failure this prevents: a whole-catalogue stock/live-status audit
+> was read off this page while the switcher sat on a neighbouring
+> market, and the resulting "these SKUs have stock but no ads" list was
+> used to plan campaigns in the *other* country. Nothing in the URL,
+> the page title, or the project id revealed the mismatch.
+
 | Page | URL |
 |------|-----|
 | Create listing | `noon-catalog.noon.partners/en/catalog/create` |


### PR DESCRIPTION
Creating four campaigns end-to-end on the live noon Ad Manager surfaced nine places where this skill described a build that no longer exists. Each cost a wrong turn; **three fail silently** — the run reports success while nothing was written.

## What was wrong

| # | Claim in the skill | Reality (verified live 2026-08-10) |
|---|---|---|
| 1 | Targets tab has `Recommended Bid`, `Verticals`, `Engagement` | None exist. The real trailing column is **`SOI`** — never documented |
| 2 | Strategies are `Dynamic Bid (Up & Down)` / `(Down Only)` / `Fixed` | Form offers **`Maximize ROAS` / `Maximize Orders` / `Fixed`** |
| 3 | *(absent)* | noon **pre-selects 3 products you didn't choose**; launching ships ads for them |
| 4 | Negative cap 30+30 (SKILL) / 20+20 (tuning) | **100 + 100** |
| 5 | *(absent)* | ant radios ignore `click_at_xy`; negative boxes are ant-select tags mode (~4px input) |
| 6 | *(absent)* | `Launch Campaign` and the keyword add buttons sit **below the fold** — coordinate clicks silently no-op, no error banner |
| 7 | Keyword research starts at storefront autocomplete | The editor has a **keyword tool with `searches/month` buckets**; autocomplete can't size anything |
| 8 | TOS boost: start at `150–250%` | Best-performing campaigns observed run **`0%`** |
| 9 | Bid at `1.0–1.5×` noon's suggested range | Suggested range isn't a calibrated target; use the account's own click-weighted bid history |

## The one worth reading

**`SOI` (Share of Impressions)** gives `available pool ≈ views ÷ SOI`. `searches/month` sizes the market; SOI says how much of it you're winning, already net of bid, relevance and competition. A live manual campaign measured **~11% capture** across targets it already owned — 8× headroom before adding a single keyword, and its budget utilisation independently corroborated it.

New `ads-tuning.md § Head terms vs modified terms` turns that into a decision: if modified terms hold healthy SOI while the bare head term sits near zero at a comparable bid, that's **relevance, not price** — bidding up burns money for traffic that converts worse.

It also carries a warning learned the hard way in this session: **a head-term result does not transfer between stores.** Two stores in the same category and country produced opposite results on the identical keyword, because the bare query's dominant intent matched one and not the other. A sibling store's config is a hypothesis to test, never evidence.

## Honesty notes

- Claims I could **not** re-verify (bulk `Apply Bids to Targets` flow; Customer Queries column list) are **kept and marked unverified** rather than deleted or replaced with a guess.
- The Customer Queries column list is written in the same `Verticals`/`Engagement` vocabulary that turned out stale on the Targets tab, so it now carries a caution to read the live header before parsing positionally.

## Scrub

Docs-only, no code. Diff scanned for brand/store names, PSKUs, ASINs, campaign IDs, project IDs, account emails and live metrics — clean. All examples use placeholders (`<category>`, `<audience>`, `…Z-3/-4/-5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)