### PR TITLE
fix(browser): bound the wait on the global launch lock (POST /browser/start could hang)

### DIFF
--- a/app/browser/launch_guards.py
+++ b/app/browser/launch_guards.py
@@ -15,6 +15,7 @@ manager is already at the repo's file-size ceiling.
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
 import logging
 import time
 
@@ -101,3 +102,111 @@ async def start_backend_bounded(backend, browser_config: dict, store_name: str):
             f'failed to start; other stores are unaffected. Retry the '
             f'task — if it persists, restart Ziniao (Settings → Ziniao).'
         ) from None
+
+
+class BrowserBusyError(RuntimeError):
+    """The global launch lock could not be taken in time.
+
+    Distinct from a launch *failure*: nothing about this store is known
+    to be wrong, and retrying is the right response — which is why the
+    routes map it to 503 rather than 500.
+    """
+
+
+class GlobalLaunchLock:
+    """The manager's global lock, with a ceiling on how long you wait.
+
+    ``BrowserManager`` serializes every launch on one lock so concurrent
+    starts cannot hammer the shared anti-detect client. The lock itself
+    was an ``asyncio.Lock``, so **a wedged holder made every later
+    caller wait for ever** — and an HTTP handler that waits for ever
+    sends no response at all. On 2026-08-24 that is exactly what a task
+    saw: ``POST /api/stores/{id}/browser/start?force=1`` with proxies
+    unset returned ``HTTP 000 (240.003041s)``, and the agent's only
+    possible reading was *"the infrastructure is broken"* — no status,
+    no message, nothing naming what to restart.
+
+    A hang is worse than a failure here. The task looks alive, its whole
+    budget drains, the wrapper's own 90 s curl gives up first, and no
+    retry can help because the next call queues behind the same holder.
+    So the wait is bounded and the refusal **names the holder and how
+    long it has been in there**, which is the one fact that separates
+    "somebody else is legitimately launching, try again" from "the
+    client is wedged, restart it".
+
+    Nothing is force-released. The holder may be inside Ziniao's own
+    client and interrupting it is how a half-built browser env is left
+    behind; ``start_backend_bounded`` is what stops a launch running
+    away, and this only stops *waiting* on one.
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._holder: str | None = None
+        self._since: float = 0.0
+
+    @property
+    def holder(self) -> str | None:
+        """What is inside the lock right now, or ``None``."""
+        return self._holder
+
+    def held_for(self) -> float:
+        """Seconds the current holder has been in, or ``0.0``."""
+        return time.monotonic() - self._since if self._holder else 0.0
+
+    def _busy_message(self, what: str, waited: float) -> str:
+        held = self.held_for()
+        holder = self._holder or 'an unnamed caller'
+        launch_cap = Options.BROWSER_START_TIMEOUT_S.get_float()
+        if launch_cap <= 0:
+            # A launch has no ceiling either, so there is no duration
+            # that would make this holder *late* — saying "within the 0s
+            # a launch may take" would read as the opposite of what 0
+            # means. Report the fact and stop short of a verdict.
+            verdict = (
+                f'It has been in there {held:.0f}s. Launches are '
+                f'unbounded here (VIBE_BROWSER_START_TIMEOUT_S=0), so '
+                f'nothing can say whether that is a launch in progress '
+                f'or a stuck holder — check Ziniao if it does not '
+                f'clear.'
+            )
+        elif held > launch_cap:
+            verdict = (
+                f'It has been in there {held:.0f}s, past the '
+                f'{launch_cap:.0f}s a launch may take, so it is stuck — '
+                f'restart Ziniao (Settings → Ziniao) rather than '
+                f'retrying.'
+            )
+        else:
+            verdict = (
+                f'It has been in there {held:.0f}s, within the '
+                f'{launch_cap:.0f}s a launch may take, so this is '
+                f'ordinary contention — retry shortly.'
+            )
+        return (
+            f'Browser subsystem busy: {what} waited {waited:.0f}s for '
+            f'the launch lock, which is held by {holder}. {verdict}'
+        )
+
+    @asynccontextmanager
+    async def hold(self, what: str):
+        """Take the lock, or raise :class:`BrowserBusyError` saying why not."""
+        timeout = Options.BROWSER_LOCK_WAIT_S.get_float()
+        started = time.monotonic()
+        if timeout <= 0:
+            await self._lock.acquire()
+        else:
+            try:
+                await asyncio.wait_for(self._lock.acquire(), timeout)
+            except TimeoutError:
+                msg = self._busy_message(what, time.monotonic() - started)
+                logger.warning('%s', msg)
+                raise BrowserBusyError(msg) from None
+        self._holder = what
+        self._since = time.monotonic()
+        try:
+            yield
+        finally:
+            self._holder = None
+            self._since = 0.0
+            self._lock.release()

--- a/app/browser/manager.py
+++ b/app/browser/manager.py
@@ -14,7 +14,11 @@ from app.auth import create_token
 from app.browser.base import BrowserBackend, BrowserSessionInfo
 from app.browser.bh_daemons import LEGACY_DAEMON_PATTERN, kill_bh_daemons
 from app.browser.daemon_reaper import reap_orphaned_daemons
-from app.browser.launch_guards import RelaunchBudget, start_backend_bounded
+from app.browser.launch_guards import (
+    GlobalLaunchLock,
+    RelaunchBudget,
+    start_backend_bounded,
+)
 from app.browser.web_wrapper import write_web_browser_use_wrapper
 from app.browser.wrapper import (
     remove_browser_use_wrapper,
@@ -183,7 +187,9 @@ class BrowserManager:
         self._proxy_ports: dict[str, int] = {}
         self._next_proxy_port = _BASE_PROXY_PORT
         # Serialize start/stop to avoid races
-        self._lock = asyncio.Lock()
+        # Bounded on purpose — a wedged holder must not turn every
+        # later caller into a request that never answers.
+        self._lock = GlobalLaunchLock()
         # Track the active Ziniao account (only one can run
         # per machine).
         self._active_ziniao_account_id: str | None = None
@@ -329,7 +335,7 @@ class BrowserManager:
 
         Serialized via lock to prevent wrapper-generation races.
         """
-        async with self._lock:
+        async with self._lock.hold(f'start_session({store.name})'):
             return await self._start_session_locked(store, db)
 
     @staticmethod
@@ -534,7 +540,7 @@ class BrowserManager:
         return session
 
     async def stop_session(self, store: Store, db: AsyncSession) -> None:
-        async with self._lock:
+        async with self._lock.hold(f'stop_session({store.name})'):
             await self._stop_session_locked(store, db)
 
     def remove_browser_entry(
@@ -590,7 +596,7 @@ class BrowserManager:
         authenticated API call.  No browser is started here;
         the agent invokes the wrapper later.
         """
-        async with self._lock:
+        async with self._lock.hold('write_browser_config_for_store'):
             # Both backends need a proxy port for CDPMuxProxy.
             result = await db.execute(
                 select(BrowserSession).where(
@@ -642,7 +648,7 @@ class BrowserManager:
         ``POST /api/browser/web/start`` on first use, so no-store tasks
         that never touch the browser pay nothing.
         """
-        async with self._lock:
+        async with self._lock.hold('write_web_browser_config'):
             proxy_port = await self._web_proxy_port(db)
             token = create_token(AI_BOT_USER_ID, 'ai_bot')
             headless = await self._read_headless_setting(db)
@@ -676,7 +682,7 @@ class BrowserManager:
         concurrent orchestrator tasks racing the lazy auto-start can't
         launch two Chromes.
         """
-        async with self._lock:
+        async with self._lock.hold('start_web_session'):
             proxy_port = await self._web_proxy_port(db)
             if (
                 WEB_BROWSER_SLUG in self._active_sessions
@@ -744,7 +750,7 @@ class BrowserManager:
             # failing the task. Serialized on the manager lock so a
             # concurrent fanout does ONE relaunch and peers just re-check
             # (WSL is kill-only → its relaunch raises, guidance propagates).
-            async with self._lock:
+            async with self._lock.hold(f'ziniao-relaunch({store.name})'):
                 try:
                     await ensure_ziniao_running(**kwargs)
                     return  # a peer already relaunched into WebDriver

--- a/app/env_options.py
+++ b/app/env_options.py
@@ -110,6 +110,17 @@ class Options(enum.Enum):
     # (0 = unbounded). See app/browser/manager.py.
     BROWSER_START_TIMEOUT_S = ('VIBE_BROWSER_START_TIMEOUT_S', '180')
 
+    # How long a caller may WAIT for the manager's global launch lock
+    # before being told the subsystem is busy. Without a ceiling here a
+    # wedged holder makes every later `POST /browser/start` hang with no
+    # response at all — the observed failure was a 240 s curl returning
+    # HTTP 000, which the agent can only read as "the machine is
+    # broken". Deliberately SHORTER than the wrapper's own 90 s curl so
+    # the caller gets a real 503 it can act on instead of a timeout, and
+    # shorter than BROWSER_START_TIMEOUT_S so a peer's legitimate launch
+    # is reported as "busy, retry" rather than waited out.
+    BROWSER_LOCK_WAIT_S = ('VIBE_BROWSER_LOCK_WAIT_S', '60')
+
     # Sync
     KNOWLEDGE_REPO_URL = ('KNOWLEDGE_REPO_URL', '')
     SKILLS_REPO_URL = ('SKILLS_REPO_URL', '')

--- a/app/routers/browser.py
+++ b/app/routers/browser.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user
 from app.browser import aux_browser
+from app.browser.launch_guards import BrowserBusyError
 from app.browser.manager import browser_manager
 from app.config import BASE_DIR
 from app.database import get_db
@@ -53,6 +54,9 @@ async def start_web_browser(
     """
     try:
         await browser_manager.start_web_session(db)
+    except BrowserBusyError as e:
+        # Busy is not broken — see the same branch in stores.py.
+        raise HTTPException(status_code=503, detail=str(e)) from e
     except Exception as e:
         raise HTTPException(
             status_code=500,

--- a/app/routers/stores.py
+++ b/app/routers/stores.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import telemetry
 from app.auth import get_current_user
 from app.browser.bookmarks import read_bookmarks, read_ziniao_bookmarks
+from app.browser.launch_guards import BrowserBusyError
 from app.browser.manager import (
     browser_manager,
     store_slug as _store_slug,
@@ -414,6 +415,13 @@ async def start_browser(
         raise HTTPException(status_code=404, detail='Store not found')
     try:
         await browser_manager.start_session(store, db)
+    except BrowserBusyError as e:
+        # 503, not 500: nothing is known to be wrong with THIS store —
+        # somebody else holds the launch lock. A hang here is what the
+        # caller used to get instead, and `HTTP 000` after 240s is not
+        # something an agent or an operator can act on. The message
+        # names the holder and how long it has been in there.
+        raise HTTPException(status_code=503, detail=str(e)) from e
     except ZiniaoNormalModeError as e:
         # Ziniao is sitting in normal (UI) mode. Only the
         # `Force Restart` button (UI) can relaunch in WebDriver

--- a/docs/ziniao-concurrency.md
+++ b/docs/ziniao-concurrency.md
@@ -185,8 +185,46 @@ Net effect: Ziniao's real concurrency is preserved, the unavoidable
 per-store flake is isolated to a retry (not an outage), and no store's
 recovery can ever tear down a peer.
 
+## Waiting on the global lock is bounded too (2026-08-24)
+
+The lock above is what makes one store's launch everyone's business, and
+`start_backend_bounded` caps how long a launch may *run*. It did not cap how
+long a peer may **wait**, and an `asyncio.Lock` waits for ever.
+
+So a wedged holder stopped being a slow launch and became a **hang**:
+
+```
+POST /api/stores/{id}/browser/start?force=1      (proxies unset)
+  → HTTP 000 (240.003041s)
+```
+
+No status, no body, nothing naming what to restart. The agent's own reading was
+*"the infrastructure is broken"* — which is all `HTTP 000` can mean — and no
+retry could help, because the next call queued behind the same holder. A hang is
+worse than a failure here: the task looks alive, its budget drains, and the
+wrapper's own 90 s curl gives up before the server has said anything at all.
+
+`GlobalLaunchLock` (`app/browser/launch_guards.py`) bounds the **wait**:
+
+- `VIBE_BROWSER_LOCK_WAIT_S`, default **60 s** — deliberately shorter than the
+  wrapper's 90 s curl, so the caller gets a real response, and shorter than
+  `VIBE_BROWSER_START_TIMEOUT_S` (180 s), so a peer's legitimate launch is
+  reported rather than waited out.
+- The refusal **names the holder and how long it has been in there**, which is
+  the one fact that separates *"somebody is launching, retry shortly"* from
+  *"held past the launch cap — restart Ziniao"*.
+- Routes map it to **503, not 500**: nothing is known to be wrong with this
+  store.
+- **Nothing is force-released.** The holder may be inside Ziniao's client, and
+  interrupting it is how a half-built env is left behind. This bounds waiting,
+  not the work.
+- `0` disables the ceiling, for an operator who wants the old behaviour back.
+
 ## Tests
 
+- **CI-safe unit** (`tests/unit/test_browser/test_launch_lock.py`): a wedged
+  holder is refused rather than waited out, the lock survives the refusal, and
+  the message distinguishes contention from a stuck holder.
 - **CI-safe unit** (`tests/unit/test_browser/test_ziniao_per_store_recovery.py`):
   mocks the Ziniao API, forces stale launches, and asserts recovery is
   per-store `stopBrowser` + retry with **no** `force_kill_ziniao` /

--- a/tests/unit/test_browser/test_launch_lock.py
+++ b/tests/unit/test_browser/test_launch_lock.py
@@ -1,0 +1,197 @@
+"""Unit test: the manager's global launch lock never waits for ever.
+
+Regression guard for the 2026-08-24 hang. ``BrowserManager`` serializes
+every launch on one lock so concurrent starts cannot hammer the shared
+anti-detect client. That lock was a bare ``asyncio.Lock``, so a wedged
+holder made every later caller wait indefinitely — and an HTTP handler
+that waits indefinitely sends **no response at all**. What the task saw
+was ``POST /api/stores/{id}/browser/start?force=1``, proxies unset,
+returning ``HTTP 000 (240.003041s)``: no status, no message, nothing
+naming what to restart, and no retry that could help because the next
+call queued behind the same holder.
+
+A hang is worse than a failure. These pin that the wait is bounded, that
+the refusal says who is inside and for how long, and — the part that
+makes it actionable — that it distinguishes ordinary contention from a
+holder that is stuck.
+"""
+
+import asyncio
+from unittest import mock
+
+import pytest
+
+from app.browser.launch_guards import BrowserBusyError, GlobalLaunchLock
+
+pytestmark = pytest.mark.unit
+
+
+def _wait(seconds: str, launch_cap: str = '180'):
+    """Patch the two env options this policy reads."""
+    return mock.patch.dict(
+        'os.environ',
+        {
+            'VIBE_BROWSER_LOCK_WAIT_S': seconds,
+            'VIBE_BROWSER_START_TIMEOUT_S': launch_cap,
+        },
+    )
+
+
+async def test_an_uncontended_lock_is_taken_immediately():
+    lock = GlobalLaunchLock()
+    with _wait('5'):
+        async with lock.hold('start_session(zuly)'):
+            assert lock.holder == 'start_session(zuly)'
+    assert lock.holder is None
+
+
+async def test_a_wedged_holder_is_refused_not_waited_out():
+    """The whole point: the second caller gets an answer."""
+    lock = GlobalLaunchLock()
+    released = asyncio.Event()
+
+    async def wedged():
+        async with lock.hold('start_session(zuly)'):
+            await released.wait()
+
+    task = asyncio.create_task(wedged())
+    await asyncio.sleep(0)  # let it take the lock
+
+    with _wait('0.05'), pytest.raises(BrowserBusyError) as err:
+        async with lock.hold('start_session(infino)'):
+            pass  # pragma: no cover
+
+    assert 'start_session(zuly)' in str(err.value)
+    assert 'start_session(infino)' in str(err.value)
+    released.set()
+    await task
+
+
+async def test_the_lock_is_still_usable_after_a_refusal():
+    """A refused waiter must not leave the lock acquired behind it."""
+    lock = GlobalLaunchLock()
+    released = asyncio.Event()
+
+    async def wedged():
+        async with lock.hold('stop_session(zuly)'):
+            await released.wait()
+
+    task = asyncio.create_task(wedged())
+    await asyncio.sleep(0)
+    with _wait('0.05'), pytest.raises(BrowserBusyError):
+        async with lock.hold('peer'):
+            pass  # pragma: no cover
+    released.set()
+    await task
+
+    with _wait('5'):
+        async with lock.hold('after'):
+            assert lock.holder == 'after'
+
+
+async def test_a_holder_inside_the_launch_budget_reads_as_contention():
+    """Somebody is legitimately launching — the answer is "retry"."""
+    lock = GlobalLaunchLock()
+    released = asyncio.Event()
+
+    async def holder():
+        async with lock.hold('start_session(zuly)'):
+            await released.wait()
+
+    task = asyncio.create_task(holder())
+    await asyncio.sleep(0)
+
+    with _wait('0.05', launch_cap='180'), pytest.raises(BrowserBusyError) as e:
+        async with lock.hold('peer'):
+            pass  # pragma: no cover
+
+    assert 'retry shortly' in str(e.value)
+    assert 'restart Ziniao' not in str(e.value)
+    released.set()
+    await task
+
+
+async def test_a_holder_past_the_launch_budget_reads_as_stuck():
+    """Past the time a launch may take, waiting is not the answer."""
+    lock = GlobalLaunchLock()
+    released = asyncio.Event()
+
+    async def holder():
+        async with lock.hold('start_session(zuly)'):
+            await released.wait()
+
+    task = asyncio.create_task(holder())
+    await asyncio.sleep(0.05)
+
+    # A launch that may take at most 0.01s, held for ~0.05s already.
+    with _wait('0.05', launch_cap='0.01'), pytest.raises(BrowserBusyError) as e:
+        async with lock.hold('peer'):
+            pass  # pragma: no cover
+
+    assert 'restart Ziniao' in str(e.value)
+    released.set()
+    await task
+
+
+async def test_no_launch_ceiling_means_no_verdict():
+    """`BROWSER_START_TIMEOUT_S=0` says a launch may take for ever.
+
+    So there is no duration that makes a holder *late*, and the old
+    message read `within the 0s a launch may take` — the opposite of
+    what 0 means. Report the fact, stop short of a verdict.
+    """
+    lock = GlobalLaunchLock()
+    released = asyncio.Event()
+
+    async def holder():
+        async with lock.hold('start_session(zuly)'):
+            await released.wait()
+
+    task = asyncio.create_task(holder())
+    await asyncio.sleep(0)
+
+    with _wait('0.05', launch_cap='0'), pytest.raises(BrowserBusyError) as e:
+        async with lock.hold('peer'):
+            pass  # pragma: no cover
+
+    msg = str(e.value)
+    assert '0s a launch may take' not in msg
+    assert 'retry shortly' not in msg and 'it is stuck' not in msg
+    assert 'unbounded' in msg
+    released.set()
+    await task
+
+
+async def test_zero_disables_the_ceiling():
+    """An operator may opt back into waiting for ever; nothing else may."""
+    lock = GlobalLaunchLock()
+    released = asyncio.Event()
+    took = asyncio.Event()
+
+    async def holder():
+        async with lock.hold('start_session(zuly)'):
+            await released.wait()
+
+    async def peer():
+        with _wait('0'):
+            async with lock.hold('peer'):
+                took.set()
+
+    task = asyncio.create_task(holder())
+    await asyncio.sleep(0)
+    waiter = asyncio.create_task(peer())
+    await asyncio.sleep(0.05)
+
+    assert not took.is_set()  # still waiting, not refused
+    released.set()
+    await asyncio.wait_for(asyncio.gather(task, waiter), timeout=2)
+    assert took.is_set()
+
+
+async def test_the_holder_is_forgotten_when_the_body_raises():
+    lock = GlobalLaunchLock()
+    with _wait('5'), pytest.raises(ValueError):
+        async with lock.hold('start_session(zuly)'):
+            raise ValueError('launch blew up')
+    assert lock.holder is None
+    assert lock.held_for() == 0.0

--- a/tests/unit/test_routers/test_stores.py
+++ b/tests/unit/test_routers/test_stores.py
@@ -8,6 +8,7 @@ from httpx import AsyncClient
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.browser.launch_guards import BrowserBusyError
 from app.browser.ziniao_utils import ZiniaoNormalModeError
 from app.models.store import Store
 from app.models.user import User
@@ -184,6 +185,63 @@ class TestBrowserStartForce:
             )
         assert response.status_code == 500
         assert 'normal mode' in response.json()['detail']
+
+    @pytest.mark.asyncio
+    async def test_a_busy_launch_lock_is_503_not_a_hang(
+        self,
+        authenticated_client: AsyncClient,
+        async_db_session: AsyncSession,
+    ):
+        """The HTTP contract this route regressed to `HTTP 000` without.
+
+        A wedged holder of the manager's global launch lock used to make
+        this handler wait for ever, so the caller got no response at all
+        — 240s and `HTTP 000`, which names nothing to restart. 503
+        rather than 500 because nothing is known to be wrong with THIS
+        store, and the detail must carry the holder so an operator can
+        tell contention from a stuck client.
+        """
+        store = await self._make_ziniao_store(async_db_session)
+        with mock.patch(
+            'app.routers.stores.browser_manager.start_session',
+            side_effect=BrowserBusyError(
+                'Browser subsystem busy: start_session(Z Store) waited '
+                '60s for the launch lock, which is held by '
+                'start_session(other).'
+            ),
+        ):
+            response = await authenticated_client.post(
+                f'/api/stores/{store.id}/browser/start'
+            )
+        assert response.status_code == 503
+        assert 'held by start_session(other)' in response.json()['detail']
+
+    @pytest.mark.asyncio
+    async def test_a_busy_lock_is_503_with_force_too(
+        self,
+        authenticated_client: AsyncClient,
+        async_db_session: AsyncSession,
+    ):
+        """`force=1` is for normal mode; a busy lock is not that.
+
+        Falling into the force branch would kill and relaunch Ziniao
+        because somebody else was mid-launch — which is the storm the
+        relaunch budget exists to stop.
+        """
+        store = await self._make_ziniao_store(async_db_session)
+        relaunch = mock.AsyncMock(return_value=True)
+        with (
+            mock.patch(
+                'app.routers.stores.browser_manager.start_session',
+                side_effect=BrowserBusyError('busy: held by peer'),
+            ),
+            mock.patch('app.routers.stores.kill_and_relaunch_ziniao', relaunch),
+        ):
+            response = await authenticated_client.post(
+                f'/api/stores/{store.id}/browser/start?force=1'
+            )
+        assert response.status_code == 503
+        relaunch.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_force_true_relaunches_and_retries(


### PR DESCRIPTION
## Symptom

A task stalled on 2026-08-24. The real signal in the log was not "the browser won't start" — it was that **the endpoint never answered**:

```
POST /api/stores/{id}/browser/start?force=1     (the agent had unset every proxy)
  → HTTP 000 (240.003041s)
```

The agent's own diagnosis was correct:

> The browser start API at port 7777 is just hanging on POST requests. … This is an infrastructure problem I cannot resolve from the agent.

`HTTP 000` carries no status, no body, and nothing naming what to restart. And **retrying cannot help** — the next call queues behind the same holder.

## Root cause

`BrowserManager` serializes every launch on one global lock. That is deliberate (see `docs/ziniao-concurrency.md`): concurrent launches must not hammer the shared anti-detect client.

`start_backend_bounded` already caps how long a launch may **run** (`VIBE_BROWSER_START_TIMEOUT_S=180`). Nothing capped how long a peer may **wait**, and an `asyncio.Lock` waits for ever.

So one wedged holder turned "a launch failed" into "the browser subsystem on this machine is unreachable, permanently".

**A hang is worse than a failure**: the task looks alive, its whole budget drains, and the wrapper's own 90s curl gives up before the server has said anything at all.

## The change

`GlobalLaunchLock` (`app/browser/launch_guards.py` — where, by that file's own docstring, this kind of policy belongs) bounds the **wait**:

| | |
|---|---|
| `VIBE_BROWSER_LOCK_WAIT_S` | default **60s**: shorter than the wrapper's 90s curl (so the caller gets a real response) and shorter than `BROWSER_START_TIMEOUT_S`'s 180s (so a peer's legitimate launch is **reported** rather than waited out) |
| The refusal | **names the holder and how long it has been in there** — the one fact separating "somebody is launching, retry shortly" from "held past the launch cap, restart Ziniao" |
| HTTP status | **503, not 500**: nothing is known to be wrong with this store, and retrying is the right response |
| No force-release | the holder may be inside Ziniao's client, and interrupting it is how a half-built env gets left behind. This bounds **waiting**, not the work |
| `0` | disables the ceiling, for an operator who wants the old behaviour back |

All six `async with self._lock` sites now name themselves, so the refusal carries a real holder (`start_session(zuly)`, `ziniao-relaunch(zuly)`, `write_web_browser_config`, …) instead of "an unnamed caller".

## Review feedback — both addressed

**1. `launch_cap <= 0` made the message read oddly** (@Copilot, `launch_guards.py:173`)

It was worse than odd — it was wrong. `VIBE_BROWSER_START_TIMEOUT_S=0` means a launch may take *for ever*, so the old text `within the 0s a launch may take` said the exact opposite. With no ceiling configured there is no duration that makes a holder **late**, so the message now reports the duration and stops short of a verdict. Pinned by `test_no_launch_ceiling_means_no_verdict`.

**2. The 503 mapping needed router coverage** (@Copilot, `stores.py:421`)

Added to the existing `TestBrowserStartForce`:
- `test_a_busy_launch_lock_is_503_not_a_hang` — 503, with the holder in `detail`
- `test_a_busy_lock_is_503_with_force_too` — asserts `kill_and_relaunch_ziniao` is **not** called. `force=1` is for Ziniao sitting in normal mode; killing the client because a peer was mid-launch is precisely the storm `RelaunchBudget` exists to stop, so that branch must not be reachable this way.

## Tests

- `tests/unit/test_browser/test_launch_lock.py` (8) — the interesting cases are not the happy path: a wedged holder is refused rather than waited out; **the lock is still usable after a refusal** (a refused waiter must never leave it acquired); each verdict appears only in its own case; `0` really does disable the bound; the holder is forgotten when the body raises.
- `tests/unit/test_routers/test_stores.py` (2) — the two above.
- `pytest tests/unit` (what CI runs): **2048 passed**. The two failures in that run (`test_install_sh`'s uv PATH, `test_platform`'s lsof self-check) fail identically with this change stashed.

## Not changed

The kill-and-relaunch for Ziniao sitting in normal mode **already exists** in `manager.py` and works. This hang was not that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7NYiT26uv6iCA826HJY3g