### PR TITLE
fix(profiles): bot-created tasks land on the empty-env 'default' profile

### DIFF
--- a/app/ai/profiles.py
+++ b/app/ai/profiles.py
@@ -643,6 +643,26 @@ def profile_kind_for_id(profile_id: str | None) -> str:
     return profile_kind(ProfileManager.get_profile(profile_id))
 
 
+async def resolve_owner_profile(owner, db) -> str | None:
+    """Resolve an owner's AI profile, falling through a bot account.
+
+    A bot account (``role == AI_BOT_ROLE``) is login-less: its
+    ``default_profile_id`` is the placeholder ``'default'`` and no
+    Settings page can ever change it. Inheriting from it is therefore
+    not a configuration but a guaranteed fall-back to plain Claude on
+    api.anthropic.com — and on an install driven entirely by
+    third-party profiles, a guaranteed failure. **A bot owner means
+    "no preference expressed", so fall through to the human admin who
+    did express one.**
+
+    Returns ``None`` when nobody expressed a preference, leaving the
+    caller to apply its own default.
+    """
+    if owner and owner.role == AI_BOT_ROLE:
+        owner = await db.get(User, DEFAULT_USER_ID)
+    return owner.default_profile_id if owner else None
+
+
 async def resolve_schedule_profile(sched, db) -> str:
     """Resolve which AI profile a schedule's fired task should use.
 
@@ -668,17 +688,12 @@ async def resolve_schedule_profile(sched, db) -> str:
     returns ``DEFAULT_PROFILE_ID`` (the global inherit sentinel) and the
     caller applies its own default.
 
-    **System schedules have no human owner.** They are seeded with
-    ``created_by=AI_BOT_USER_ID`` — a login-less account whose
-    ``default_profile_id`` is the placeholder ``'default'`` and which no
-    Settings page can ever change. Inheriting from it therefore resolved
-    right back to ``'default'``, i.e. plain Claude on
-    api.anthropic.com. On an install driven entirely by third-party
-    profiles that is not a configuration, it is a guaranteed failure:
-    the nightly catalog sync died with "Not logged in · Please run
-    /login" every night for weeks while the admin's default was set to
-    a working provider the whole time. A bot owner means "no preference
-    expressed", so fall through to the human admin who did express one.
+    **System schedules have no human owner** — they are seeded with
+    ``created_by=AI_BOT_USER_ID``, and the nightly catalog sync died
+    with "Not logged in · Please run /login" every night for weeks
+    because of it. That fall-through is
+    :func:`resolve_owner_profile`'s, shared with task creation so the
+    two paths cannot drift apart again.
     """
     if (
         sched
@@ -688,8 +703,7 @@ async def resolve_schedule_profile(sched, db) -> str:
         return sched.ai_profile_id
     if sched and sched.created_by:
         owner = await db.get(User, sched.created_by)
-        if owner and owner.role == AI_BOT_ROLE:
-            owner = await db.get(User, DEFAULT_USER_ID)
-        if owner and owner.default_profile_id:
-            return owner.default_profile_id
+        resolved = await resolve_owner_profile(owner, db)
+        if resolved:
+            return resolved
     return DEFAULT_PROFILE_ID

--- a/app/routers/schedule_planning.py
+++ b/app/routers/schedule_planning.py
@@ -22,6 +22,7 @@ from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.claude_backend_manager import agent_manager
+from app.ai.profiles import resolve_schedule_profile
 from app.database import async_session
 from app.models.schedule import Schedule
 from app.models.schedule_constants import PhaseMode
@@ -97,6 +98,14 @@ async def spawn_planning_task(
     author a new version, or edit the schedule prompt (which flips
     ``plan_status`` to ``stale`` and requires a re-plan before the
     next fire).
+
+    The profile comes from :func:`resolve_schedule_profile`, the same
+    resolver the fire path uses, so the plan is authored by the
+    provider that will run the schedule. Reading
+    ``schedule.ai_profile_id`` directly missed that: ``'default'`` is
+    the inherit sentinel *and* the column default, so every unpinned
+    schedule planned on the empty-env profile no matter what its
+    owner had configured.
     """
     task = Task(
         store_id=None,
@@ -107,7 +116,7 @@ async def spawn_planning_task(
         status=TaskStatus.PENDING,
         plan_mode=True,
         is_plan_only=True,
-        ai_profile_id=schedule.ai_profile_id or 'default',
+        ai_profile_id=await resolve_schedule_profile(schedule, db),
     )
     db.add(task)
     # Flush so we get the task.id before linking the Schedule pointer,

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -10,7 +10,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import telemetry
 from app.ai.bash_safety import check_exec_review_status
 from app.ai.claude_backend_manager import agent_manager
-from app.ai.profiles import DEFAULT_PROFILE_ID, profile_kind_for_id
+from app.ai.profiles import (
+    DEFAULT_PROFILE_ID,
+    profile_kind_for_id,
+    resolve_owner_profile,
+)
 from app.ai.review_redrive import reset_ledger
 from app.ai.stop_gates import (
     CONTRADICTION_MAX_DENIALS,
@@ -164,7 +168,9 @@ async def create_task(
         plan_mode=plan_mode,
         skip_reflection=bool(data.skip_reflection),
         ai_profile_id=(
-            data.profile_id or current_user.default_profile_id or 'default'
+            data.profile_id
+            or await resolve_owner_profile(current_user, db)
+            or DEFAULT_PROFILE_ID
         ),
     )
     db.add(task)

--- a/tests/workflow/test_wf_task_profile_bot_owner.py
+++ b/tests/workflow/test_wf_task_profile_bot_owner.py
@@ -1,0 +1,260 @@
+"""Workflow tests: a bot-created task inherits the human admin's profile.
+
+The ``'default'`` profile's ``env`` is ``{}``. That is not "the Claude
+profile", it is *no provider configured* — an agent launched under it
+runs on whatever credentials the host machine happens to carry. The
+bot account is login-less, its ``default_profile_id`` is permanently
+that placeholder, and no Settings page can change it.
+
+``resolve_schedule_profile`` already fell through a bot owner to the
+human admin. Two other paths did not:
+
+* ``create_task`` resolved ``current_user.default_profile_id or
+  'default'`` — so every task an integration created as the bot
+  landed on the empty-env profile.
+* ``spawn_planning_task`` stored ``schedule.ai_profile_id or
+  'default'`` — and since ``'default'`` is the *inherit sentinel* as
+  well as the column default, an unpinned schedule authored its plan
+  on the empty-env profile even when the fire-time resolver would
+  later pick the owner's.
+
+These tests drive the real endpoints, not a copy of their
+expressions: a regression that drops the resolver from either call
+site must fail here.
+"""
+
+import uuid
+
+from httpx import ASGITransport, AsyncClient
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.ai.profiles import (
+    DEFAULT_PROFILE_ID,
+    resolve_owner_profile,
+    resolve_schedule_profile,
+)
+from app.auth import create_token
+from app.config import AI_BOT_ROLE, AI_BOT_USER_ID, DEFAULT_USER_ID
+from app.main import app
+from app.models.schedule import Schedule
+from app.models.schedule_constants import PhaseMode
+from app.models.task import Task
+from app.models.user import User
+from app.routers.schedule_planning import spawn_planning_task
+
+pytestmark = pytest.mark.workflow
+
+THIRD_PARTY = 'some-third-party-profile'
+
+
+async def _seed(db, admin_profile=THIRD_PARTY):
+    """The two accounts this rule is about: the bot and the human admin."""
+    bot = await db.get(User, AI_BOT_USER_ID)
+    if bot is None:
+        bot = User(
+            id=AI_BOT_USER_ID,
+            username='ai_bot',
+            email='ai@vibe-seller.local',
+            password_hash='disabled',
+            role=AI_BOT_ROLE,
+        )
+        db.add(bot)
+    bot.role = AI_BOT_ROLE
+    bot.default_profile_id = DEFAULT_PROFILE_ID
+
+    admin = await db.get(User, DEFAULT_USER_ID)
+    if admin is None:
+        admin = User(
+            id=DEFAULT_USER_ID,
+            username='human-admin',
+            email='admin@example.com',
+            password_hash='x',
+            role='admin',
+        )
+        db.add(admin)
+    admin.role = 'admin'
+    admin.default_profile_id = admin_profile
+
+    await db.commit()
+    return bot, admin
+
+
+@pytest_asyncio.fixture
+async def bot_client(
+    override_async_session,
+    install_fake_agent,
+    mock_browser_wf,
+    mock_knowledge_sync,
+    mock_skills_sync,
+    mock_workspace,
+    isolated_profiles,
+    fast_polling,
+):
+    """A client authenticated as the login-less bot account."""
+    async with override_async_session() as db:
+        await _seed(db)
+    token = create_token(AI_BOT_USER_ID, AI_BOT_ROLE)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url='http://test'
+    ) as client:
+        client.cookies.set('auth_token', token)
+        yield client
+
+
+async def _created_task(db, title):
+    rows = await db.execute(select(Task).where(Task.title == title))
+    return rows.scalars().first()
+
+
+class TestBotCreatedTaskUsesAdminProfile:
+    """POST /api/tasks as the bot — the path that was broken."""
+
+    async def test_inherits_admin_profile(
+        self, bot_client, override_async_session
+    ):
+        r = await bot_client.post(
+            '/api/tasks', json={'title': 'bot task', 'defer_start': True}
+        )
+        assert r.status_code in (200, 201), r.text
+        async with override_async_session() as db:
+            task = await _created_task(db, 'bot task')
+        assert task is not None
+        assert task.ai_profile_id == THIRD_PARTY, (
+            'a bot-created task must not land on the empty-env '
+            f"'{DEFAULT_PROFILE_ID}' profile while an admin default exists"
+        )
+
+    async def test_explicit_pin_still_wins(
+        self, bot_client, override_async_session
+    ):
+        r = await bot_client.post(
+            '/api/tasks',
+            json={
+                'title': 'pinned task',
+                'defer_start': True,
+                'profile_id': 'pinned-profile',
+            },
+        )
+        assert r.status_code in (200, 201), r.text
+        async with override_async_session() as db:
+            task = await _created_task(db, 'pinned task')
+        assert task.ai_profile_id == 'pinned-profile'
+
+    async def test_default_when_admin_expressed_nothing(
+        self, bot_client, override_async_session
+    ):
+        # Nobody configured a provider — 'default' is then the honest
+        # answer, not a regression.
+        async with override_async_session() as db:
+            await _seed(db, admin_profile=DEFAULT_PROFILE_ID)
+        r = await bot_client.post(
+            '/api/tasks', json={'title': 'no pref', 'defer_start': True}
+        )
+        assert r.status_code in (200, 201), r.text
+        async with override_async_session() as db:
+            task = await _created_task(db, 'no pref')
+        assert task.ai_profile_id == DEFAULT_PROFILE_ID
+
+
+class TestHumanCreatedTaskUnaffected:
+    """A human creator keeps their own default — no fall-through."""
+
+    async def test_admin_client_uses_own_default(
+        self, admin_client, override_async_session, admin_user
+    ):
+        async with override_async_session() as db:
+            owner = await db.get(User, admin_user.id)
+            owner.default_profile_id = 'creator-profile'
+            await db.commit()
+        r = await admin_client.post(
+            '/api/tasks', json={'title': 'human task', 'defer_start': True}
+        )
+        assert r.status_code in (200, 201), r.text
+        async with override_async_session() as db:
+            task = await _created_task(db, 'human task')
+        assert task.ai_profile_id == 'creator-profile'
+
+
+class TestPlanningTaskUsesResolvedProfile:
+    """spawn_planning_task authored plans on the empty-env profile."""
+
+    async def _schedule(self, db, ai_profile_id, created_by):
+        sched = Schedule(
+            id=str(uuid.uuid4()),
+            title='planned',
+            description='d',
+            schedule_type='minutes',
+            schedule_time='00:00',
+            interval_value=5,
+            plan_mode=True,
+            phase_mode=PhaseMode.SINGLE.value,
+            ai_profile_id=ai_profile_id,
+            created_by=created_by,
+        )
+        db.add(sched)
+        await db.commit()
+        await db.refresh(sched)
+        return sched
+
+    async def test_unpinned_plan_task_uses_owner_profile(
+        self, override_async_session, mock_workspace, isolated_profiles
+    ):
+        async with override_async_session() as db:
+            bot, _ = await _seed(db)
+            # 'default' is the column default for an unpinned
+            # schedule — the sentinel, not a Claude pin.
+            sched = await self._schedule(db, DEFAULT_PROFILE_ID, AI_BOT_USER_ID)
+            task = await spawn_planning_task(sched, bot, db)
+            assert task.ai_profile_id == THIRD_PARTY
+
+    async def test_pinned_plan_task_keeps_its_pin(
+        self, override_async_session, mock_workspace, isolated_profiles
+    ):
+        async with override_async_session() as db:
+            bot, _ = await _seed(db)
+            sched = await self._schedule(db, 'pinned-profile', AI_BOT_USER_ID)
+            task = await spawn_planning_task(sched, bot, db)
+            assert task.ai_profile_id == 'pinned-profile'
+
+
+class TestSharedResolver:
+    """The helper both paths go through, and the schedule fire path."""
+
+    async def test_bot_owner_falls_through_to_admin(
+        self, override_async_session
+    ):
+        async with override_async_session() as db:
+            bot, _ = await _seed(db)
+            assert await resolve_owner_profile(bot, db) == THIRD_PARTY
+
+    async def test_human_owner_keeps_own_default(self, override_async_session):
+        async with override_async_session() as db:
+            _, admin = await _seed(db)
+            assert await resolve_owner_profile(admin, db) == THIRD_PARTY
+
+    async def test_no_owner_expresses_nothing(self, override_async_session):
+        async with override_async_session() as db:
+            assert await resolve_owner_profile(None, db) is None
+
+    async def test_bot_owned_schedule_fire_still_falls_through(
+        self, override_async_session
+    ):
+        async with override_async_session() as db:
+            await _seed(db)
+            sched = Schedule(
+                id=str(uuid.uuid4()),
+                title='bot-owned',
+                description='d',
+                schedule_type='minutes',
+                schedule_time='00:00',
+                interval_value=5,
+                plan_mode=False,
+                phase_mode=PhaseMode.SINGLE.value,
+                ai_profile_id=None,
+                created_by=AI_BOT_USER_ID,
+            )
+            db.add(sched)
+            await db.commit()
+            assert await resolve_schedule_profile(sched, db) == THIRD_PARTY


### PR DESCRIPTION
## The bug

The `default` profile's `env` is `{}`. That is not "the Claude profile" — it is **no provider configured**, so an agent launched under it runs on whatever credentials the host machine happens to carry. On an install whose owner only ever configured third-party profiles, that is never what they asked for.

The bot account (`role == AI_BOT_ROLE`) is login-less: its `default_profile_id` is permanently that placeholder, and no Settings page can change it. `resolve_schedule_profile` already knew this and fell through to the human admin — its docstring records the outage that produced the rule (a nightly schedule failing with `Not logged in · Please run /login` for weeks while the admin's default was a working provider the whole time).

Two other paths did not:

```python
# app/routers/tasks.py — create_task
ai_profile_id=(data.profile_id or current_user.default_profile_id or 'default')

# app/routers/schedule_planning.py — spawn_planning_task
ai_profile_id=schedule.ai_profile_id or 'default'
```

The first means every task created by an API client authenticating as the bot lands on the empty-env profile. The second is subtler: `'default'` is the *inherit sentinel* as well as the `Schedule.ai_profile_id` column default, so an unpinned schedule authored its plan on the empty-env profile even though the fire-time resolver would later pick the owner's — plan and run could come from two different providers.

## Observed

Creating a task over the API as the bot account, the spawned agent process carried **no `ANTHROPIC_*` environment variable at all** — no base URL, no model, no auth token — while the admin's default was a working third-party profile. Re-creating the same task with an explicit `profile_id` produced the expected provider env, so execution was fine; the fallback was not.

## The fix

Extract the rule into `resolve_owner_profile(owner, db)` and share it, so the three call sites cannot drift apart again:

- `create_task` resolves through it
- `spawn_planning_task` calls `resolve_schedule_profile`, the same resolver the fire path uses
- `resolve_schedule_profile` delegates the bot fall-through to it

An explicit `profile_id` still wins, and `'default'` is still the answer when nobody expressed a preference — at that point it is honest.

## Verification

`tests/workflow/test_wf_task_profile_bot_owner.py` drives the real paths — `POST /api/tasks` as a bot-authenticated client asserting the persisted `Task.ai_profile_id`, and `spawn_planning_task` directly — rather than restating the production expression, so a regression at any call site fails here.

Reverting each call site in turn:

| reverted | failures |
|---|---|
| `create_task` | 1 |
| `spawn_planning_task` | 1 |
| the shared helper | 4 |

```
40 passed   # new 10 + schedule-profile 9 + profile-sync 5 + task-lifecycle 16
ruff check / ruff format / line-limit: clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
